### PR TITLE
Build PySbagen’s dependable sleep-audio product and creativity research path

### DIFF
--- a/.beads/mindmanipulation_full_product_train_2026_07_29.md
+++ b/.beads/mindmanipulation_full_product_train_2026_07_29.md
@@ -56,6 +56,7 @@ This train is product work, not a recursive audit. The smell/bug check below exi
 - Preserve silence instead of collapsing the schedule.
 - Honor explicit duration boundaries.
 - Fail loudly on unknown tone-set names.
+- Remove scheduled generators by object identity so equal-valued tone sets do not erase each other.
 
 ### Bead 4 — Make schedules and background audio dependable
 **Status:** complete
@@ -66,6 +67,7 @@ This train is product work, not a recursive audit. The smell/bug check below exi
 - Normalize mono/multichannel input to stereo.
 - Make looping a real `FileSpec` behavior.
 - Keep pink-noise filter state continuous.
+- Expand user paths consistently for MP3 and other supported audio files.
 
 ### Bead 5 — Repair the GUI as a real front door
 **Status:** complete
@@ -88,11 +90,12 @@ This train is product work, not a recursive audit. The smell/bug check below exi
 
 - Add parser, mixer, schedule, file, API, and CLI tests.
 - Add GitHub Actions qualification on supported Python versions.
-- Validate locally with 13 passing tests and a wheel build.
+- Validate locally with 14 passing tests, compile checks, and a wheel build.
 
 ## Qualification
 
-- `PYTHONPATH=. pytest -q` → **13 passed**
+- `PYTHONPATH=. pytest -q` → **14 passed**
+- `python -m compileall -q pysbagen gui.py visualization.py drg_decoder.py` → **passed**
 - `python -m pip wheel . --no-deps --no-build-isolation` → **wheel built successfully**
 - Wheel inspection confirms the canonical `pysbagen` package and GUI modules are included while the nested duplicate and tests are excluded.
 

--- a/.beads/mindmanipulation_full_product_train_2026_07_29.md
+++ b/.beads/mindmanipulation_full_product_train_2026_07_29.md
@@ -31,6 +31,7 @@ This train is product work, not a recursive audit. The smell/bug check below exi
 15. Pink-noise filter state reset every chunk, creating discontinuities.
 16. The package carried a second nested source copy. It is preserved for provenance, but packaging did not explicitly exclude it from the canonical distribution.
 17. Tests covered only one happy-path parser example and one one-second mixer example.
+18. Python 3.13 qualification exposed that `pydub` imported the removed standard-library `audioop` module during package import, breaking every product path even when MP3 was not used.
 
 ## Beads
 
@@ -68,6 +69,7 @@ This train is product work, not a recursive audit. The smell/bug check below exi
 - Make looping a real `FileSpec` behavior.
 - Keep pink-noise filter state continuous.
 - Expand user paths consistently for MP3 and other supported audio files.
+- Decode MP3 directly through FFmpeg, removing the obsolete `pydub`/`audioop` compatibility trap.
 
 ### Bead 5 — Repair the GUI as a real front door
 **Status:** complete
@@ -88,16 +90,17 @@ This train is product work, not a recursive audit. The smell/bug check below exi
 ### Bead 7 — Prove the user journeys
 **Status:** complete
 
-- Add parser, mixer, schedule, file, API, and CLI tests.
+- Add parser, mixer, schedule, file, MP3/FFmpeg, API, and CLI tests.
 - Add GitHub Actions qualification on supported Python versions.
-- Validate locally with 14 passing tests, compile checks, and a wheel build.
+- Validate locally under Python 3.13 with 16 passing tests, compile checks, and a wheel build.
 
 ## Qualification
 
-- `PYTHONPATH=. pytest -q` → **14 passed**
+- `PYTHONPATH=. pytest -q` → **16 passed on Python 3.13**
 - `python -m compileall -q pysbagen gui.py visualization.py drg_decoder.py` → **passed**
 - `python -m pip wheel . --no-deps --no-build-isolation` → **wheel built successfully**
 - Wheel inspection confirms the canonical `pysbagen` package and GUI modules are included while the nested duplicate and tests are excluded.
+- The first live matrix run correctly caught the `pydub`/`audioop` incompatibility on Python 3.13; the dependency was removed and a new matrix run was triggered by the repair commits.
 
 ## Next product train
 

--- a/.beads/mindmanipulation_full_product_train_2026_07_29.md
+++ b/.beads/mindmanipulation_full_product_train_2026_07_29.md
@@ -1,0 +1,105 @@
+# MindManipulation / pysbagen — Full Product Reliability Train
+
+**Date:** 2026-07-29
+**Branch:** `agent/full-product-reliability-train-20260729`
+**Base:** `main` at `f44025323a438dda7ff6c247fb679b46d2824cea`
+
+## Train goal
+
+Turn the existing Python SBaGen work into one dependable product path that can be installed, used from the command line, used from the GUI, tested, and extended without choosing between duplicate implementations.
+
+This train is product work, not a recursive audit. The smell/bug check below exists only to identify what must be repaired now.
+
+## Smell and bug check
+
+### Product-path failures found
+
+1. The public README contained only a title and one sentence, leaving installation, CLI, GUI, schedules, and supported generators undocumented.
+2. The GUI changed `sys.argv` to impersonate the CLI instead of calling a real application API.
+3. The GUI referenced matplotlib `Figure` and `FigureCanvasTkAgg` without importing them.
+4. The GUI required PyAudio at import time even for users who only wanted file export.
+5. The visualization path generated a generic sine tone while waiting for `isochronic` metadata, so its update condition could never become true.
+6. The soundscape path constructed `FileSpec` positionally, assigning values to inherited dataclass fields rather than `path` and `amp`, and then called `generator(..., loop=True)` even though that argument did not exist.
+7. `mix_generators` stopped the entire mix when any one input ended. A short background file could truncate a longer tone session.
+8. Empty scheduled spans emitted no audio, collapsing intentional silence and shifting all later events earlier.
+9. Explicit schedule durations shorter than the schedule could still process later events instead of ending cleanly.
+10. Unknown tone-set names were silently ignored, producing incomplete or silent output instead of a useful error.
+11. File references containing `/` were split incorrectly; ordinary relative and absolute paths could not be parsed reliably.
+12. Schedule-relative audio paths were resolved against the process working directory rather than the schedule file's directory.
+13. Non-44.1 kHz source audio raised an error instead of being resampled despite SciPy already being a dependency.
+14. Mono and multichannel files did not have an explicit stereo normalization path.
+15. Pink-noise filter state reset every chunk, creating discontinuities.
+16. The package carried a second nested source copy. It is preserved for provenance, but packaging did not explicitly exclude it from the canonical distribution.
+17. Tests covered only one happy-path parser example and one one-second mixer example.
+
+## Beads
+
+### Bead 1 — Resolve live state and define the train
+**Status:** complete
+
+- Resolved `main`, open PRs, open issues, and recent history.
+- Confirmed there were no open PRs or issues to inherit.
+- Converted concrete product failures into this bounded train.
+
+### Bead 2 — Establish one public application API
+**Status:** complete
+
+- Add `pysbagen.api` for building specs, rendering schedules/specs, and streaming output to disk.
+- Make both CLI and GUI use the same API.
+- Export the stable entry points from `pysbagen`.
+
+### Bead 3 — Make timeline and mixing behavior truthful
+**Status:** complete
+
+- Render exact requested durations.
+- Continue mixing when one source ends.
+- Preserve silence instead of collapsing the schedule.
+- Honor explicit duration boundaries.
+- Fail loudly on unknown tone-set names.
+
+### Bead 4 — Make schedules and background audio dependable
+**Status:** complete
+
+- Parse quoted paths and paths containing directory separators.
+- Resolve files relative to the SBG file.
+- Resample source files to 44.1 kHz.
+- Normalize mono/multichannel input to stereo.
+- Make looping a real `FileSpec` behavior.
+- Keep pink-noise filter state continuous.
+
+### Bead 5 — Repair the GUI as a real front door
+**Status:** complete
+
+- Remove the `sys.argv`/CLI impersonation hack.
+- Keep export usable without PyAudio.
+- Repair quick, advanced, schedule, I-Doser, tone-builder, soundscape, preview, and visualization paths.
+- Route worker-thread completion back through Tk's main thread.
+
+### Bead 6 — Make installation and ownership unambiguous
+**Status:** complete
+
+- Configure package discovery explicitly.
+- Exclude the preserved nested source copy and tests from the wheel.
+- Add CLI and GUI entry points plus `dev` and `gui` extras.
+- Document the canonical package and the preserved legacy/original source.
+
+### Bead 7 — Prove the user journeys
+**Status:** complete
+
+- Add parser, mixer, schedule, file, API, and CLI tests.
+- Add GitHub Actions qualification on supported Python versions.
+- Validate locally with 13 passing tests and a wheel build.
+
+## Qualification
+
+- `PYTHONPATH=. pytest -q` → **13 passed**
+- `python -m pip wheel . --no-deps --no-build-isolation` → **wheel built successfully**
+- Wheel inspection confirms the canonical `pysbagen` package and GUI modules are included while the nested duplicate and tests are excluded.
+
+## Next product train
+
+Do not reopen this train as an audit of the audit. The next useful train should be one of:
+
+1. **Schedule compatibility train:** qualify against a representative library of original SBaGen schedules and implement unsupported schedule operators from real fixtures.
+2. **I-Doser compatibility train:** add legal user-supplied `.drg` fixtures, harden decoding, and prove image/schedule extraction end to end.
+3. **Live studio train:** add pause/stop, transport position, non-blocking preview, and live parameter changes to the GUI.

--- a/.beads/pysbagen_sleep_experience_train_2026_07_29.md
+++ b/.beads/pysbagen_sleep_experience_train_2026_07_29.md
@@ -96,14 +96,29 @@ Saved journeys receive `.sleep.json` manifests with exact timing, carrier/beat m
 - consent or study protocol UI inside the ordinary app;
 - claims that a frequency guarantees sleep, dopamine, pain relief, migraine relief, or sobriety.
 
+## Review-driven product repairs
+
+Live review found several real product faults after the first sleep implementation. They were repaired rather than deferred into an audit report:
+
+- file output now renders to a same-directory temporary file and atomically replaces the destination only after success;
+- failed or empty renders preserve any existing destination;
+- long looping background audio streams in bounded chunks instead of `np.tile`-materializing the full session;
+- FFmpeg product paths stream decoded audio instead of buffering the entire decoded source;
+- schedule generators that remain active keep their phase and file position across event boundaries;
+- a bare `-` event really silences the schedule;
+- trailing SBaGen `->` syntax is preserved and performs a full-interval crossfade to the next timed event instead of flattening both tone sets together;
+- the canonical advanced-studio entry point now uses a guarded wrapper that captures widget values on the Tk thread, prevents overlapping export jobs and previews, and closes replaced Matplotlib figures;
+- GUI and playback dependencies are separate, with a combined `desktop` extra;
+- research evidence and user-facing safety boundaries were tightened before calling the train complete.
+
 ## Qualification
 
 Local reconstructed exact product path:
 
-- `PYTHONPATH=. pytest -q` — **26 passed**;
-- `python -m compileall -q pysbagen sleep_gui.py` — **passed**;
+- `PYTHONPATH=. pytest -q` — **33 passed**;
+- `python -m compileall -q pysbagen gui.py gui_safe.py sleep_gui.py visualization.py drg_decoder.py` — **passed**;
 - `python -m pip wheel . --no-deps --no-build-isolation` — **built `pysbagen-0.3.0-py3-none-any.whl`**;
-- wheel contents inspected — sleep model, generator, terminal guide, playback helper, and desktop guide included.
+- wheel contents inspected — sleep model, generator, terminal guide, playback helper, Sleep Guide, and advanced studio included.
 
 ## Truthful continuation
 

--- a/.beads/pysbagen_sleep_experience_train_2026_07_29.md
+++ b/.beads/pysbagen_sleep_experience_train_2026_07_29.md
@@ -1,0 +1,115 @@
+# PySbagen Sleep Experience Beadtrain
+
+**Date:** July 29, 2026  
+**Branch:** `agent/full-product-reliability-train-20260729`  
+**Purpose:** Turn the research discussion into the first complete human-facing sleep product without wiring fictional sensors or mixing research controls into ordinary use.
+
+## Product decisions carried into the build
+
+- The ordinary person answers human questions instead of choosing frequencies.
+- Sleep Descent and Sleep Support are different phases.
+- Sensor-driven closed-loop timing remains documented future work and is not stubbed.
+- Pleasant audio is a first-class part of the journey.
+- PySbagen supports generated sound and user-provided audio in broadly decodable formats.
+- Binaural, monaural, isochronic, and Harmonic Box X-style layers are independently selectable.
+- Research doses belong in a separate future environment.
+- All three initial sleep complaints receive materially different routes.
+
+## Beads completed
+
+### 1. Human sleep request model
+
+Added `pysbagen.sleep` with:
+
+- racing-mind, threshold-crossing, and repeated-waking problems;
+- pleasant sound-world choices;
+- gentle, balanced, and immersive strengths;
+- recommended layer blends that differ by use case;
+- 10–180 minute validated journeys;
+- exact recipe and manifest capture.
+
+### 2. Time-changing sleep journey engine
+
+Added `SleepJourneySpec` with:
+
+- separate descent and support envelopes;
+- changing beat relationships rather than one static difference;
+- continuously accumulated phase across chunks;
+- binaural, monaural, smooth isochronic, and Harmonic Box X-style layers;
+- strong post-descent reduction of active stimulation;
+- gradual bed and final-output fading;
+- deterministic generation seeds;
+- chunk metadata identifying route, stage, current beat, sound world, and layers.
+
+### 3. Generated pleasant audio
+
+Added four local sound worlds:
+
+- warm evolving ambient chords;
+- slow night music with long chord crossfades and sparse melody;
+- a stateful soft rain-like room;
+- a deep low-stimulation night environment.
+
+### 4. User audio without WAV-only restrictions
+
+Refactored file loading so SoundFile is tried first and FFmpeg becomes a general fallback rather than an MP3-only exception. User audio can be looped underneath the full journey and receives the same descent/support/fade treatment.
+
+### 5. Conversational terminal guide
+
+Added `sbgpy-sleep`.
+
+It asks four ordinary questions, shows the matched route, then saves a reproducible journey or starts immediate playback with `--play`.
+
+### 6. Conversational desktop guide
+
+Added `sbgpy-sleep-gui` as a separate normal-user application rather than burying the experience in the advanced studio.
+
+It provides:
+
+- four guided pages;
+- optional custom layer choices;
+- immediate headphone playback;
+- stop control;
+- audio export;
+- exact recipe sidecar export;
+- clear listening-safety language.
+
+The existing `sbgpy-gui` remains the advanced laboratory.
+
+### 7. Reproducibility
+
+Saved journeys receive `.sleep.json` manifests with exact timing, carrier/beat movement, layers, seed, and source-audio hash.
+
+### 8. Documentation and packaging
+
+- Version advanced to `0.3.0`.
+- Added both sleep entry points.
+- Added `docs/SLEEP_GUIDE.md`.
+- Reframed the README around the human product while preserving advanced SBaGen instructions.
+- Extended recognized schedule audio extensions while retaining file-existence detection.
+
+## Intentionally not built
+
+- EEG, watch, movement, heart-rate, breathing, or other sensor adapters;
+- fake closed-loop endpoints;
+- blinded research assignment;
+- consent or study protocol UI inside the ordinary app;
+- claims that a frequency guarantees sleep, dopamine, pain relief, migraine relief, or sobriety.
+
+## Qualification
+
+Local reconstructed exact product path:
+
+- `PYTHONPATH=. pytest -q` — **26 passed**;
+- `python -m compileall -q pysbagen sleep_gui.py` — **passed**;
+- `python -m pip wheel . --no-deps --no-build-isolation` — **built `pysbagen-0.3.0-py3-none-any.whl`**;
+- wheel contents inspected — sleep model, generator, terminal guide, playback helper, and desktop guide included.
+
+## Truthful continuation
+
+The next product choices are not sensor plumbing. The useful next trains are:
+
+1. local next-morning feedback and personal preference learning;
+2. more generated musical worlds and user-audio transformation controls;
+3. the separately launched Research Dose Environment with consent, sham/control conditions, and exact protocol assignment;
+4. only after supported hardware exists, a real closed-loop Sleep Support integration.

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: python-qualification-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,39 @@
+name: Python qualification
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package and test tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run product-path tests
+        run: pytest
+
+      - name: Build distributable package
+        if: matrix.python-version == '3.12'
+        run: python -m build

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 PySbagen is a local layered-audio product with two front doors:
 
-- **Sleep Guide** â€” answer ordinary questions and receive a matched, gradually fading audio journey;
-- **Advanced Studio** â€” build SBaGen schedules, binaural, monaural, isochronic, Harmonic Box X-style, noise, music, I-Doser, and visualization sessions.
+- **Sleep Guide**: answer ordinary questions and receive a matched, gradually fading audio journey.
+- **Advanced Studio**: build SBaGen schedules, binaural, monaural, isochronic, Harmonic Box X-style, noise, music, I-Doser, and visualization sessions.
 
 Its first complete human use case is sleep difficulty:
 
-- â€œMy mind will not stop.â€
-- â€œI feel relaxed, but cannot cross into sleep.â€
-- â€œI fall asleep, then keep waking back up.â€
+- "My mind will not stop."
+- "I feel relaxed, but cannot cross into sleep."
+- "I fall asleep, then keep waking back up."
 
 ## Install
 
@@ -25,26 +25,155 @@ Export-capable desktop interfaces:
 python -m pip install -e ".[gui]"
 ```
 
-Immediate playback:B‚˜˜\Úœ]Ûˆ[H\[œÝ[YH‹–Ü^X˜XÚ×H‚˜‚‘[\ÚÝÜÙ]\‚‚˜˜\Úœ]Ûˆ[H\[œÝ[YH‹–Ù\ÚÝÜH‚˜‚‘›Üˆ]™[ÜY[‚‚˜˜\Úœ]Ûˆ[H\[œÝ[YH‹–Ù]—H‚œ]\Ý˜‚”P]Y[ÈX^H™\]Z\™HÜ\˜][™Ë\Þ\Ý[H]Y[ÈXÚØYÙ\Ëˆ^Ü™[XZ[œÈ]˜Z[X›HÚ]Ý]]ˆÛÝ[™š[H[™\ÈÛÛ[[Ûˆ›Ü›X]ÎÈ‘›\YÈ\ÈHœ›ØYÝ™X[Z[™È˜[˜XÚÈ›ÜˆÝ\ˆØØ[HXÛÙX›H›Ü›X]Ë‚‚ˆÈÈÛY\ÝZYB‚˜˜\ÚœØ™ÜK\ÛY\YÝZB˜‚“ÜŽ‚‚˜˜\ÚœØ™ÜK\ÛY\œØ™ÜK\ÛY\K\^B˜‚•HÝZYH\ÚÜÈÚ]\È\[š[™ËÚXÚÛÝ[™ÛÜ›™Y[ÈÛ\˜X›KÝÈ™\Ù[HY[ˆ^Y\œÈÚÝ[™K[™ÝÈÛ™ÈH›Ý\›™^HÚÝ[™[XZ[‹‚‚’]ÚÛÜÙ\È[[Û™Î‚‚‹H
-Š”˜XÚ[™ÈZ[™\ØÙ[
-Šˆ8 %[Ü™H[š]X[[Ý™[Y[[™HÛ™È™YXÝ[Ûˆ[ˆ›Ý™[NÂ‹H
-ŠÜ›ÜÜÚ[™ÈH™\ÚÛ
-Šˆ8 %]ZY]\ˆ\ØÙ[›ÜˆÛÛY[Û™H[™XYH™[^YÂ‹H
-Š”Ý^KP\ÛY\Ý\Ü
-Šˆ8 %ÚÜ\ˆ\ØÙ[[™Û™Ù\ˆÝX›HÝ\Ü‚‚‘]™\žH›Ý]HÛÛZ[œÈ
-Š”ÛY\\ØÙ[
-Šˆ[™
-Š”ÛY\Ý\Ü
-Š‹ˆHÝ\œ™[˜[œÚ][Ûˆ\È[›™YžH[YKˆÙ[œÛÜˆ[YÜ˜][Ûˆ\ÈØÝ[Y[Y]\™HÛÜšÈ[™\È[[[Û˜[H›Ý™Y[ˆÚ\™YÈ›Û™^\Ý[\™Ø\™HÜˆ[™Ú[Ë‚‚‘Ù[™\˜]YÛÝ[™ÛÜ›È[˜ÛYHØ\›H[XšY[˜ÙKÛÝÈšYÚ]\ÚXËH˜Z[‹[ZÙH›ÛÛK[™HY\[šYÚ[š\›Û›Y[ˆ\Ù\‹\›ÝšYY]Y[È\È[ÛÈÝ\ÜY[ˆœ›ØYHXÛÙX›H›Ü›X]È[™Ý™X[\È[ˆ›Ý[™YÚ[šÜË‚‚•[™\›Z[™Èš[˜]\˜[[Û˜]\˜[\ÛØÚ›ÛšXË[™\›[ÛšXÈ›Þ\Ý[H^Y\œÈ\™H[™\[™[HÙ[XÝX›KÚ[™ÙHÝ™\ˆ[YK[™™XÙYH\š[™ÈÝ\ÜˆØ]™Y›Ý\›™^\È[˜ÛYH[ˆ^XÝœÛY\šœÛÛ˜™XÚ\K‚‚”ÙYHØÜËÔÓQTÑÕRQK›Y[™ØÜËÜ™\ÙX\˜ÚÔÓQTÐUQS×Ô‘TÑPTÒÑ“ÕS‘USÓ”Ë›Y‚‚ˆÈÈY˜[˜ÙYÝY[Â‚˜˜\ÚœØ™ÜKYÝZB˜‚•H[œÝ[Y[žHÚ[\Ù\ÈHÝX\™YÜ˜\\ˆ][ÝÜÈÛ™H^Ü[™Û™H™]šY]È]H[YKØ\\™\ÈÈ˜[Y\È™Y›Ü™HÛÜšÙ\ˆ™XYÈÝ\[™ÛÜÙ\È™\XÙYš\ÝX[^˜][ÛˆšYÝ\™\Ë‚‚”]ZXÚÈÓH^[\\Î‚‚˜˜\ÚœØ™ÜHKX˜\ÙHŒKX™X]LKY\˜][ÛˆŒK[Ý]š[HÙ\ÜÚ[Û‹Ø]‚œØ™ÜHKZ\ÛØÚ›ÛšXÈŒŒK[›Ú\ÙHLˆK[›Ú\ÙKZÚ[™[šÈKY\˜][ÛˆÌK[Ý]š[H›ØÝ\ËØ]‚œØ™ÜHKZ\›[ÛšXËX›ÞNHK[]\ÚXÈœÛÝ[™ØØ\\ËÜ˜Z[‹™›XÈˆK[ÛÜ[]\ÚXÈKY\˜][ÛˆŒK[Ý]š[H˜Z[‹\Ù\ÜÚ[Û‹Ø]‚˜‚ˆÈÈÐ‘ˆØÚY[\Â‚˜˜\ÚœØ™ÜHØÚY[\ËÙ^[\KœØ™ÈK[Ý]š[HØÚY[YØ]‚˜‚‘^[\N‚‚˜^˜[NˆŒ
-ÌLÍL[šËÎœ[ÙNˆ\ÛÎŒŒŒÌÍB˜™Yˆ˜]Y[ËÜÛÙ˜Z[‹™›XËÍ‚‚““ÕÈ[H
-Ø™YNŒ[ÙH
-Ø™YO‚ŒLŒ[H
-Ø™YŒMNŒÙ™‚‚‚”ØÚY[H™Z]š[ÜŽ‚‚‹H[ˆ[œ™Yš^Y]™[™\XÙ\ÈXÝ]™HÛ™HÙ]ÎÂ‹H
-Ú[˜[YXYÈ[™Z[˜[YX™[[Ý™\ÎÂ‹HÙ™˜X[™[Ù™˜ÛX\ˆ]Y[È\È\›ÜšX]NÂ‹HÚ[[˜ÙH™[XZ[œÈÛˆH[Y[[™NÂ‹HÝ[XXÝ]™HÙ[™\˜]ÜœÈ™]Z[ˆ\ÙH[™š[HÜÚ][ÛˆXÜ›ÜÜÈ]™[ÎÂ‹H˜Z[[™ÈO˜Ü›ÜÜÙ˜Y\ÈÝ™\ˆH[[\˜[ÈH™^[YY]™[Â‹H[šÛ›ÝÛˆ˜[Y\È[™X[›Ü›YY˜[œÚ][ÛœÈ\™H\œ›ÜœË‚‚“Ý]]\ÈÝ™X[YY›ÝYÚHØ[YKY\™XÝÜžH[\Ü˜\žHš[H[™]ÛZXØ[H™\XÙ\ÈH\Ý[˜][ÛˆÛ›HY\ˆÝXØÙ\ÜËˆH˜Z[YÜˆ[\H™[™\ˆ™\Ù\™\È[žH^\Ý[™Èš[K‚‚ˆÈÈ]ÛˆTB‚˜]Û‚™œ›ÛH\Ø˜YÙ[ˆ[\ÜÛY\™\]Y\Ý™[™\—ÜÛY\Üš]WØ]Y[Â™œ›ÛH\Ø˜YÙ[‹œÛY\[\ÜZ[ÜÛY\Ü™XÚ\KÜš]WÜ™XÚ\WÛX[šY™\Ý‚œ™\]Y\ÝHÛY\™\]Y\Ý
-ˆ›Ø›[OHœ˜XÚ[™×ÛZ[™‹ˆÛÝ[™ÝÛÜ›HœÛÝ×ÛšYÚÛ]\ÚXÈ‹ˆ[[œÚ]OH˜˜[[˜ÙY‹ˆ\˜][Û—ÛZ[]\ÏMKŠBœ™XÚ\HHZ[ÜÛY\Ü™XÚ\J™\]Y\Ý
-Bœ™\Ý[HÜš]WØ]Y[Ê™[™\—ÜÛY\
-™\]Y\Ý
-KœÛY\Z›Ý\›™^KØ]ˆŠBÜš]WÜ™XÚ\WÛX[šY™\Ý
-™XÚ\K™\Ý[›Ý]š[JB˜‚ˆÈÈÜ™[˜\žH\ÙH[™™\ÙX\˜Ú\ÙH\™HÙ\\˜]B‚•HÛY\ÝZYHÙ\È›ÝÙXÜ™]H\ÜÚYÛˆÚ[HÜˆ›[™YÛÛ™][ÛœËˆH]\™HÙ\\˜][H][˜ÚY
-Š”™\ÙX\˜ÚÜÙH[š\›Û›Y[
-Šˆ\È™\Ù\™Y›Üˆ[™›Ü›YYÛÛœÙ[[YÚXš[]K›ÝØÛÛ\ÜÚYÛ›Y[^XÝ™XÚ\\Ë™KÜÜÝYX\Ý\™\ËY™\œÙKYY™™XÝ™\Ü[™Ë[™^Ü‚‚ˆÈÈ]X[YšXØ][Û‚‚˜˜\Úœ]\Ýœ]Ûˆ[HÛÛ\[X[\H\Ø˜YÙ[ˆÝZKœHÝZWÜØY™KœHÛY\ÙÝZKœHš\ÝX[^˜][Û‹œH™×ÙXÛÙ\‹œBœ]Ûˆ[H\ÚY[ˆK[›ËY\Â˜‚‘Ú]XˆXÝ[ÛœÈ]X[YšY\È]ÛˆËŒL8 $ÌËŒLË‚‚ˆÈÈØY™]B‚•\ÙHHÛÛY›ÜX›H›Û[YH[™ÝÜÛˆ\ØÛÛY›ÜXYXÚK^žš[™\ÜËYÚ]][Û‹ÜˆÛÜœÙ[™YÞ[\Û\ËˆÈ›Ý\ÙHÛY\]Y[ÈÚ[Hš]š[™ÈÜˆÚ[™È[\™\ÜËXÜš]XØ[ÛÜšË‚‚”TØ˜YÙ[ˆÙ\È›Ý›ÛZ\ÙHXYÛ›ÜÚ\Ë™X]Y[Ü[Z[™H[]™\žKÝX\˜[YYÛY\Z[ˆÜˆZYÜ˜Z[™H™[YY‹ÛØœšY]KÜˆ™Z]š[Ü˜[Ý]ÛÛY\ËˆÙ]™\™HÜˆ[\ÝX[Þ[\Û\Ë[™Ù\›Ý\ÈÚ]˜]Ø[Ý™\™ÜÙKÙ[‹Z\›Hš\ÚË[™\™Ù[Üš\Ù\È™\]Z\™H™X[]ÛÜ››Ù™\ÜÚ[Û˜[[Y\™Ù[˜ÞKÜˆÜš\Ú\ÈÝ\Ü‚‚ˆÈÈXÙ[œÙB‚•H]ÛˆXÚØYÙHY]Y]HXÛ\™\ÈÔL‹Œ[Û›XÛÛœÚ\Ý[Ú]H™\Ù\™YÐ˜QÙ[ˆ[™XYÙKˆ™\šYžHYYXH[™\[™[˜ÞHXÙ[œÙ\È™Y›Ü™H\ÝšX][Û‹‚
+Immediate playback:
+
+```bash
+python -m pip install -e ".[playback]"
+```
+
+Full desktop setup:
+
+```bash
+python -m pip install -e ".[desktop]"
+```
+
+For development:
+
+```bash
+python -m pip install -e ".[dev]"
+pytest
+```
+
+PyAudio can require operating-system audio packages. Export remains available without it. SoundFile handles common formats; FFmpeg is the broad streaming fallback for other locally decodable formats.
+
+## Sleep Guide
+
+Open the desktop guide:
+
+```bash
+sbgpy-sleep-gui
+```
+
+Or use the terminal guide:
+
+```bash
+sbgpy-sleep
+sbgpy-sleep --play
+```
+
+The guide asks:
+
+1. What is keeping you awake?
+2. What sound world feels tolerable or pleasant tonight?
+3. How present should the underlying layers feel?
+4. How long should the journey remain?
+
+It chooses among three materially different routes:
+
+- **Racing Mind Descent**: more initial movement followed by a long reduction in novelty.
+- **Crossing the Threshold**: a quieter descent for someone already relaxed.
+- **Stay-Asleep Support**: a shorter descent and longer stable support period.
+
+Every route contains a **Sleep Descent** phase and a quieter **Sleep Support** phase. The current transition is planned by time. Sensor integration remains documented future work and has intentionally not been wired to nonexistent hardware or endpoints.
+
+Generated sound worlds include warm ambience, slow night music, a rain-like room, and a deep-night environment. User-provided audio is also supported in broadly decodable formats and streams in bounded chunks instead of being loaded or tiled into a session-sized array.
+
+Underlying binaural, monaural, isochronic, and Harmonic Box X-style layers are independently selectable, change over time, and recede during support. Saved journeys include an exact `.sleep.json` recipe.
+
+See:
+
+- `docs/SLEEP_GUIDE.md`
+- `docs/research/SLEEP_AUDIO_RESEARCH_FOUNDATIONS.md`
+
+## Advanced Studio
+
+```bash
+sbgpy-gui
+```
+
+The installed entry point uses a guarded wrapper that:
+
+- allows one export and one preview at a time;
+- captures Tk values before worker threads start;
+- keeps Tk updates on the UI thread;
+- closes replaced Matplotlib figures.
+
+Quick CLI examples:
+
+```bash
+sbgpy --base 200 --beat 10 --duration 60 --outfile session.wav
+sbgpy --isochronic 220 8 --noise 12 --noise-kind pink --duration 300 --outfile focus.wav
+sbgpy --harmonic-box 180 5 8 --music "soundscapes/rain.flac" --loop-music --duration 600 --outfile rain-session.wav
+```
+
+## SBG schedules
+
+```bash
+sbgpy schedules/example.sbg --outfile scheduled.wav
+```
+
+Example:
+
+```text
+alpha: 200+10/50 pink/8
+pulse: iso:220,8/35
+bed: "audio/soft rain.flac/40"
+
+NOW alpha +bed
+5:00 pulse +bed ->
+10:00 alpha +bed
+15:00 off
+```
+
+Schedule behavior:
+
+- an unprefixed event replaces active tone sets;
+- `+name` adds and `-name` removes;
+- `off`, `-`, and `alloff` clear audio as appropriate;
+- silence remains on the timeline;
+- still-active generators retain phase and file position across events;
+- trailing `->` crossfades over the full interval to the next timed event;
+- unknown names and malformed transitions are errors.
+
+Output is written to a same-directory temporary file and atomically replaces the destination only after success. A failed or empty render preserves an existing file.
+
+## Python API
+
+```python
+from pysbagen import SleepRequest, render_sleep, write_audio
+from pysbagen.sleep import build_sleep_recipe, write_recipe_manifest
+
+request = SleepRequest(
+    problem="racing_mind",
+    sound_world="slow_night_music",
+    intensity="balanced",
+    duration_minutes=45,
+)
+recipe = build_sleep_recipe(request)
+result = write_audio(render_sleep(request), "sleep-journey.wav")
+write_recipe_manifest(recipe, result.outfile)
+```
+
+## Ordinary use and research use are separate
+
+The Sleep Guide does not secretly assign sham or blinded conditions. A future separately launched **Research Dose Environment** is reserved for informed consent, eligibility, protocol assignment, exact recipes, pre/post measures, adverse-effect reporting, and data export.
+
+## Qualification
+
+```bash
+pytest
+python -m compileall -q pysbagen gui.py gui_safe.py sleep_gui.py visualization.py drg_decoder.py
+python -m pip wheel . --no-deps
+```
+
+GitHub Actions qualifies Python 3.10 through 3.13.
+
+## Safety
+
+Use a comfortable volume and stop on discomfort, headache, dizziness, agitation, or worsened symptoms. Do not use sleep audio while driving or doing alertness-critical work.
+
+PySbagen does not promise diagnosis, treatment, dopamine delivery, guaranteed sleep, pain or migraine relief, sobriety, or behavioral outcomes. Severe or unusual symptoms, dangerous withdrawal, overdose, self-harm risk, and urgent crises require real-world professional, emergency, or crisis support.
+
+## License
+
+The Python package metadata declares `GPL-2.0-only`, consistent with the preserved SBaGen lineage. Verify media and dependency licenses before distribution.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,205 @@
-# pysbagen
+# MindManipulation / pysbagen
 
-Modern Python reimplementation of SBaGen with plugin generators.
+`pysbagen` is a local Python audio-session builder inspired by SBaGen. It can generate and combine:
+
+- binaural tones;
+- isochronic tones;
+- Harmonic Box X-style tones;
+- white and pink noise;
+- arbitrary sine, square, triangle, and sawtooth tones;
+- WAV, OGG, FLAC, AIFF, and MP3 background audio;
+- SBG schedule files;
+- supported I-Doser `.drg` files through the desktop GUI;
+- Chladni-style frequency visualizations.
+
+The repository also preserves the original SBaGen 1.4.5 source and earlier Python experiments for reference. The **canonical maintained Python product** is the top-level `pysbagen/` package, the `sbgpy` command, and the `sbgpy-gui` desktop application.
+
+## Install
+
+Python 3.10 or newer is required.
+
+```bash
+python -m pip install .
+```
+
+For development and tests:
+
+```bash
+python -m pip install -e ".[dev]"
+pytest
+```
+
+For the desktop GUI and live playback:
+
+```bash
+python -m pip install -e ".[gui]"
+```
+
+PyAudio can require an operating-system audio package or compiler toolchain. File generation does **not** depend on PyAudio; the GUI still opens and exports audio when live playback is unavailable.
+
+MP3 input uses `pydub` and normally requires FFmpeg to be installed and discoverable on the system path. WAV, OGG, FLAC, and AIFF input use `soundfile` directly.
+
+## Quick CLI generation
+
+Create a 60-second binaural session:
+
+```bash
+sbgpy --base 200 --beat 10 --duration 60 --outfile session.wav
+```
+
+Create an isochronic session with pink noise:
+
+```bash
+sbgpy \
+  --isochronic 220 8 \
+  --noise 12 \
+  --noise-kind pink \
+  --duration 300 \
+  --outfile focus.wav
+```
+
+Combine Harmonic Box X-style audio with a looping soundscape:
+
+```bash
+sbgpy \
+  --harmonic-box 180 5 8 \
+  --music "soundscapes/rain.wav" \
+  --music-amp 40 \
+  --loop-music \
+  --duration 600 \
+  --outfile rain-session.wav
+```
+
+The writer streams chunks directly to disk instead of buffering an entire long session in memory.
+
+## SBG schedules
+
+Generate a schedule:
+
+```bash
+sbgpy schedules/example.sbg --outfile scheduled.wav
+```
+
+Override its endpoint:
+
+```bash
+sbgpy schedules/example.sbg --duration 900 --outfile scheduled.wav
+```
+
+A small schedule looks like this:
+
+```text
+# Components are declared first.
+alpha: 200+10/50 pink/8
+pulse: iso:220,8/35
+bed: "audio/soft rain.wav/40"
+
+# Events follow. The final event normally marks the end.
+NOW alpha +bed
+5:00 pulse +bed
+10:00 off
+```
+
+Supported component forms:
+
+```text
+200+10/50             # base + beat / amplitude
+200-10/50             # negative beat difference
+white/10              # white noise / amplitude
+pink/10               # pink noise / amplitude
+iso:220,8/40          # frequency, beat / amplitude
+hbox:180,5,8/35       # base, difference, modulation / amplitude
+file:audio/rain.wav/40
+"audio/soft rain.wav/40"
+```
+
+Audio paths inside schedules are resolved relative to the schedule file, not the shell's current directory. Quoted paths may contain spaces. Source audio is converted to stereo and resampled to 44.1 kHz when necessary.
+
+Schedule event behavior:
+
+- an unprefixed event replaces the active tone sets;
+- `+name` adds a tone set;
+- `-name` removes a tone set;
+- `off`, `-`, or `alloff` clears audio as appropriate;
+- silent spans remain real silence and do not collapse the timeline;
+- unknown tone-set names produce an error instead of silently disappearing.
+
+When no explicit `--duration` is supplied, the final schedule timestamp is treated as the endpoint. End a schedule with an `off` event when the final active section needs a defined length.
+
+## Desktop GUI
+
+After installing the GUI extra:
+
+```bash
+sbgpy-gui
+```
+
+The application provides:
+
+- quick binaural export;
+- advanced isochronic, Harmonic Box X, noise, and music sessions;
+- SBG selection and duration override;
+- I-Doser loading, artwork preview, and schedule generation;
+- a multi-tone waveform builder with optional looping soundscape;
+- Chladni visualization;
+- optional live preview through PyAudio.
+
+All export paths use the same `pysbagen.api` functions as the CLI. The GUI no longer changes process arguments or maintains a separate audio engine.
+
+## Python API
+
+```python
+from pysbagen.api import build_quick_specs, render_specs, write_audio
+
+specs = build_quick_specs(
+    base=200,
+    beat=10,
+    noise=8,
+    noise_kind="pink",
+)
+result = write_audio(render_specs(specs, 60), "session.wav")
+print(result.duration, result.outfile)
+```
+
+For a schedule:
+
+```python
+from pysbagen.api import render_schedule, write_audio
+
+result = write_audio(render_schedule("session.sbg"), "session.wav")
+```
+
+Third-party generator packages can register entry points under `pysbagen.generators`. A generator must expose a `generator(duration)` iterator that yields `(audio_chunk, info)` pairs at 44.1 kHz.
+
+## Repository map
+
+```text
+pysbagen/                 Canonical maintained Python package
+pysbagen/generators/      Built-in generator specifications
+pysbagen/tests/           Product-path qualification
+pysbagen/src/pysbagen/    Preserved duplicate from the earlier refactor; excluded from builds
+gui.py                    Desktop application entry point
+visualization.py          Chladni visualization functions
+drg_decoder.py            I-Doser decoder
+sbagen-1.4.5/             Preserved original SBaGen source and examples
+.beads/                   Product-train state and continuation notes
+```
+
+## Qualification
+
+Run:
+
+```bash
+pytest
+python -m pip wheel . --no-deps
+```
+
+GitHub Actions runs the test suite on Python 3.10 through 3.13 and verifies that the package can build.
+
+## Listening safety
+
+Keep playback at a comfortable volume and stop if audio causes discomfort, headache, dizziness, agitation, or other unwanted effects. This software is an audio experimentation and creative-session tool; it is not medical treatment and does not promise diagnostic, therapeutic, or behavioral outcomes.
+
+## License
+
+The Python package metadata declares `GPL-2.0-only`, consistent with the preserved SBaGen lineage. Before distributing binaries or derivative packages, verify that all included third-party media and dependencies have compatible licenses.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,85 @@
 # MindManipulation / pysbagen
 
-`pysbagen` is a local Python audio-session builder inspired by SBaGen. It can generate and combine:
+`pysbagen` is a local layered-audio product for people who want help changing the conditions around a difficult moment without needing to understand audio engineering.
 
-- binaural tones;
-- isochronic tones;
-- Harmonic Box X-style tones;
-- white and pink noise;
-- arbitrary sine, square, triangle, and sawtooth tones;
-- WAV, OGG, FLAC, AIFF, and MP3 background audio;
-- SBG schedule files;
-- supported I-Doser `.drg` files through the desktop GUI;
-- Chladni-style frequency visualizations.
+Its first complete human use-case is **sleep difficulty**:
 
-The repository also preserves the original SBaGen 1.4.5 source and earlier Python experiments for reference. The **canonical maintained Python product** is the top-level `pysbagen/` package, the `sbgpy` command, and the `sbgpy-gui` desktop application.
+- “My mind will not stop.”
+- “I feel relaxed, but I cannot cross into sleep.”
+- “I fall asleep, then keep waking back up.”
 
-## Install
+The Sleep Guide asks a few ordinary questions, creates a matched time-changing journey, and either plays it immediately or saves it for later. Pleasant generated music, ambient sound, rain-like sound, deep-night sound, or the listener’s own audio can carry independently controlled binaural, monaural, isochronic, and Harmonic Box X-style layers.
+
+The repository also preserves the advanced SBaGen-compatible laboratory for schedules, tone construction, I-Doser decoding, and exact audio experiments. The **canonical maintained Python product** is the top-level `pysbagen/` package.
+
+## Start with the Sleep Guide
+
+Install the GUI and playback extras:
+
+```bash
+python -m pip install -e ".[gui]"
+```
+
+Open the conversational desktop guide:
+
+```bash
+sbgpy-sleep-gui
+```
+
+Or use the terminal guide:
+
+```bash
+sbgpy-sleep
+```
+
+To answer the questions and begin live playback instead of saving a file:
+
+```bash
+sbgpy-sleep --play
+```
+
+The guide asks:
+
+1. what is keeping you awake;
+2. what kind of sound feels pleasant or tolerable tonight;
+3. how present the underlying layers should feel;
+4. how long the journey should remain before fading away.
+
+It then selects one of three materially different routes:
+
+- **Racing Mind Descent** — more initial movement, followed by a long reduction in novelty;
+- **Crossing the Threshold** — a quieter descent for someone already relaxed;
+- **Stay-Asleep Support** — a shorter descent and longer stable support bed.
+
+Each route contains a **Sleep Descent** period and a quieter **Sleep Support** period. The present implementation uses a planned transition. Sensor-driven sleep-state detection remains documented future work and has intentionally not been wired to nonexistent devices or endpoints.
+
+### Pleasant audio choices
+
+PySbagen currently generates four original sound worlds:
+
+- warm evolving ambient chords;
+- slow night music with long chord movement and a sparse fading melody;
+- a soft rain-like room;
+- a dark low-stimulation night environment.
+
+The listener can instead supply their own music, ambience, recording, or other audio. SoundFile handles common formats directly; FFmpeg is used as a broad fallback for other locally decodable formats. This is not a WAV-only workflow.
+
+### Underlying layers
+
+Normal users can accept a recommended blend. They may also choose among:
+
+- binaural;
+- monaural;
+- soft isochronic modulation;
+- Harmonic Box X-style multi-layer modulation.
+
+The layers change over time and recede strongly during the support period. PySbagen does not encode one technique as universally superior.
+
+When a journey is saved, PySbagen also writes a `.sleep.json` manifest containing the exact route, timing, carrier and beat movement, layer choices, seed, and—when supplied—the source-audio SHA-256. That makes a personally useful session reproducible without turning ordinary use into a research study.
+
+See [`docs/SLEEP_GUIDE.md`](docs/SLEEP_GUIDE.md) for the complete product behavior and [`docs/research/SLEEP_AUDIO_RESEARCH_FOUNDATIONS.md`](docs/research/SLEEP_AUDIO_RESEARCH_FOUNDATIONS.md) for the research basis and evidence limits.
+
+## Install the advanced studio
 
 Python 3.10 or newer is required.
 
@@ -29,17 +94,17 @@ python -m pip install -e ".[dev]"
 pytest
 ```
 
-For the desktop GUI and live playback:
+For desktop applications and live playback:
 
 ```bash
 python -m pip install -e ".[gui]"
 ```
 
-PyAudio can require an operating-system audio package or compiler toolchain. File generation does **not** depend on PyAudio; the GUI still opens and exports audio when live playback is unavailable.
+PyAudio can require an operating-system audio package or compiler toolchain. File generation does **not** depend on PyAudio; both desktop applications can still export audio when live playback is unavailable.
 
-MP3 input is decoded directly through FFmpeg, which must be installed and discoverable on the system path. WAV, OGG, FLAC, and AIFF input use `soundfile` directly.
+FFmpeg should be installed and discoverable on the system path for formats that SoundFile cannot decode.
 
-## Quick CLI generation
+## Advanced CLI generation
 
 Create a 60-second binaural session:
 
@@ -113,7 +178,7 @@ file:audio/rain.wav/40
 "audio/soft rain.wav/40"
 ```
 
-Audio paths inside schedules are resolved relative to the schedule file, not the shell's current directory. Quoted paths may contain spaces. Source audio is converted to stereo and resampled to 44.1 kHz when necessary.
+Audio paths inside schedules are resolved relative to the schedule file, not the shell’s current directory. Quoted paths may contain spaces. Source audio is converted to stereo and resampled to 44.1 kHz when necessary.
 
 Schedule event behavior:
 
@@ -126,27 +191,44 @@ Schedule event behavior:
 
 When no explicit `--duration` is supplied, the final schedule timestamp is treated as the endpoint. End a schedule with an `off` event when the final active section needs a defined length.
 
-## Desktop GUI
-
-After installing the GUI extra:
+## Advanced desktop studio
 
 ```bash
 sbgpy-gui
 ```
 
-The application provides:
+The advanced application provides:
 
 - quick binaural export;
-- advanced isochronic, Harmonic Box X, noise, and music sessions;
+- isochronic, Harmonic Box X, noise, and background-audio sessions;
 - SBG selection and duration override;
 - I-Doser loading, artwork preview, and schedule generation;
 - a multi-tone waveform builder with optional looping soundscape;
 - Chladni visualization;
 - optional live preview through PyAudio.
 
-All export paths use the same `pysbagen.api` functions as the CLI. The GUI no longer changes process arguments or maintains a separate audio engine.
+All export paths use the same `pysbagen.api` functions as the CLI.
 
 ## Python API
+
+Create a sleep journey:
+
+```python
+from pysbagen import SleepRequest, render_sleep, write_audio
+from pysbagen.sleep import build_sleep_recipe, write_recipe_manifest
+
+request = SleepRequest(
+    problem="racing_mind",
+    sound_world="slow_night_music",
+    intensity="balanced",
+    duration_minutes=45,
+)
+recipe = build_sleep_recipe(request)
+result = write_audio(render_sleep(request), "sleep-journey.wav")
+write_recipe_manifest(recipe, result.outfile)
+```
+
+Create a direct generator session:
 
 ```python
 from pysbagen.api import build_quick_specs, render_specs, write_audio
@@ -161,28 +243,31 @@ result = write_audio(render_specs(specs, 60), "session.wav")
 print(result.duration, result.outfile)
 ```
 
-For a schedule:
-
-```python
-from pysbagen.api import render_schedule, write_audio
-
-result = write_audio(render_schedule("session.sbg"), "session.wav")
-```
-
 Third-party generator packages can register entry points under `pysbagen.generators`. A generator must expose a `generator(duration)` iterator that yields `(audio_chunk, info)` pairs at 44.1 kHz.
+
+## Ordinary use and research use are separate
+
+The Sleep Guide is help-oriented. It does not assign blinded conditions, present sham sessions, or make the user feel like an unwitting experiment.
+
+A future **Research Dose Environment** is documented separately for consenting volunteers, protocol versioning, exact condition assignment, pre/post measures, and adverse-effect reporting. It is intentionally not stubbed into the ordinary GUI, TUI, or playback path yet.
 
 ## Repository map
 
 ```text
-pysbagen/                 Canonical maintained Python package
-pysbagen/generators/      Built-in generator specifications
-pysbagen/tests/           Product-path qualification
-pysbagen/src/pysbagen/    Preserved duplicate from the earlier refactor; excluded from builds
-gui.py                    Desktop application entry point
-visualization.py          Chladni visualization functions
-drg_decoder.py            I-Doser decoder
-sbagen-1.4.5/             Preserved original SBaGen source and examples
-.beads/                   Product-train state and continuation notes
+pysbagen/                    Canonical maintained Python package
+pysbagen/sleep.py           Human sleep requests and matched recipes
+pysbagen/generators/sleep.py Time-changing layered sleep synthesis
+pysbagen/sleep_cli.py       Conversational terminal Sleep Guide
+pysbagen/playback.py        Immediate streaming playback
+sleep_gui.py                Conversational desktop Sleep Guide
+pysbagen/generators/        Advanced built-in generator specifications
+pysbagen/tests/             Product-path qualification
+gui.py                      Advanced desktop studio
+visualization.py            Chladni visualization functions
+drg_decoder.py              I-Doser decoder
+sbagen-1.4.5/                Preserved original SBaGen source and examples
+docs/research/              Evidence and product-research foundations
+.beads/                     Product-train state and continuation notes
 ```
 
 ## Qualification
@@ -198,7 +283,9 @@ GitHub Actions runs the test suite on Python 3.10 through 3.13 and verifies that
 
 ## Listening safety
 
-Keep playback at a comfortable volume and stop if audio causes discomfort, headache, dizziness, agitation, or other unwanted effects. This software is an audio experimentation and creative-session tool; it is not medical treatment and does not promise diagnostic, therapeutic, or behavioral outcomes.
+Keep playback at a comfortable volume and stop if audio causes discomfort, headache, dizziness, agitation, worsened symptoms, or other unwanted effects. PySbagen is an audio experimentation and sleep-support tool. It does not promise diagnosis, treatment, dopamine delivery, guaranteed sleep, pain relief, migraine relief, sobriety, or behavioral outcomes.
+
+Do not use sleep audio while driving, operating machinery, or doing anything that requires alertness.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ python -m pip install -e ".[gui]"
 
 PyAudio can require an operating-system audio package or compiler toolchain. File generation does **not** depend on PyAudio; the GUI still opens and exports audio when live playback is unavailable.
 
-MP3 input uses `pydub` and normally requires FFmpeg to be installed and discoverable on the system path. WAV, OGG, FLAC, and AIFF input use `soundfile` directly.
+MP3 input is decoded directly through FFmpeg, which must be installed and discoverable on the system path. WAV, OGG, FLAC, and AIFF input use `soundfile` directly.
 
 ## Quick CLI generation
 

--- a/README.md
+++ b/README.md
@@ -1,85 +1,17 @@
-# MindManipulation / pysbagen
+# MindManipulation / PySbagen
 
-`pysbagen` is a local layered-audio product for people who want help changing the conditions around a difficult moment without needing to understand audio engineering.
+PySbagen is a local layered-audio product with two front doors:
 
-Its first complete human use-case is **sleep difficulty**:
+- **Sleep Guide** â€” answer ordinary questions and receive a matched, gradually fading audio journey;
+- **Advanced Studio** â€” build SBaGen schedules, binaural, monaural, isochronic, Harmonic Box X-style, noise, music, I-Doser, and visualization sessions.
+
+Its first complete human use case is sleep difficulty:
 
 - â€œMy mind will not stop.â€
-- â€œI feel relaxed, but I cannot cross into sleep.â€
+- â€œI feel relaxed, but cannot cross into sleep.â€
 - â€œI fall asleep, then keep waking back up.â€
 
-The Sleep Guide asks a few ordinary questions, creates a matched time-changing journey, and either plays it immediately or saves it for later. Pleasant generated music, ambient sound, rain-like sound, deep-night sound, or the listenerâ€™s own audio can carry independently controlled binaural, monaural, isochronic, and Harmonic Box X-style layers.
-
-The repository also preserves the advanced SBaGen-compatible laboratory for schedules, tone construction, I-Doser decoding, and exact audio experiments. The **canonical maintained Python product** is the top-level `pysbagen/` package.
-
-## Start with the Sleep Guide
-
-Install the GUI and playback extras:
-
-```bash
-python -m pip install -e ".[gui]"
-```
-
-Open the conversational desktop guide:
-
-```bash
-sbgpy-sleep-gui
-```
-
-Or use the terminal guide:
-
-```bash
-sbgpy-sleep
-```
-
-To answer the questions and begin live playback instead of saving a file:
-
-```bash
-sbgpy-sleep --play
-```
-
-The guide asks:
-
-1. what is keeping you awake;
-2. what kind of sound feels pleasant or tolerable tonight;
-3. how present the underlying layers should feel;
-4. how long the journey should remain before fading away.
-
-It then selects one of three materially different routes:
-
-- **Racing Mind Descent** â€” more initial movement, followed by a long reduction in novelty;
-- **Crossing the Threshold** â€” a quieter descent for someone already relaxed;
-- **Stay-Asleep Support** â€” a shorter descent and longer stable support bed.
-
-Each route contains a **Sleep Descent** period and a quieter **Sleep Support** period. The present implementation uses a planned transition. Sensor-driven sleep-state detection remains documented future work and has intentionally not been wired to nonexistent devices or endpoints.
-
-### Pleasant audio choices
-
-PySbagen currently generates four original sound worlds:
-
-- warm evolving ambient chords;
-- slow night music with long chord movement and a sparse fading melody;
-- a soft rain-like room;
-- a dark low-stimulation night environment.
-
-The listener can instead supply their own music, ambience, recording, or other audio. SoundFile handles common formats directly; FFmpeg is used as a broad fallback for other locally decodable formats. This is not a WAV-only workflow.
-
-### Underlying layers
-
-Normal users can accept a recommended blend. They may also choose among:
-
-- binaural;
-- monaural;
-- soft isochronic modulation;
-- Harmonic Box X-style multi-layer modulation.
-
-The layers change over time and recede strongly during the support period. PySbagen does not encode one technique as universally superior.
-
-When a journey is saved, PySbagen also writes a `.sleep.json` manifest containing the exact route, timing, carrier and beat movement, layer choices, seed, andâ€”when suppliedâ€”the source-audio SHA-256. That makes a personally useful session reproducible without turning ordinary use into a research study.
-
-See [`docs/SLEEP_GUIDE.md`](docs/SLEEP_GUIDE.md) for the complete product behavior and [`docs/research/SLEEP_AUDIO_RESEARCH_FOUNDATIONS.md`](docs/research/SLEEP_AUDIO_RESEARCH_FOUNDATIONS.md) for the research basis and evidence limits.
-
-## Install the advanced studio
+## Install
 
 Python 3.10 or newer is required.
 
@@ -87,206 +19,32 @@ Python 3.10 or newer is required.
 python -m pip install .
 ```
 
-For development and tests:
-
-```bash
-python -m pip install -e ".[dev]"
-pytest
-```
-
-For desktop applications and live playback:
+Export-capable desktop interfaces:
 
 ```bash
 python -m pip install -e ".[gui]"
 ```
 
-PyAudio can require an operating-system audio package or compiler toolchain. File generation does **not** depend on PyAudio; both desktop applications can still export audio when live playback is unavailable.
-
-FFmpeg should be installed and discoverable on the system path for formats that SoundFile cannot decode.
-
-## Advanced CLI generation
-
-Create a 60-second binaural session:
-
-```bash
-sbgpy --base 200 --beat 10 --duration 60 --outfile session.wav
-```
-
-Create an isochronic session with pink noise:
-
-```bash
-sbgpy \
-  --isochronic 220 8 \
-  --noise 12 \
-  --noise-kind pink \
-  --duration 300 \
-  --outfile focus.wav
-```
-
-Combine Harmonic Box X-style audio with a looping soundscape:
-
-```bash
-sbgpy \
-  --harmonic-box 180 5 8 \
-  --music "soundscapes/rain.wav" \
-  --music-amp 40 \
-  --loop-music \
-  --duration 600 \
-  --outfile rain-session.wav
-```
-
-The writer streams chunks directly to disk instead of buffering an entire long session in memory.
-
-## SBG schedules
-
-Generate a schedule:
-
-```bash
-sbgpy schedules/example.sbg --outfile scheduled.wav
-```
-
-Override its endpoint:
-
-```bash
-sbgpy schedules/example.sbg --duration 900 --outfile scheduled.wav
-```
-
-A small schedule looks like this:
-
-```text
-# Components are declared first.
-alpha: 200+10/50 pink/8
-pulse: iso:220,8/35
-bed: "audio/soft rain.wav/40"
-
-# Events follow. The final event normally marks the end.
-NOW alpha +bed
-5:00 pulse +bed
-10:00 off
-```
-
-Supported component forms:
-
-```text
-200+10/50             # base + beat / amplitude
-200-10/50             # negative beat difference
-white/10              # white noise / amplitude
-pink/10               # pink noise / amplitude
-iso:220,8/40          # frequency, beat / amplitude
-hbox:180,5,8/35       # base, difference, modulation / amplitude
-file:audio/rain.wav/40
-"audio/soft rain.wav/40"
-```
-
-Audio paths inside schedules are resolved relative to the schedule file, not the shellâ€™s current directory. Quoted paths may contain spaces. Source audio is converted to stereo and resampled to 44.1 kHz when necessary.
-
-Schedule event behavior:
-
-- an unprefixed event replaces the active tone sets;
-- `+name` adds a tone set;
-- `-name` removes a tone set;
-- `off`, `-`, or `alloff` clears audio as appropriate;
-- silent spans remain real silence and do not collapse the timeline;
-- unknown tone-set names produce an error instead of silently disappearing.
-
-When no explicit `--duration` is supplied, the final schedule timestamp is treated as the endpoint. End a schedule with an `off` event when the final active section needs a defined length.
-
-## Advanced desktop studio
-
-```bash
-sbgpy-gui
-```
-
-The advanced application provides:
-
-- quick binaural export;
-- isochronic, Harmonic Box X, noise, and background-audio sessions;
-- SBG selection and duration override;
-- I-Doser loading, artwork preview, and schedule generation;
-- a multi-tone waveform builder with optional looping soundscape;
-- Chladni visualization;
-- optional live preview through PyAudio.
-
-All export paths use the same `pysbagen.api` functions as the CLI.
-
-## Python API
-
-Create a sleep journey:
-
-```python
-from pysbagen import SleepRequest, render_sleep, write_audio
-from pysbagen.sleep import build_sleep_recipe, write_recipe_manifest
-
-request = SleepRequest(
-    problem="racing_mind",
-    sound_world="slow_night_music",
-    intensity="balanced",
-    duration_minutes=45,
-)
-recipe = build_sleep_recipe(request)
-result = write_audio(render_sleep(request), "sleep-journey.wav")
-write_recipe_manifest(recipe, result.outfile)
-```
-
-Create a direct generator session:
-
-```python
-from pysbagen.api import build_quick_specs, render_specs, write_audio
-
-specs = build_quick_specs(
-    base=200,
-    beat=10,
-    noise=8,
-    noise_kind="pink",
-)
-result = write_audio(render_specs(specs, 60), "session.wav")
-print(result.duration, result.outfile)
-```
-
-Third-party generator packages can register entry points under `pysbagen.generators`. A generator must expose a `generator(duration)` iterator that yields `(audio_chunk, info)` pairs at 44.1 kHz.
-
-## Ordinary use and research use are separate
-
-The Sleep Guide is help-oriented. It does not assign blinded conditions, present sham sessions, or make the user feel like an unwitting experiment.
-
-A future **Research Dose Environment** is documented separately for consenting volunteers, protocol versioning, exact condition assignment, pre/post measures, and adverse-effect reporting. It is intentionally not stubbed into the ordinary GUI, TUI, or playback path yet.
-
-## Repository map
-
-```text
-pysbagen/                    Canonical maintained Python package
-pysbagen/sleep.py           Human sleep requests and matched recipes
-pysbagen/generators/sleep.py Time-changing layered sleep synthesis
-pysbagen/sleep_cli.py       Conversational terminal Sleep Guide
-pysbagen/playback.py        Immediate streaming playback
-sleep_gui.py                Conversational desktop Sleep Guide
-pysbagen/generators/        Advanced built-in generator specifications
-pysbagen/tests/             Product-path qualification
-gui.py                      Advanced desktop studio
-visualization.py            Chladni visualization functions
-drg_decoder.py              I-Doser decoder
-sbagen-1.4.5/                Preserved original SBaGen source and examples
-docs/research/              Evidence and product-research foundations
-.beads/                     Product-train state and continuation notes
-```
-
-## Qualification
-
-Run:
-
-```bash
-pytest
-python -m pip wheel . --no-deps
-```
-
-GitHub Actions runs the test suite on Python 3.10 through 3.13 and verifies that the package can build.
-
-## Listening safety
-
-Keep playback at a comfortable volume and stop if audio causes discomfort, headache, dizziness, agitation, worsened symptoms, or other unwanted effects. PySbagen is an audio experimentation and sleep-support tool. It does not promise diagnosis, treatment, dopamine delivery, guaranteed sleep, pain relief, migraine relief, sobriety, or behavioral outcomes.
-
-Do not use sleep audio while driving, operating machinery, or doing anything that requires alertness.
-
-## License
-
-The Python package metadata declares `GPL-2.0-only`, consistent with the preserved SBaGen lineage. Before distributing binaries or derivative packages, verify that all included third-party media and dependencies have compatible licenses.
+Immediate playback:B‚˜˜\Úœ]Ûˆ[H\[œİ[YH‹–Ü^X˜XÚ×H‚˜‚‘[\ÚİÜÙ]\‚‚˜˜\Úœ]Ûˆ[H\[œİ[YH‹–Ù\ÚİÜH‚˜‚‘›Üˆ]™[ÜY[‚‚˜˜\Úœ]Ûˆ[H\[œİ[YH‹–Ù]—H‚œ]\İ˜‚”P]Y[ÈX^H™\]Z\™HÜ\˜][™Ë\Ş\İ[H]Y[ÈXÚØYÙ\Ëˆ^Ü™[XZ[œÈ]˜Z[X›HÚ]İ]]ˆÛİ[™š[H[™\ÈÛÛ[[Ûˆ›Ü›X]ÎÈ‘›\YÈ\ÈHœ›ØYİ™X[Z[™È˜[˜XÚÈ›Üˆİ\ˆØØ[HXÛÙX›H›Ü›X]Ë‚‚ˆÈÈÛY\İZYB‚˜˜\ÚœØ™ÜK\ÛY\YİZB˜‚“Ü‚‚˜˜\ÚœØ™ÜK\ÛY\œØ™ÜK\ÛY\K\^B˜‚•HİZYH\ÚÜÈÚ]\È\[š[™ËÚXÚÛİ[™ÛÜ›™Y[ÈÛ\˜X›KİÈ™\Ù[HY[ˆ^Y\œÈÚİ[™K[™İÈÛ™ÈH›İ\›™^HÚİ[™[XZ[‹‚‚’]ÚÛÜÙ\È[[Û™Î‚‚‹H
+Š”˜XÚ[™ÈZ[™\ØÙ[
+Šˆ8 %[Ü™H[š]X[[İ™[Y[[™HÛ™È™YXİ[Ûˆ[ˆ›İ™[NÂ‹H
+ŠÜ›ÜÜÚ[™ÈH™\ÚÛ
+Šˆ8 %]ZY]\ˆ\ØÙ[›ÜˆÛÛY[Û™H[™XYH™[^YÂ‹H
+Š”İ^KP\ÛY\İ\Ü
+Šˆ8 %ÚÜ\ˆ\ØÙ[[™Û™Ù\ˆİX›Hİ\Ü‚‚‘]™\H›İ]HÛÛZ[œÈ
+Š”ÛY\\ØÙ[
+Šˆ[™
+Š”ÛY\İ\Ü
+Š‹ˆHİ\œ™[˜[œÚ][Ûˆ\È[›™YH[YKˆÙ[œÛÜˆ[YÜ˜][Ûˆ\ÈØİ[Y[Y]\™HÛÜšÈ[™\È[[[Û˜[H›İ™Y[ˆÚ\™YÈ›Û™^\İ[\™Ø\™HÜˆ[™Ú[Ë‚‚‘Ù[™\˜]YÛİ[™ÛÜ›È[˜ÛYHØ\›H[XšY[˜ÙKÛİÈšYÚ]\ÚXËH˜Z[‹[ZÙH›ÛÛK[™HY\[šYÚ[š\›Û›Y[ˆ\Ù\‹\›İšYY]Y[È\È[ÛÈİ\ÜY[ˆœ›ØYHXÛÙX›H›Ü›X]È[™İ™X[\È[ˆ›İ[™YÚ[šÜË‚‚•[™\›Z[™Èš[˜]\˜[[Û˜]\˜[\ÛØÚ›ÛšXË[™\›[ÛšXÈ›Ş\İ[H^Y\œÈ\™H[™\[™[HÙ[XİX›KÚ[™ÙHİ™\ˆ[YK[™™XÙYH\š[™Èİ\ÜˆØ]™Y›İ\›™^\È[˜ÛYH[ˆ^XİœÛY\šœÛÛ˜™XÚ\K‚‚”ÙYHØÜËÔÓQTÑÕRQK›Y[™ØÜËÜ™\ÙX\˜ÚÔÓQTĞUQS×Ô‘TÑPTÒÑ“ÕS‘USÓ”Ë›Y‚‚ˆÈÈY˜[˜ÙYİY[Â‚˜˜\ÚœØ™ÜKYİZB˜‚•H[œİ[Y[HÚ[\Ù\ÈHİX\™YÜ˜\\ˆ][İÜÈÛ™H^Ü[™Û™H™]šY]È]H[YKØ\\™\ÈÈ˜[Y\È™Y›Ü™HÛÜšÙ\ˆ™XYÈİ\[™ÛÜÙ\È™\XÙYš\İX[^˜][ÛˆšYİ\™\Ë‚‚”]ZXÚÈÓH^[\\Î‚‚˜˜\ÚœØ™ÜHKX˜\ÙHŒKX™X]LKY\˜][ÛˆŒK[İ]š[HÙ\ÜÚ[Û‹Ø]‚œØ™ÜHKZ\ÛØÚ›ÛšXÈŒŒK[›Ú\ÙHLˆK[›Ú\ÙKZÚ[™[šÈKY\˜][ÛˆÌK[İ]š[H›Øİ\ËØ]‚œØ™ÜHKZ\›[ÛšXËX›ŞNHK[]\ÚXÈœÛİ[™ØØ\\ËÜ˜Z[‹™›XÈˆK[ÛÜ[]\ÚXÈKY\˜][ÛˆŒK[İ]š[H˜Z[‹\Ù\ÜÚ[Û‹Ø]‚˜‚ˆÈÈĞ‘ˆØÚY[\Â‚˜˜\ÚœØ™ÜHØÚY[\ËÙ^[\KœØ™ÈK[İ]š[HØÚY[YØ]‚˜‚‘^[\N‚‚˜^˜[NˆŒ
+ÌLÍL[šËÎœ[ÙNˆ\ÛÎŒŒŒÌÍB˜™Yˆ˜]Y[ËÜÛÙ˜Z[‹™›XËÍ‚‚““ÕÈ[H
+Ø™YNŒ[ÙH
+Ø™YO‚ŒLŒ[H
+Ø™YŒMNŒÙ™‚‚‚”ØÚY[H™Z]š[Ü‚‚‹H[ˆ[œ™Yš^Y]™[™\XÙ\ÈXİ]™HÛ™HÙ]ÎÂ‹H
+Ú[˜[YXYÈ[™Z[˜[YX™[[İ™\ÎÂ‹HÙ™˜X[™[Ù™˜ÛX\ˆ]Y[È\È\›ÜšX]NÂ‹HÚ[[˜ÙH™[XZ[œÈÛˆH[Y[[™NÂ‹Hİ[XXİ]™HÙ[™\˜]ÜœÈ™]Z[ˆ\ÙH[™š[HÜÚ][ÛˆXÜ›ÜÜÈ]™[ÎÂ‹H˜Z[[™ÈO˜Ü›ÜÜÙ˜Y\Èİ™\ˆH[[\˜[ÈH™^[YY]™[Â‹H[šÛ›İÛˆ˜[Y\È[™X[›Ü›YY˜[œÚ][ÛœÈ\™H\œ›ÜœË‚‚“İ]]\Èİ™X[YY›İYÚHØ[YKY\™XİÜH[\Ü˜\Hš[H[™]ÛZXØ[H™\XÙ\ÈH\İ[˜][ÛˆÛ›HY\ˆİXØÙ\ÜËˆH˜Z[YÜˆ[\H™[™\ˆ™\Ù\™\È[H^\İ[™Èš[K‚‚ˆÈÈ]ÛˆTB‚˜]Û‚™œ›ÛH\Ø˜YÙ[ˆ[\ÜÛY\™\]Y\İ™[™\—ÜÛY\Üš]WØ]Y[Â™œ›ÛH\Ø˜YÙ[‹œÛY\[\ÜZ[ÜÛY\Ü™XÚ\KÜš]WÜ™XÚ\WÛX[šY™\İ‚œ™\]Y\İHÛY\™\]Y\İ
+ˆ›Ø›[OHœ˜XÚ[™×ÛZ[™‹ˆÛİ[™İÛÜ›HœÛİ×ÛšYÚÛ]\ÚXÈ‹ˆ[[œÚ]OH˜˜[[˜ÙY‹ˆ\˜][Û—ÛZ[]\ÏMKŠBœ™XÚ\HHZ[ÜÛY\Ü™XÚ\J™\]Y\İ
+Bœ™\İ[HÜš]WØ]Y[Ê™[™\—ÜÛY\
+™\]Y\İ
+KœÛY\Z›İ\›™^KØ]ˆŠBÜš]WÜ™XÚ\WÛX[šY™\İ
+™XÚ\K™\İ[›İ]š[JB˜‚ˆÈÈÜ™[˜\H\ÙH[™™\ÙX\˜Ú\ÙH\™HÙ\\˜]B‚•HÛY\İZYHÙ\È›İÙXÜ™]H\ÜÚYÛˆÚ[HÜˆ›[™YÛÛ™][ÛœËˆH]\™HÙ\\˜][H][˜ÚY
+Š”™\ÙX\˜ÚÜÙH[š\›Û›Y[
+Šˆ\È™\Ù\™Y›Üˆ[™›Ü›YYÛÛœÙ[[YÚXš[]K›İØÛÛ\ÜÚYÛ›Y[^Xİ™XÚ\\Ë™KÜÜİYX\İ\™\ËY™\œÙKYY™™Xİ™\Ü[™Ë[™^Ü‚‚ˆÈÈ]X[YšXØ][Û‚‚˜˜\Úœ]\İœ]Ûˆ[HÛÛ\[X[\H\Ø˜YÙ[ˆİZKœHİZWÜØY™KœHÛY\ÙİZKœHš\İX[^˜][Û‹œH™×ÙXÛÙ\‹œBœ]Ûˆ[H\ÚY[ˆK[›ËY\Â˜‚‘Ú]XˆXİ[ÛœÈ]X[YšY\È]ÛˆËŒL8 $ÌËŒLË‚‚ˆÈÈØY™]B‚•\ÙHHÛÛY›ÜX›H›Û[YH[™İÜÛˆ\ØÛÛY›ÜXYXÚK^š[™\ÜËYÚ]][Û‹ÜˆÛÜœÙ[™YŞ[\Û\ËˆÈ›İ\ÙHÛY\]Y[ÈÚ[Hš]š[™ÈÜˆÚ[™È[\™\ÜËXÜš]XØ[ÛÜšË‚‚”TØ˜YÙ[ˆÙ\È›İ›ÛZ\ÙHXYÛ›ÜÚ\Ë™X]Y[Ü[Z[™H[]™\KİX\˜[YYÛY\Z[ˆÜˆZYÜ˜Z[™H™[YY‹ÛØœšY]KÜˆ™Z]š[Ü˜[İ]ÛÛY\ËˆÙ]™\™HÜˆ[\İX[Ş[\Û\Ë[™Ù\›İ\ÈÚ]˜]Ø[İ™\™ÜÙKÙ[‹Z\›Hš\ÚË[™\™Ù[Üš\Ù\È™\]Z\™H™X[]ÛÜ››Ù™\ÜÚ[Û˜[[Y\™Ù[˜ŞKÜˆÜš\Ú\Èİ\Ü‚‚ˆÈÈXÙ[œÙB‚•H]ÛˆXÚØYÙHY]Y]HXÛ\™\ÈÔL‹Œ[Û›XÛÛœÚ\İ[Ú]H™\Ù\™YĞ˜QÙ[ˆ[™XYÙKˆ™\šYHYYXH[™\[™[˜ŞHXÙ[œÙ\È™Y›Ü™H\İšX][Û‹‚

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,65 @@
+# pysbagen Architecture
+
+## Product boundary
+
+The maintained Python product has one direction of dependency:
+
+```text
+CLI / GUI
+   ↓
+pysbagen.api
+   ↓
+parser + mixer
+   ↓
+generator specifications
+   ↓
+NumPy / SciPy / SoundFile / pydub
+```
+
+The CLI and GUI are adapters. They gather user input and call the public API; neither owns a separate rendering engine.
+
+## Canonical code
+
+- `pysbagen/api.py` — public render/write operations and quick-spec construction.
+- `pysbagen/parser.py` — SBG text and file parsing, including schedule-relative media paths.
+- `pysbagen/mixer.py` — exact-duration stereo timeline, limiting, silence, and scheduled activation.
+- `pysbagen/generators/` — built-in audio-source specifications.
+- `gui.py` — Tk desktop adapter.
+- `pysbagen/cli.py` — command-line adapter.
+
+`pysbagen/src/pysbagen/` is an earlier duplicate retained for provenance. Package discovery explicitly excludes it so installed behavior cannot depend on which copy Python happens to find.
+
+## Audio contract
+
+Built-in and third-party generators expose:
+
+```python
+generator(duration) -> iterator[(chunk, info)]
+```
+
+The mixer expects 44.1 kHz. Chunks may be mono, stereo, or multichannel and may have different lengths; the mixer normalizes them to stereo, buffers uneven chunks, and emits exactly the requested frame count. A generator that ends early becomes silence rather than ending the entire session.
+
+The writer receives stereo float chunks and streams them to disk. This keeps long renders bounded in memory.
+
+## Schedule contract
+
+The parser returns:
+
+```python
+(tone_sets, schedule)
+```
+
+- `tone_sets` maps labels to generator objects.
+- `schedule` is an ordered list of `(timestamp_seconds, tokens)` events.
+
+The scheduler renders the state active before each event, applies the event at its timestamp, and continues until the chosen endpoint. Empty active state produces silence. An unprefixed event is absolute; `+` and `-` events are relative.
+
+The final timestamp is the endpoint when the caller does not provide an explicit duration. Schedules should therefore end with `off` when they need a final audible section.
+
+## Optional capabilities
+
+Core export requires NumPy, SciPy, SoundFile, and pydub. GUI rendering, artwork, and visualization use the `gui` extra. PyAudio is only required for live preview; missing playback support must never block file generation.
+
+## Compatibility work
+
+Compatibility additions must be driven by real schedules or legal user-supplied fixtures. Add a failing fixture/test first, implement the missing operator or decoder behavior, then update the supported-syntax documentation. Avoid speculative parser branches that silently reinterpret unknown syntax.

--- a/docs/SLEEP_GUIDE.md
+++ b/docs/SLEEP_GUIDE.md
@@ -1,135 +1,90 @@
 # PySbagen Sleep Guide
 
-## Purpose
+## What it is
 
-The Sleep Guide is the ordinary-person front door to PySbagen. A tired listener explains what is happening in human terms, chooses a tolerable sound environment, chooses how present the underlying layers should feel, and starts a complete audio journey.
+The Sleep Guide is PySbagen’s ordinary-person front door. A tired listener answers four human questions and receives a complete time-changing journey. The advanced studio and future Research Dose Environment remain separate.
 
-It is deliberately separate from the advanced tone laboratory and from the future Research Dose Environment.
-
-## The conversation
-
-The guide asks four short questions:
+## The four questions
 
 1. **What is keeping you awake?**
    - My mind will not stop.
    - I feel relaxed, but cannot cross into sleep.
    - I fall asleep, then keep waking back up.
-2. **What would feel pleasant tonight?**
-   - warm evolving ambient chords;
+2. **What feels pleasant or tolerable tonight?**
+   - warm evolving ambience;
    - slow night music;
    - a soft rain-like room;
    - a deep low-stimulation night environment;
    - the listener’s own audio.
-3. **How present should the hidden layers feel?**
+3. **How present should the underlying layers feel?**
    - gentle;
    - balanced;
    - immersive.
-4. **How long should it remain?**
-   - 30, 45, 60, or 90 minutes in the standard guide;
-   - the programmatic API accepts 10–180 minutes.
+4. **How long should the journey remain?**
+   - 30, 45, 60, or 90 minutes in the guide;
+   - 10–180 minutes through the API.
 
-The listener does not need to choose frequencies or understand entrainment terminology.
+The listener does not choose frequencies unless they deliberately enter advanced work.
 
-## Matched routes
+## Three matched routes
 
 ### Racing Mind Descent
 
-For a listener whose thoughts keep demanding attention.
-
-- The descent occupies approximately 68% of the session.
-- It begins with more musical or textural movement.
-- Novelty, beat rate, and active-layer strength recede progressively.
-- The remaining support period becomes increasingly uneventful before fading.
+Starts with enough musical or textural movement to occupy a busy mind, then progressively reduces novelty, beat rate, and active-layer strength.
 
 ### Crossing the Threshold
 
-For a listener who feels relaxed but does not cross into sleep.
-
-- The descent occupies approximately 52% of the session.
-- It begins more quietly than Racing Mind Descent.
-- It leaves a longer stable support period.
+Begins more quietly for someone already relaxed and leaves a longer stable support tail.
 
 ### Stay-Asleep Support
 
-For a listener who falls asleep and wakes repeatedly.
+Uses a shorter descent, longer low-novelty support bed, and a less-active recommended blend.
 
-- The descent occupies approximately 30% of the session.
-- The support bed is materially longer.
-- The recommended blend avoids the most active optional layers.
+These are the only ordinary routes currently implemented. Pain, migraine, craving, and substance-use pathways are future work, not hidden interpretations of these three choices.
 
-These are support recipes, not medical guarantees.
+## Two phases
 
-## Two sleep systems
+Every journey contains:
 
-Every current recipe contains:
+1. **Sleep Descent** for the awake listener;
+2. **Sleep Support**, a quieter period after sleep is more likely.
 
-1. **Sleep Descent** — audio for a person who is still awake;
-2. **Sleep Support** — a quieter, lower-novelty period after sleep is more likely.
+The present transition is time-planned. PySbagen does not claim to detect sleep stage. Sensor-driven support begins only when real supported hardware and an end-to-end validation path exist.
 
-The current transition is planned by time. PySbagen does not claim to detect sleep stage.
+## Pleasant audio
 
-Future closed-loop support may use real hardware such as supported EEG, movement, heart-rate, or breathing sensors. No device adapters, placeholder endpoints, or fake sensor services are included now. Hardware work begins only when a real device and an end-to-end validation path exist.
+PySbagen can generate:
 
-## Pleasant sound generation
+- slowly moving warm chords;
+- long-crossfade night music with sparse fading melody;
+- stateful filtered rain-like texture;
+- dark low-stimulation drones and subdued noise.
 
-### Warm ambient chords
-
-A deterministic stereo pad built from slowly phase-moving harmonic voices. A subtle upper component diminishes as the journey progresses.
-
-### Slow night music
-
-A procedural four-chord cycle with long crossfades and a sparse, smoothly enveloped melody. Both chord motion and melody lose prominence during descent and support.
-
-### Rain-like room
-
-A stateful filtered-noise room plus a quieter high-frequency droplet texture. Filter state persists across chunks so the sound does not restart every buffer.
-
-### Deep night
-
-Low stereo drones, a fading upper voice, and a very subdued filtered-noise floor.
-
-### User-provided audio
-
-The chosen audio is looped when shorter than the journey, faded with the session, and combined with a small generated underlay. Common formats use SoundFile. Other formats fall back to the system’s FFmpeg decoder.
+A listener may instead supply their own audio. Common formats use SoundFile; other locally decodable formats use streaming FFmpeg fallback. Audio is looped in bounded chunks rather than loaded or tiled into a session-sized array.
 
 ## Underlying layers
 
-The recipe can combine:
+Recommended blends may combine:
 
-- evolving binaural relationships;
+- binaural relationships;
 - within-channel monaural beating;
-- smooth isochronic amplitude modulation;
-- a Harmonic Box X-style multi-phase, multi-carrier layer.
+- smooth isochronic modulation;
+- Harmonic Box X-style multi-phase layering.
 
-The normal guide offers a recommended blend based on the reported problem and desired intensity. Optional controls allow the listener to change the layer selection.
+Layers change over time, maintain phase between chunks, and recede strongly during support while the pleasant bed fades more slowly.
 
-All active layers use continuously accumulated phase rather than restarting at chunk boundaries. Their strength recedes sharply after the descent period, while the pleasant bed continues longer and fades gradually.
+## Playback and export
 
-## Immediate playback and export
+- `sbgpy-sleep-gui` opens the desktop guide.
+- `sbgpy-sleep` runs the terminal guide.
+- `sbgpy-sleep --play` starts immediate playback after the questions.
 
-The desktop guide can stream the journey directly to PyAudio so the listener can put on headphones and begin without pre-rendering a long file.
+Install export-only GUI support with `pysbagen[gui]`, playback with `pysbagen[playback]`, or both with `pysbagen[desktop]`.
 
-It can also save the audio. Saved journeys receive a companion `.sleep.json` manifest containing:
-
-- the problem and sound selection;
-- intensity and duration;
-- resolved layer blend;
-- descent/support timing;
-- carrier and beat movement;
-- fade timing;
-- deterministic generation seed;
-- user-audio path and SHA-256 when applicable.
-
-This preserves reproducibility without placing research controls in ordinary use.
-
-## Research boundary
-
-Ordinary Sleep Guide sessions are not research doses.
-
-Blinding, sham conditions, protocol assignment, consent, eligibility rules, pre/post measures, adverse-effect reporting, and study data export belong in a separately launched Research Dose Environment. See `docs/research/SLEEP_AUDIO_RESEARCH_FOUNDATIONS.md`.
+Saved sessions receive a `.sleep.json` sidecar with the route, exact timings, layers, carriers/beat movement, deterministic seed, and source-audio SHA-256 when used.
 
 ## Safety boundary
 
-The guide tells the listener to use a comfortable volume and stop if the audio causes pain, dizziness, agitation, worsened symptoms, or other unwanted effects.
+Use a comfortable volume and stop on pain, dizziness, agitation, worsened symptoms, or another unwanted effect. Do not use sleep audio while driving or doing anything requiring alertness.
 
-It must not claim to diagnose or treat insomnia, migraine, chronic pain, substance use disorder, or another condition. It must not promise direct dopamine delivery or guaranteed sleep.
+This is sleep-preparation audio, not medical, addiction, withdrawal, or emergency treatment. Severe, unusual, worsening, or persistent symptoms need ordinary professional care. Dangerous withdrawal, overdose, self-harm risk, or an urgent crisis needs real-world emergency or crisis support, not PySbagen.

--- a/docs/SLEEP_GUIDE.md
+++ b/docs/SLEEP_GUIDE.md
@@ -1,0 +1,135 @@
+# PySbagen Sleep Guide
+
+## Purpose
+
+The Sleep Guide is the ordinary-person front door to PySbagen. A tired listener explains what is happening in human terms, chooses a tolerable sound environment, chooses how present the underlying layers should feel, and starts a complete audio journey.
+
+It is deliberately separate from the advanced tone laboratory and from the future Research Dose Environment.
+
+## The conversation
+
+The guide asks four short questions:
+
+1. **What is keeping you awake?**
+   - My mind will not stop.
+   - I feel relaxed, but cannot cross into sleep.
+   - I fall asleep, then keep waking back up.
+2. **What would feel pleasant tonight?**
+   - warm evolving ambient chords;
+   - slow night music;
+   - a soft rain-like room;
+   - a deep low-stimulation night environment;
+   - the listener’s own audio.
+3. **How present should the hidden layers feel?**
+   - gentle;
+   - balanced;
+   - immersive.
+4. **How long should it remain?**
+   - 30, 45, 60, or 90 minutes in the standard guide;
+   - the programmatic API accepts 10–180 minutes.
+
+The listener does not need to choose frequencies or understand entrainment terminology.
+
+## Matched routes
+
+### Racing Mind Descent
+
+For a listener whose thoughts keep demanding attention.
+
+- The descent occupies approximately 68% of the session.
+- It begins with more musical or textural movement.
+- Novelty, beat rate, and active-layer strength recede progressively.
+- The remaining support period becomes increasingly uneventful before fading.
+
+### Crossing the Threshold
+
+For a listener who feels relaxed but does not cross into sleep.
+
+- The descent occupies approximately 52% of the session.
+- It begins more quietly than Racing Mind Descent.
+- It leaves a longer stable support period.
+
+### Stay-Asleep Support
+
+For a listener who falls asleep and wakes repeatedly.
+
+- The descent occupies approximately 30% of the session.
+- The support bed is materially longer.
+- The recommended blend avoids the most active optional layers.
+
+These are support recipes, not medical guarantees.
+
+## Two sleep systems
+
+Every current recipe contains:
+
+1. **Sleep Descent** — audio for a person who is still awake;
+2. **Sleep Support** — a quieter, lower-novelty period after sleep is more likely.
+
+The current transition is planned by time. PySbagen does not claim to detect sleep stage.
+
+Future closed-loop support may use real hardware such as supported EEG, movement, heart-rate, or breathing sensors. No device adapters, placeholder endpoints, or fake sensor services are included now. Hardware work begins only when a real device and an end-to-end validation path exist.
+
+## Pleasant sound generation
+
+### Warm ambient chords
+
+A deterministic stereo pad built from slowly phase-moving harmonic voices. A subtle upper component diminishes as the journey progresses.
+
+### Slow night music
+
+A procedural four-chord cycle with long crossfades and a sparse, smoothly enveloped melody. Both chord motion and melody lose prominence during descent and support.
+
+### Rain-like room
+
+A stateful filtered-noise room plus a quieter high-frequency droplet texture. Filter state persists across chunks so the sound does not restart every buffer.
+
+### Deep night
+
+Low stereo drones, a fading upper voice, and a very subdued filtered-noise floor.
+
+### User-provided audio
+
+The chosen audio is looped when shorter than the journey, faded with the session, and combined with a small generated underlay. Common formats use SoundFile. Other formats fall back to the system’s FFmpeg decoder.
+
+## Underlying layers
+
+The recipe can combine:
+
+- evolving binaural relationships;
+- within-channel monaural beating;
+- smooth isochronic amplitude modulation;
+- a Harmonic Box X-style multi-phase, multi-carrier layer.
+
+The normal guide offers a recommended blend based on the reported problem and desired intensity. Optional controls allow the listener to change the layer selection.
+
+All active layers use continuously accumulated phase rather than restarting at chunk boundaries. Their strength recedes sharply after the descent period, while the pleasant bed continues longer and fades gradually.
+
+## Immediate playback and export
+
+The desktop guide can stream the journey directly to PyAudio so the listener can put on headphones and begin without pre-rendering a long file.
+
+It can also save the audio. Saved journeys receive a companion `.sleep.json` manifest containing:
+
+- the problem and sound selection;
+- intensity and duration;
+- resolved layer blend;
+- descent/support timing;
+- carrier and beat movement;
+- fade timing;
+- deterministic generation seed;
+- user-audio path and SHA-256 when applicable.
+
+This preserves reproducibility without placing research controls in ordinary use.
+
+## Research boundary
+
+Ordinary Sleep Guide sessions are not research doses.
+
+Blinding, sham conditions, protocol assignment, consent, eligibility rules, pre/post measures, adverse-effect reporting, and study data export belong in a separately launched Research Dose Environment. See `docs/research/SLEEP_AUDIO_RESEARCH_FOUNDATIONS.md`.
+
+## Safety boundary
+
+The guide tells the listener to use a comfortable volume and stop if the audio causes pain, dizziness, agitation, worsened symptoms, or other unwanted effects.
+
+It must not claim to diagnose or treat insomnia, migraine, chronic pain, substance use disorder, or another condition. It must not promise direct dopamine delivery or guaranteed sleep.

--- a/docs/planning/CREATIVITY_PRODUCT_GAP_CHECK.md
+++ b/docs/planning/CREATIVITY_PRODUCT_GAP_CHECK.md
@@ -1,0 +1,179 @@
+# PySbagen Creativity Product Gap Check
+
+**Date:** July 30, 2026  
+**Status:** Recorded before implementation  
+**Related research:** `docs/research/CREATIVITY_AUDIO_RESEARCH_FOUNDATIONS.md`
+
+## Question checked
+
+What is missing between existing audio/creativity products and the product PySbagen could build?
+
+The scout pass looked for systems that combine more than a soundtrack or a frequency preset. The target combination was:
+
+- human problem intake;
+- phase-aware divergent and convergent work;
+- incubation and mind-wandering;
+- lateral cueing;
+- idea capture;
+- active musical interaction;
+- exact audio recipes;
+- controlled creativity evaluation.
+
+## Existing pieces found
+
+The wider field already contains separate pieces:
+
+- background-music and ambient-noise products;
+- binaural and entrainment creativity presets;
+- focus and productivity soundscapes;
+- generative ambient-music systems;
+- brainstorming and semantic-association tools;
+- voice-note and idea-capture tools;
+- music improvisation and biofeedback experiments;
+- patents for context-sensitive soundscapes using user state, context, tempo, noise, volume, and binaural components;
+- sleep-onset and targeted-dream-incubation research.
+
+A representative patent lineage describes systems that select or adapt soundscapes using context and feedback:
+
+- https://patents.google.com/patent/US20180344968A1/en
+
+A patent demonstrates a design trail, not successful creativity outcomes.
+
+## The conspicuous gap
+
+The scout did not identify an obvious complete product that treats creativity as a **changing cycle** and connects all of the following in one reproducible flow:
+
+1. ask what the person is creating;
+2. identify whether they are blank, stuck, overflowing, improvising, or deciding;
+3. choose a phase-appropriate audio environment;
+4. support active divergent generation;
+5. deliberately enter a low-demand incubation interval;
+6. offer sparse, task-aware lateral bridges;
+7. create idea-capture windows without breaking the state;
+8. switch into a quieter convergence and refinement environment;
+9. preserve the exact recipe and user response;
+10. evaluate whether the audio helped beyond merely feeling pleasant.
+
+This is the product opening.
+
+## Why common alternatives do not fill it
+
+### “Creativity frequency” products
+
+These generally reduce creativity to a beat rate or brain-wave label. Research does not support one universal creativity frequency, and divergent versus convergent tasks can respond differently.
+
+### Background-music products
+
+These may influence mood, arousal, or distraction, but normally do not know the task, creative phase, or whether words are central. They do not transition intentionally from idea generation into incubation, capture, and selection.
+
+### Brainstorming tools
+
+These can generate prompts or associations but usually do not shape the listener’s audio state, create incubation intervals, or preserve exact sound recipes.
+
+### Generative-music tools
+
+These produce music but do not generally ask what cognitive job the person is performing, measure creative outcomes, or separate ordinary use from blinded research conditions.
+
+### Note and voice-capture tools
+
+These preserve ideas after they appear. They do not help construct the conditions under which ideas emerge.
+
+### Sleep and dream-incubation systems
+
+These explore hypnagogia or dream content but do not cover the full waking creative cycle. Sensor-confirmed N1 work also remains a future research path rather than an ordinary unsensed promise.
+
+## Proposed product position
+
+PySbagen should become a **Creative Cycle engine**, not a Creativity Frequency generator.
+
+The first complete ordinary-user paths should be:
+
+- **Blank Page** — open possibilities and create capture windows;
+- **Stuck Problem** — frame, disengage, incubate, bridge, and return;
+- **Idea Flood** — reduce divergence and organize existing possibilities;
+- **Choose and Refine** — protect convergence with low-novelty audio or silence;
+- **Improvisation** — let user action shape the sound in call-and-response.
+
+## Minimum complete experience
+
+A real first creativity train should include:
+
+### Human front door
+
+Ask:
+
+- What are you trying to create?
+- Are you blank, stuck, overflowing, improvising, or deciding?
+- Do words help or interfere?
+- Do you want passive listening or active interaction?
+- How long is available?
+
+### Phase engine
+
+Support:
+
+- Frame;
+- Open;
+- Drift;
+- Bridge;
+- Capture;
+- Converge.
+
+The audio must materially change between these phases.
+
+### Pleasant audio
+
+Support both:
+
+- generated sound worlds;
+- user-provided audio in broadly decodable formats.
+
+### Capture
+
+Allow voice or text capture at deliberate windows without ending the journey. Store ideas beside the session recipe and phase timestamp.
+
+### Reproducibility
+
+Record emotional tone, tempo, complexity, novelty, distraction strength, semantic content, layer choices, cue timing, incubation duration, capture points, and transition timing.
+
+### Boundaries
+
+Do not add:
+
+- fake creativity guarantees;
+- universal frequency claims;
+- premature EEG or sensor adapters;
+- hidden research assignment in the ordinary UI;
+- random cue spam;
+- one soundtrack reused across every creative phase.
+
+## Separate research gap
+
+The Research Dose Environment should be able to compare:
+
+- soundscape alone versus hidden audio layers;
+- active control versus passive listening;
+- task-aware lateral cues versus arbitrary cues;
+- phase-aware journeys versus one continuous soundtrack;
+- divergence audio used appropriately versus used during convergence;
+- calibrated ambient distraction levels;
+- instrumental, lyrical, and silent conditions;
+- repeated within-person outcomes.
+
+The research product must measure actual creative output, not only self-reported inspiration.
+
+## Implementation order
+
+1. Build the phase model and ordinary conversation.
+2. Build Blank Page, Stuck Problem, Idea Flood, and Choose and Refine as complete journeys.
+3. Add idea capture and exact recipe manifests.
+4. Add more generated sound worlds and user-audio transformation.
+5. Add active Improvisation controls.
+6. Build the separate Research Dose Environment.
+7. Add sensor-confirmed hypnagogic work only when real supported hardware exists.
+
+## Final gap statement
+
+The opportunity is not better background music. It is a system that knows **which creative job is happening now**, changes the audio when that job changes, creates room for incubation and lateral connection, captures the result, and can later test which parts actually contributed.
+
+That combination remains the clearest product gap uncovered by this scout pass.

--- a/docs/research/CREATIVITY_AUDIO_RESEARCH_FOUNDATIONS.md
+++ b/docs/research/CREATIVITY_AUDIO_RESEARCH_FOUNDATIONS.md
@@ -1,0 +1,327 @@
+# PySbagen Creativity Audio Research Foundations
+
+**Status:** Research and product direction recorded before implementation  
+**Date:** July 30, 2026  
+**Scope:** Audio-supported creativity, divergent thinking, incubation, insight, capture, and convergence
+
+## Core finding
+
+Creativity is not one mental state and should not be represented by one frequency or one universal soundtrack.
+
+The useful product model is a cycle:
+
+1. frame the problem;
+2. open idea generation;
+3. stop forcing and incubate;
+4. introduce sparse lateral bridges;
+5. capture emerging ideas;
+6. converge, judge, and refine.
+
+Audio that helps divergent idea generation can impair judgment, language work, or convergence. PySbagen should therefore change its audio behavior across phases rather than play one unchanging “creativity” dose.
+
+## Reconnaissance method
+
+The research pass used the InvisiSynth / scout model to search laterally across:
+
+- direct creativity and cognition studies;
+- music, mood, arousal, and attention research;
+- ambient-noise and controlled-distraction work;
+- incubation and mind-wandering;
+- hypnagogia and sleep-onset insight;
+- binaural and entrainment studies;
+- improvisation and active musical control;
+- semantic-distance and remote-association work;
+- patents, commercial lineages, and maker implementations.
+
+The findings below distinguish observed results from product hypotheses. No source establishes a universal audio recipe that makes everyone more creative.
+
+---
+
+## Finding 1: positive, energizing instrumental music can support divergent thinking
+
+A controlled study comparing several musical conditions with silence found that positive, high-arousal music improved divergent thinking but did not improve convergent thinking.
+
+### Product implication
+
+An opening phase may use pleasant, energizing, instrumental music to help the mind spread outward. That same audio should not automatically continue into evaluation or final editing.
+
+**Source:**  
+https://pubmed.ncbi.nlm.nih.gov/28877176/
+
+---
+
+## Finding 2: controlled distraction follows an inverted-U
+
+Experiments on ambient noise found that moderate noise improved creative performance compared with quieter conditions, while louder noise impaired it.
+
+The laboratory sound-pressure values should not be copied directly into PySbagen because actual loudness depends on hardware, environment, hearing sensitivity, and calibration.
+
+### Product implication
+
+Expose a human control such as:
+
+- clear and quiet;
+- gently busy;
+- coffee-shop active.
+
+The target is enough processing friction to loosen narrow thinking without overwhelming attention.
+
+**Source:**  
+https://academic.oup.com/jcr/article-abstract/39/4/784/1798283
+
+---
+
+## Finding 3: incubation needs a low-demand interval
+
+Research found improved later creative performance when people first encountered a problem and then completed an undemanding task that allowed mind-wandering. A demanding task, pure rest, or no break did not produce the same result.
+
+### Product implication
+
+PySbagen should support a real incubation phase:
+
+1. record or frame the problem;
+2. perform an active generation interval;
+3. intentionally back away;
+4. use pleasant but non-fascinating audio during walking, doodling, tidying, or resting;
+5. return with a gentle capture cue.
+
+The incubation soundscape should not constantly demand attention with musical surprises.
+
+**Source:**  
+https://pubmed.ncbi.nlm.nih.gov/22941876/
+
+---
+
+## Finding 4: the N1 sleep boundary is promising but belongs in careful research
+
+A controlled study found that a brief period in N1 sleep substantially increased hidden-rule discovery compared with remaining awake, while the benefit disappeared after deeper sleep. Later work found that theme-related auditory prompts during sleep onset could influence post-sleep creativity and semantic distance.
+
+Open-loop sound during early sleep can also alter sleep architecture and does not automatically improve insight.
+
+### Product implication
+
+A future creativity path may use:
+
+> prime the problem -> descend toward N1 -> wake gently -> capture
+
+Without real sensing, ordinary PySbagen may offer a clearly labeled hypnagogic rest timer but must not claim it detected N1. Sensor-confirmed timing belongs later and in the Research Dose Environment.
+
+**Sources:**
+
+- https://pubmed.ncbi.nlm.nih.gov/34878849/
+- https://pubmed.ncbi.nlm.nih.gov/37188795/
+- https://pubmed.ncbi.nlm.nih.gov/38107593/
+
+---
+
+## Finding 5: binaural effects are individual and inconsistent
+
+A direct creativity study found that alpha and gamma binaural beats affected divergent but not convergent thinking, but outcomes depended on participant characteristics. Some people benefited, while others did not or performed worse.
+
+A wider systematic review found mixed and contradictory entrainment evidence.
+
+### Product implication
+
+Do not create a universal “creativity frequency.” Binaural, monaural, isochronic, and Harmonic Box X-style layers should remain optional and reproducible. Their contribution should be learned within the individual or compared against matched controls in research mode.
+
+**Sources:**
+
+- https://pubmed.ncbi.nlm.nih.gov/24294202/
+- https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0286023
+
+---
+
+## Finding 6: active control may matter more than passive listening
+
+A music-feedback exercise study found greater divergent-thinking improvement when participants’ actions actively controlled the music than in passive-listening comparison conditions.
+
+Improvisation research also suggests that creative production can involve reduced conscious self-monitoring alongside stronger internally generated activity.
+
+### Product implication
+
+PySbagen should eventually support an active creativity mode where the listener can:
+
+- tap rhythm;
+- hum or vocalize;
+- move a mouse, controller, or body;
+- alter a few simple musical dimensions;
+- receive call-and-response audio;
+- capture fragments without stopping the flow.
+
+This implies an explicit **Editor Off** phase followed later by **Editor On**.
+
+**Sources:**
+
+- https://pubmed.ncbi.nlm.nih.gov/33329231/
+- https://pubmed.ncbi.nlm.nih.gov/18301756/
+
+---
+
+## Finding 7: useful lateral cues require semantic distance, not randomness
+
+Divergent thinking partly behaves like exploratory search through semantic memory. Creativity measures also correlate with the ability to generate semantically distant but meaningful associations.
+
+### Product implication
+
+A future Lateral Cue Layer should not emit arbitrary words and noises. It should:
+
+- accept the user’s problem;
+- identify its central concepts;
+- select remote but structurally relevant analogies;
+- control semantic distance;
+- present cues sparsely;
+- let the user mark which cues produced a useful connection.
+
+Examples for a scheduling problem might include tides, railway switching, migrating birds, orchestral handoffs, crop rotation, or breathing cycles.
+
+**Sources:**
+
+- https://pubmed.ncbi.nlm.nih.gov/28601001/
+- https://pubmed.ncbi.nlm.nih.gov/34140408/
+
+---
+
+## Finding 8: lyrics and foreground music can harm language-heavy work
+
+Background-music findings are inconsistent overall, but reviews report costs to memory and language-related tasks, especially when lyrics compete with verbal processing. Instrumental music can also impair some remote-association tasks.
+
+### Product implication
+
+The ordinary flow should ask whether words are central to the task.
+
+Writing, reading, naming, and coding may need:
+
+- no lyrics;
+- fewer foreground melodic events;
+- fewer semantic prompts during active composition;
+- quieter or silent convergence periods.
+
+Visual art, physical making, movement, and improvisation may tolerate richer sound.
+
+**Sources:**
+
+- https://journals.sagepub.com/doi/abs/10.1177/20592043221134392
+- https://eric.ed.gov/?id=EJ1262032
+
+---
+
+## Proposed ordinary-user model: the Creative Cycle
+
+| Phase | Human purpose | Audio behavior |
+|---|---|---|
+| **Frame** | Load the problem into mind | Quiet bed; optional spoken or written problem capture |
+| **Open** | Generate possibilities | Positive instrumental movement, controlled novelty, optional moderate ambience |
+| **Drift** | Stop forcing | Low-demand ambience, reduced musical events, no questions |
+| **Bridge** | Find remote connections | Sparse task-aware sonic metaphors or distant verbal cues |
+| **Capture** | Preserve emerging ideas | Sound thins; gentle cue; voice, text, or sketch capture |
+| **Converge** | Judge, combine, and finish | Quiet, predictable, low-semantic sound or silence |
+
+The cycle may loop through Open, Drift, Bridge, and Capture before entering Converge.
+
+## Proposed first journeys
+
+### Blank Page
+
+For someone who needs ideas but cannot begin. Use more uplifting movement initially, controlled ambient friction, and several short capture windows.
+
+### Stuck Problem
+
+For someone trapped in one approach. Record the problem, disengage deliberately, incubate, then introduce sparse remote analogies.
+
+### Idea Flood
+
+For someone with too many possibilities. Avoid additional divergence pressure. Space, group, and compare existing ideas in a calmer environment.
+
+### Choose and Refine
+
+For someone who already has ideas and needs judgment. Use minimal novelty, no lyrics, no lateral cues, and possibly silence.
+
+### Improvisation
+
+For someone who wants to create by reacting. Use active call-and-response shaped by tapping, humming, movement, MIDI, or simple controls.
+
+## Ordinary conversation
+
+The normal user should not choose alpha, decibels, or semantic-distance values. PySbagen should ask:
+
+1. What are you trying to create?
+2. What is happening now: blank, stuck, overflowing, or deciding?
+3. Do words help or interrupt you?
+4. Do you want to listen or interact?
+5. How long can you give this?
+
+## Reproducible recipe dimensions
+
+Creativity recipes should record:
+
+- emotional tone;
+- energy and tempo;
+- musical complexity;
+- predictability and novelty;
+- semantic content;
+- calibrated distraction strength;
+- spatial movement;
+- binaural, monaural, isochronic, or Harmonic Box X layers;
+- active-control mappings;
+- incubation duration;
+- lateral-cue timing and distance;
+- capture windows;
+- divergence-to-convergence transition.
+
+## Research Dose Environment comparisons
+
+Candidate comparisons include:
+
+- positive instrumental versus matched neutral instrumental;
+- lower, moderate, and stronger calibrated ambience;
+- active control versus passive listening;
+- task-aware remote cues versus arbitrary cues;
+- lyrics versus instrumental versus silence;
+- binaural or other hidden layers versus matched sham;
+- one uninterrupted soundtrack versus phase-changing audio;
+- divergence audio used during divergence versus the same audio used during convergence;
+- timed hypnagogic rest versus future sensor-confirmed N1.
+
+Outcomes should include:
+
+- idea count;
+- flexibility across categories;
+- semantic distance;
+- independent usefulness and originality ratings;
+- number of ideas retained;
+- time to first useful idea;
+- quality of the completed artifact;
+- repeated within-person performance.
+
+## Evidence position
+
+### Higher confidence
+
+- Divergent and convergent phases need different conditions.
+- Positive energizing instrumental music can help some divergent tasks.
+- Moderate controlled distraction can help while excessive distraction harms.
+- Incubation after problem exposure can improve later creativity.
+- N1 is a meaningful state worth researching carefully.
+
+### Promising but narrower
+
+- Active musical agency may outperform passive listening.
+- Semantic distance is useful for lateral prompts.
+- Reducing self-monitoring can support improvisation.
+
+### Research-only
+
+- Personalized binaural or other entrainment layers.
+- Auditory dream incubation and sleep cueing.
+- Predictive-violation schedules designed to provoke insight.
+
+### Unsupported
+
+- One universal creativity frequency.
+- One soundtrack that improves every creative task.
+- More novelty always producing more creativity.
+- Passive audio reliably making everyone more creative.
+
+## Boundary
+
+No creativity build should collapse this research into a single preset. The product should implement a phase-aware Creative Cycle, preserve exact recipes, and keep ordinary use separate from controlled research.

--- a/docs/research/SLEEP_AUDIO_RESEARCH_FOUNDATIONS.md
+++ b/docs/research/SLEEP_AUDIO_RESEARCH_FOUNDATIONS.md
@@ -1,0 +1,372 @@
+# PySbagen Sleep Audio Research Foundations
+
+**Status:** Product direction recorded before the next build beadtrain  
+**Date:** July 29, 2026  
+**Scope:** Sleep support, audio-layer research, and future voluntary participant research
+
+## Why this document exists
+
+PySbagen must not collapse back into a frequency picker or a utility that only produces exposed sine tones, static, and noise. Its deeper purpose is to accept a human problem, construct a pleasant and technically reproducible audio experience for that problem, and learn what parts of the experience are actually useful.
+
+The first complete use-case family is **sleep difficulty**:
+
+- a racing mind that will not disengage;
+- a person who becomes relaxed but does not cross into sleep;
+- a person who falls asleep and repeatedly wakes;
+- combinations of the above, including sleep difficulty complicated by pain, migraine, agitation, or cravings.
+
+The ordinary user should be able to answer a human question about what is happening and receive an audio experience designed for that situation. They should not need to understand carrier frequencies, beat matrices, modulation depth, or schedule syntax.
+
+The technical and research layers remain available underneath that experience.
+
+---
+
+## Product decisions already made
+
+### 1. Two sleep systems
+
+PySbagen will treat sleep onset and sleep-state support as different problems.
+
+#### Sleep Descent
+
+For a person who is still awake. It should:
+
+- meet the listener where they are;
+- reduce mental and sensory engagement without becoming irritating;
+- use pleasant generated or supplied audio as a real part of the intervention;
+- change its underlying audio structures over time rather than presenting one static beat indefinitely;
+- fade gradually after the intended descent period.
+
+#### Sleep Support
+
+For use after sleep is likely or has been detected. It may eventually use closed-loop timing to support sleep-stage rhythms without waking the listener.
+
+**Sensors are a documented future path, not part of the next implementation.** Do not add dead device adapters, fake endpoints, placeholder services, or hardware integrations before supported hardware and a real validation path exist. Future smellchecks must not find systems that were wired only because they might be useful someday.
+
+### 2. Pleasant audio from two sources
+
+PySbagen should support both:
+
+1. **Self-generated sound worlds** — evolving ambient material, musical beds, environmental textures, and other composed audio.
+2. **User-provided audio** — music, ambience, recordings, or other source material in broadly encountered formats, not a WAV-only workflow.
+
+The product should use broad decoder support, including FFmpeg fallback where appropriate, rather than exposing arbitrary file-format restrictions in the user experience.
+
+### 3. Separate research-dose environment
+
+Blinded comparisons, research conditions, consent, condition assignment, and study data do **not** belong in the standard user GUI, TUI, or ordinary session flow.
+
+They belong in a separate **Research Dose Environment** with its own:
+
+- informed consent;
+- study protocol and eligibility rules;
+- condition definitions;
+- blinded or partially blinded assignment;
+- session identity and exact recipe capture;
+- pre-session and post-session measures;
+- adverse-effect reporting;
+- data export and protocol versioning.
+
+Normal users receive help-oriented experiences. Research volunteers enter a deliberately marked research setting.
+
+### 4. Ask what is happening, then choose the experience
+
+The product should not force one generic “sleep” preset on every sleep complaint.
+
+The ordinary flow should ask what is happening in human terms, distinguish the major sleep problems, and select or construct an appropriate journey. The goal is to deliver the best-matched audio intervention for the reported problem while remaining honest that no single recipe can be guaranteed to work for every listener.
+
+---
+
+## Reconnaissance method
+
+The research pass used the uploaded **InvisiSynth / Holo Scout** framework as a map rather than relying on a shallow “binaural beats for sleep” search.
+
+The useful scout lines were:
+
+- historical patents and expired technical lineage;
+- academic lab-to-market work;
+- adjacent sleep and closed-loop stimulation research;
+- original SBaGen documentation and maker lineage;
+- current systematic reviews that test whether the popular claims survive comparison.
+
+The findings below distinguish:
+
+- **documented mechanism or observed result**;
+- **patent claim or product lineage**;
+- **promising but unsettled evidence**;
+- **future hypothesis that PySbagen should test rather than advertise as fact**.
+
+---
+
+## Research finding 1: pleasant sound is part of the system, not decoration
+
+Robert Monroe’s 1970 sleep patent describes a familiar, pleasing, repetitive sound modulated by a waveform shaped like an EEG sleep pattern. The chosen sound was intended to be pleasant to the individual, repetitive, and strong enough to mask environmental sound, with timed shutoff.
+
+This does not prove all of the patent’s outcome claims. It does show that the original design lineage was not based on a bare sine wave alone. Preference, masking, repetition, modulation, and time progression were part of the proposed mechanism.
+
+### Product implication
+
+The pleasant layer is not merely camouflage over the “real” tone. PySbagen should treat soundscape choice, familiarity, musical movement, masking, and gradual reduction of novelty as first-class session parameters.
+
+**Primary source:**  
+https://patents.google.com/patent/US3884218A/en
+
+---
+
+## Research finding 2: Monroe’s later work used layered beat geometry
+
+Monroe’s later patent describes an algorithmic sound system combining binaural relationships, monaural amplitude beats, amplitude and frequency modulation, pink-sound masking, optional voice, multiple carriers, and changing sequences.
+
+Its named “Septon” example uses three tones in each ear. The spacing creates three cross-ear binaural relationships and two monaural beat relationships per channel, yielding seven beat signals rather than one static left/right difference.
+
+A patent records a design and its claims; it does not by itself establish clinical effectiveness. The important engineering lesson is the **multi-layer, time-varying signal architecture**.
+
+### Product implication
+
+PySbagen should support independently controllable and reproducible layers, including:
+
+- multiple carrier groups;
+- cross-ear binaural relationships;
+- within-channel monaural relationships;
+- isochronic or shaped amplitude modulation;
+- phase and frequency movement;
+- masking or musical beds;
+- scheduled changes rather than a single unchanging tone.
+
+**Primary source:**  
+https://patents.google.com/patent/US5356368A/en
+
+---
+
+## Research finding 3: state and timing can matter more than a frequency label
+
+A human study using 0.8 Hz rhythmic acoustic stimulation found that stimulation delivered while participants were still awake delayed sleep onset. Once sleep was established, the same rhythm increased and entrained endogenous slow-oscillation activity.
+
+Closed-loop studies further show that sound timed to particular phases of ongoing slow oscillations can alter slow-oscillation and spindle activity. The effect depends on timing relative to the brain’s current state; merely selecting “delta” is not enough.
+
+### Product implication
+
+PySbagen must not assume:
+
+> slow frequency = immediate sleep induction
+
+Sleep Descent and Sleep Support require different schedules and different evidence standards. Until real sensing exists, the ordinary product can provide a planned descent and fade, but it must not pretend to know the listener’s exact sleep stage.
+
+**Primary sources:**
+
+- https://pubmed.ncbi.nlm.nih.gov/22913273/
+- https://pubmed.ncbi.nlm.nih.gov/23583623/
+- https://pubmed.ncbi.nlm.nih.gov/37660843/
+
+---
+
+## Research finding 4: music provides a more credible reward path than a magical “dopamine frequency”
+
+Human PET and fMRI work found endogenous striatal dopamine release during intense musical pleasure. Anticipation and peak emotional response involved distinguishable reward-system activity.
+
+This does **not** show that an arbitrary tone or beat rate directly “gives dopamine.” It does support a stronger research path: rewarding musical expectation, emotional movement, personalization, and tension/release may help make a non-drug audio experience compelling and repeatable.
+
+### Product implication
+
+For sleep, the audio may begin with enough pleasant structure to satisfy and hold a restless mind, then reduce novelty and stimulation during the descent. Candidate dimensions include:
+
+- anticipation without startling changes;
+- gentle harmonic arrival and release;
+- personally preferred timbre;
+- evolving but slowing texture;
+- an early emotional settling point;
+- a long, increasingly uneventful fade.
+
+The hidden beat layers and the pleasant musical journey should be tested independently and together.
+
+**Primary source:**  
+https://pubmed.ncbi.nlm.nih.gov/21217764/
+
+---
+
+## Research finding 5: monaural and binaural are different tools, not a quality ladder
+
+A human auditory steady-state response study found a measurable 40 Hz binaural response at a low mean carrier near 400 Hz, but not above 3 kHz. The binaural response was smaller than the acoustic/monaural beat response.
+
+Other studies report differing EEG or behavioral effects for monaural and binaural conditions. Results across the wider binaural-beat literature remain inconsistent and methodologically heterogeneous.
+
+### Product implication
+
+PySbagen should not encode:
+
+- binaural as automatically superior;
+- monaural as a fallback;
+- isochronic as merely crude;
+- one carrier range as interchangeable with another.
+
+Research recipes must record carrier frequency, beat frequency, amplitude, channel arrangement, masking, duration, ramping, and other signal details. The product should compare techniques rather than choose a winner in advance.
+
+**Primary sources:**
+
+- https://pubmed.ncbi.nlm.nih.gov/15721080/
+- https://pubmed.ncbi.nlm.nih.gov/25345689/
+- https://pubmed.ncbi.nlm.nih.gov/37205669/
+
+---
+
+## Research finding 6: closed-loop sleep audio is technically plausible, but belongs later
+
+Research has demonstrated slow-oscillation detection using in-ear EEG and brain-state-dependent auditory stimulation. Newer work continues to investigate timing informed by EEG and heart rhythms.
+
+This makes future state-responsive sleep support plausible. It does not justify coding adapters for hardware PySbagen does not possess or support.
+
+### Documented future path
+
+Potential future signals include:
+
+- in-ear or scalp EEG;
+- a supported consumer sleep headband;
+- movement or stillness;
+- heart rate and heart-rate variability;
+- breathing information;
+- phone interaction stopping;
+- agreement among several weaker signals.
+
+Hardware integration begins only when there is a real device, documented access path, test fixture, and end-to-end validation plan.
+
+**Primary sources:**
+
+- https://pubmed.ncbi.nlm.nih.gov/35124848/
+- https://pubmed.ncbi.nlm.nih.gov/41593748/
+
+---
+
+## Research finding 7: H-box X should be translated into measurable signal structure
+
+The reconnaissance did not find a peer-reviewed research field using “H-box,” “HboxX,” or “Harmonic Box X” as a standardized scientific intervention name.
+
+That is not a reason to remove it. It is a reason to describe and test the actual signal rather than treating the label as proof.
+
+### Product implication
+
+Every H-box X recipe should be inspectable in ordinary DSP terms:
+
+- carrier count and carrier frequencies;
+- left/right assignment;
+- cross-ear frequency differences;
+- within-channel beat products;
+- phase relationships;
+- amplitude envelopes;
+- modulation frequency and depth;
+- transitions over time.
+
+Research conditions should compare the resulting structure with simpler controls.
+
+---
+
+## Research finding 8: original SBaGen was an experimenter’s laboratory
+
+Original SBaGen documentation describes scheduled smooth changes, mixtures of multiple brain-wave frequencies, pink noise and background MP3/OGG audio, user-supplied soundtracks, randomized looping river sounds, analysis tools, and ideas for live-event response and independent channels.
+
+The lineage is broader than a static tone generator. It explicitly supports personal experimentation and precise tuning while warning users that the claims are not guaranteed.
+
+### Product implication
+
+PySbagen should preserve SBaGen’s inspectability and scheduling power while adding a human front door, broader audio handling, better composition, exact recipe capture, and a separate controlled-research environment.
+
+**Primary sources:**
+
+- https://uazu.net/sbagen/
+- https://uazu.net/sbagen/faq.html
+
+---
+
+## Current evidence position
+
+The evidence does not support a universal chart where one frequency reliably causes one mental outcome in every person.
+
+The useful evidence supports a more careful product:
+
+- pleasant and personally acceptable sound matters;
+- audio composition may contribute reward and engagement;
+- timing and current brain state matter;
+- carrier and modulation details matter;
+- monaural, binaural, isochronic, noise, music, and multi-carrier structures should be compared rather than conflated;
+- effects can differ by person and context;
+- research recipes must be reproducible;
+- standard use and experimental use require separate environments.
+
+A 2023 systematic review found binaural-entrainment EEG results inconsistent across heterogeneous studies. A 2026 systematic review of music and binaural interventions reported promising outcomes across some sleep, anxiety, and cognition studies while emphasizing small samples and design heterogeneity. These are reasons to build better controlled tools, not reasons to make guaranteed medical claims.
+
+**Reviews:**
+
+- https://pubmed.ncbi.nlm.nih.gov/37205669/
+- https://pubmed.ncbi.nlm.nih.gov/41656644/
+- https://pubmed.ncbi.nlm.nih.gov/34964434/
+
+---
+
+## Proposed ordinary-user model
+
+A tired person should not be confronted with a laboratory console.
+
+The product asks what is happening, such as:
+
+- “My mind keeps racing.”
+- “I feel relaxed, but I cannot cross into sleep.”
+- “I keep waking back up.”
+- “Pain or migraine is keeping me awake.”
+- “I am agitated or craving something and cannot settle.”
+
+PySbagen then chooses a complete journey using:
+
+- an appropriate descent shape;
+- a generated or user-supplied pleasant audio bed;
+- independently layered beat and modulation structures;
+- tolerability settings;
+- a session duration and fade plan;
+- previous personal feedback when available.
+
+Advanced users may inspect and alter the recipe, but the normal listener should not have to engineer it.
+
+---
+
+## Proposed Research Dose Environment
+
+The separate research product should make it possible to compare:
+
+- pleasant soundscape alone;
+- identical soundscape plus binaural layers;
+- identical soundscape plus monaural layers;
+- identical soundscape plus isochronic modulation;
+- H-box X structures versus decomposed controls;
+- one carrier pair versus multi-carrier matrices;
+- static stimulation versus gradual movement;
+- generated audio versus participant-selected audio;
+- fixed-time descent versus future state-responsive support;
+- stimulation continuing after likely sleep versus an earlier fade.
+
+Each dose should preserve:
+
+- source-audio identity and hash;
+- generated-audio seed and composition parameters;
+- every carrier and modulation parameter;
+- exact timing and fades;
+- software and protocol versions;
+- listener volume calibration or reported level;
+- equipment and headphone/speaker route;
+- pre-session condition;
+- outcome and adverse-effect reports.
+
+The research environment should support control and sham conditions without making the ordinary app feel like an experiment.
+
+---
+
+## Boundaries for the next build discussion
+
+Before implementation begins, the remaining product conversation should settle:
+
+1. How PySbagen asks about the user’s sleep problem without resembling a medical intake form.
+2. What the first generated pleasant sound worlds should sound like.
+3. How much user-supplied music is transformed versus left recognizable.
+4. Whether the first journey is selected from trusted recipes, generated from constraints, or built through a hybrid approach.
+5. How the listener reports “worked,” “did nothing,” or “made it worse.”
+6. How the system learns personal preference without turning each ordinary night into an uncontrolled experiment.
+7. What safety and exclusion language belongs in ordinary use versus the Research Dose Environment.
+
+No next build beadtrain begins until the conversation establishes the intended human experience.

--- a/docs/research/SLEEP_AUDIO_RESEARCH_FOUNDATIONS.md
+++ b/docs/research/SLEEP_AUDIO_RESEARCH_FOUNDATIONS.md
@@ -1,372 +1,157 @@
 # PySbagen Sleep Audio Research Foundations
 
-**Status:** Product direction recorded before the next build beadtrain  
-**Date:** July 29, 2026  
-**Scope:** Sleep support, audio-layer research, and future voluntary participant research
+**Status:** Product direction recorded before and during the sleep-experience beadtrain  
+**Date:** July 29, 2026
 
-## Why this document exists
+## Purpose
 
-PySbagen must not collapse back into a frequency picker or a utility that only produces exposed sine tones, static, and noise. Its deeper purpose is to accept a human problem, construct a pleasant and technically reproducible audio experience for that problem, and learn what parts of the experience are actually useful.
+PySbagen is not a frequency picker. Its ordinary product asks what a person is experiencing, builds a pleasant and reproducible audio journey, and learns—without pretending certainty—which parts are useful.
 
-The first complete use-case family is **sleep difficulty**:
+The first supported family is sleep difficulty:
 
 - a racing mind that will not disengage;
-- a person who becomes relaxed but does not cross into sleep;
-- a person who falls asleep and repeatedly wakes;
-- combinations of the above, including sleep difficulty complicated by pain, migraine, agitation, or cravings.
+- feeling relaxed but not crossing into sleep;
+- falling asleep and repeatedly waking.
 
-The ordinary user should be able to answer a human question about what is happening and receive an audio experience designed for that situation. They should not need to understand carrier frequencies, beat matrices, modulation depth, or schedule syntax.
+Pain, migraine, cravings, substance-use support, and other use cases remain future product and research paths. They must not be silently inferred from the current sleep routes.
 
-The technical and research layers remain available underneath that experience.
+## Product decisions
 
----
+### Two sleep systems
 
-## Product decisions already made
+**Sleep Descent** serves a person who is still awake. It should begin where their attention is, reduce novelty and stimulation over time, and fade gradually.
 
-### 1. Two sleep systems
+**Sleep Support** is the quieter period after sleep is more likely. Future closed-loop timing may use real sensors, but no EEG, watch, movement, heart-rate, breathing, or other device adapters are coded until supported hardware and an end-to-end validation path exist.
 
-PySbagen will treat sleep onset and sleep-state support as different problems.
+### Pleasant audio is first-class
 
-#### Sleep Descent
+PySbagen supports both:
 
-For a person who is still awake. It should:
+1. self-generated music, ambience, environmental texture, and sound worlds;
+2. user-provided audio in broadly decodable formats, not a WAV-only workflow.
 
-- meet the listener where they are;
-- reduce mental and sensory engagement without becoming irritating;
-- use pleasant generated or supplied audio as a real part of the intervention;
-- change its underlying audio structures over time rather than presenting one static beat indefinitely;
-- fade gradually after the intended descent period.
+### Ordinary use and research use are separate
 
-#### Sleep Support
-
-For use after sleep is likely or has been detected. It may eventually use closed-loop timing to support sleep-stage rhythms without waking the listener.
-
-**Sensors are a documented future path, not part of the next implementation.** Do not add dead device adapters, fake endpoints, placeholder services, or hardware integrations before supported hardware and a real validation path exist. Future smellchecks must not find systems that were wired only because they might be useful someday.
-
-### 2. Pleasant audio from two sources
-
-PySbagen should support both:
-
-1. **Self-generated sound worlds** — evolving ambient material, musical beds, environmental textures, and other composed audio.
-2. **User-provided audio** — music, ambience, recordings, or other source material in broadly encountered formats, not a WAV-only workflow.
-
-The product should use broad decoder support, including FFmpeg fallback where appropriate, rather than exposing arbitrary file-format restrictions in the user experience.
-
-### 3. Separate research-dose environment
-
-Blinded comparisons, research conditions, consent, condition assignment, and study data do **not** belong in the standard user GUI, TUI, or ordinary session flow.
-
-They belong in a separate **Research Dose Environment** with its own:
-
-- informed consent;
-- study protocol and eligibility rules;
-- condition definitions;
-- blinded or partially blinded assignment;
-- session identity and exact recipe capture;
-- pre-session and post-session measures;
-- adverse-effect reporting;
-- data export and protocol versioning.
-
-Normal users receive help-oriented experiences. Research volunteers enter a deliberately marked research setting.
-
-### 4. Ask what is happening, then choose the experience
-
-The product should not force one generic “sleep” preset on every sleep complaint.
-
-The ordinary flow should ask what is happening in human terms, distinguish the major sleep problems, and select or construct an appropriate journey. The goal is to deliver the best-matched audio intervention for the reported problem while remaining honest that no single recipe can be guaranteed to work for every listener.
-
----
+The normal GUI/TUI/CLI provides help-oriented sessions. Blinding, sham conditions, consent, eligibility, protocol assignment, pre/post measures, adverse-event reporting, and study export belong in a separately launched **Research Dose Environment**.
 
 ## Reconnaissance method
 
-The research pass used the uploaded **InvisiSynth / Holo Scout** framework as a map rather than relying on a shallow “binaural beats for sleep” search.
+The uploaded InvisiSynth / Holo Scout framework guided separate searches through:
 
-The useful scout lines were:
-
-- historical patents and expired technical lineage;
-- academic lab-to-market work;
+- historical patents and technical lineage;
+- overlooked academic and lab-to-market work;
 - adjacent sleep and closed-loop stimulation research;
 - original SBaGen documentation and maker lineage;
-- current systematic reviews that test whether the popular claims survive comparison.
+- systematic reviews that test popular claims.
 
-The findings below distinguish:
+Patents document designs and claims, not clinical proof. Observed study results, unsettled hypotheses, and product lineage are kept distinct.
 
-- **documented mechanism or observed result**;
-- **patent claim or product lineage**;
-- **promising but unsettled evidence**;
-- **future hypothesis that PySbagen should test rather than advertise as fact**.
+## Findings
 
----
+### 1. Pleasant sound was part of the mechanism
 
-## Research finding 1: pleasant sound is part of the system, not decoration
+Robert Monroe’s 1970 sleep patent described a familiar, pleasing, repetitive sound modulated by a sleep-pattern-shaped waveform, used for environmental masking and timed shutoff. This does not prove its outcome claims, but it shows that preference, masking, repetition, modulation, and progression were central—not decorative material covering a bare tone.
 
-Robert Monroe’s 1970 sleep patent describes a familiar, pleasing, repetitive sound modulated by a waveform shaped like an EEG sleep pattern. The chosen sound was intended to be pleasant to the individual, repetitive, and strong enough to mask environmental sound, with timed shutoff.
+Source: https://patents.google.com/patent/US3884218A/en
 
-This does not prove all of the patent’s outcome claims. It does show that the original design lineage was not based on a bare sine wave alone. Preference, masking, repetition, modulation, and time progression were part of the proposed mechanism.
+### 2. Monroe’s later system used layered beat geometry
 
-### Product implication
+A later Monroe patent described multiple carriers, cross-ear binaural relationships, within-channel monaural beats, amplitude and frequency modulation, phased pink sound, optional voice, and changing sequences. Its “Septon” example creates several simultaneous relationships rather than one static left/right difference.
 
-The pleasant layer is not merely camouflage over the “real” tone. PySbagen should treat soundscape choice, familiarity, musical movement, masking, and gradual reduction of novelty as first-class session parameters.
+Product implication: recipes must expose carrier groups, channel assignment, amplitude envelopes, modulation, phase/frequency movement, masking beds, and timing.
 
-**Primary source:**  
-https://patents.google.com/patent/US3884218A/en
+Source: https://patents.google.com/patent/US5356368A/en
 
----
+### 3. State and timing can matter more than a frequency label
 
-## Research finding 2: Monroe’s later work used layered beat geometry
+A human study found that 0.8 Hz rhythmic acoustic stimulation begun while participants were awake delayed sleep onset; after stable non-REM sleep existed, the same rhythm increased slow-oscillation activity. Other closed-loop work found effects depended on stimulus timing relative to the ongoing slow-oscillation phase.
 
-Monroe’s later patent describes an algorithmic sound system combining binaural relationships, monaural amplitude beats, amplitude and frequency modulation, pink-sound masking, optional voice, multiple carriers, and changing sequences.
+Product implication: “slow frequency = immediate sleep” is not a safe design rule. Descent and support require different schedules and evidence standards.
 
-Its named “Septon” example uses three tones in each ear. The spacing creates three cross-ear binaural relationships and two monaural beat relationships per channel, yielding seven beat signals rather than one static left/right difference.
-
-A patent records a design and its claims; it does not by itself establish clinical effectiveness. The important engineering lesson is the **multi-layer, time-varying signal architecture**.
-
-### Product implication
-
-PySbagen should support independently controllable and reproducible layers, including:
-
-- multiple carrier groups;
-- cross-ear binaural relationships;
-- within-channel monaural relationships;
-- isochronic or shaped amplitude modulation;
-- phase and frequency movement;
-- masking or musical beds;
-- scheduled changes rather than a single unchanging tone.
-
-**Primary source:**  
-https://patents.google.com/patent/US5356368A/en
-
----
-
-## Research finding 3: state and timing can matter more than a frequency label
-
-A human study using 0.8 Hz rhythmic acoustic stimulation found that stimulation delivered while participants were still awake delayed sleep onset. Once sleep was established, the same rhythm increased and entrained endogenous slow-oscillation activity.
-
-Closed-loop studies further show that sound timed to particular phases of ongoing slow oscillations can alter slow-oscillation and spindle activity. The effect depends on timing relative to the brain’s current state; merely selecting “delta” is not enough.
-
-### Product implication
-
-PySbagen must not assume:
-
-> slow frequency = immediate sleep induction
-
-Sleep Descent and Sleep Support require different schedules and different evidence standards. Until real sensing exists, the ordinary product can provide a planned descent and fade, but it must not pretend to know the listener’s exact sleep stage.
-
-**Primary sources:**
+Sources:
 
 - https://pubmed.ncbi.nlm.nih.gov/22913273/
 - https://pubmed.ncbi.nlm.nih.gov/23583623/
 - https://pubmed.ncbi.nlm.nih.gov/37660843/
 
----
+### 4. Music is a more credible reward path than a magical dopamine frequency
 
-## Research finding 4: music provides a more credible reward path than a magical “dopamine frequency”
+Human PET/fMRI work found endogenous striatal dopamine release during intense musical pleasure, with distinguishable anticipation and peak-response activity. It does not show that an arbitrary beat rate directly “gives dopamine.”
 
-Human PET and fMRI work found endogenous striatal dopamine release during intense musical pleasure. Anticipation and peak emotional response involved distinguishable reward-system activity.
+Product implication: personally rewarding timbre, expectation, gentle harmonic movement, tension/release, and decreasing novelty are stronger research dimensions than advertising a dopamine frequency. Pleasant music and hidden modulation layers should be compared separately and together.
 
-This does **not** show that an arbitrary tone or beat rate directly “gives dopamine.” It does support a stronger research path: rewarding musical expectation, emotional movement, personalization, and tension/release may help make a non-drug audio experience compelling and repeatable.
+Source: https://pubmed.ncbi.nlm.nih.gov/21217764/
 
-### Product implication
+### 5. Monaural and binaural are different tools, not a quality ladder
 
-For sleep, the audio may begin with enough pleasant structure to satisfy and hold a restless mind, then reduce novelty and stimulation during the descent. Candidate dimensions include:
+A human auditory steady-state study detected a 40 Hz binaural response near a 400 Hz carrier but not above 3 kHz; the binaural response was smaller than the monaural/acoustic beat response. Wider findings remain inconsistent and methodologically heterogeneous.
 
-- anticipation without startling changes;
-- gentle harmonic arrival and release;
-- personally preferred timbre;
-- evolving but slowing texture;
-- an early emotional settling point;
-- a long, increasingly uneventful fade.
+Product implication: record carrier, beat, amplitude, channels, masking, ramping, and duration. Do not encode binaural as automatically superior, monaural as a fallback, or isochronic as crude.
 
-The hidden beat layers and the pleasant musical journey should be tested independently and together.
-
-**Primary source:**  
-https://pubmed.ncbi.nlm.nih.gov/21217764/
-
----
-
-## Research finding 5: monaural and binaural are different tools, not a quality ladder
-
-A human auditory steady-state response study found a measurable 40 Hz binaural response at a low mean carrier near 400 Hz, but not above 3 kHz. The binaural response was smaller than the acoustic/monaural beat response.
-
-Other studies report differing EEG or behavioral effects for monaural and binaural conditions. Results across the wider binaural-beat literature remain inconsistent and methodologically heterogeneous.
-
-### Product implication
-
-PySbagen should not encode:
-
-- binaural as automatically superior;
-- monaural as a fallback;
-- isochronic as merely crude;
-- one carrier range as interchangeable with another.
-
-Research recipes must record carrier frequency, beat frequency, amplitude, channel arrangement, masking, duration, ramping, and other signal details. The product should compare techniques rather than choose a winner in advance.
-
-**Primary sources:**
+Sources:
 
 - https://pubmed.ncbi.nlm.nih.gov/15721080/
 - https://pubmed.ncbi.nlm.nih.gov/25345689/
 - https://pubmed.ncbi.nlm.nih.gov/37205669/
 
----
+### 6. Closed-loop sleep audio is plausible but later
 
-## Research finding 6: closed-loop sleep audio is technically plausible, but belongs later
+Researchers have demonstrated in-ear EEG detection and brain-state-dependent auditory stimulation. Newer work also explores timing informed by EEG and heart rhythms. This supports a future hardware path, not placeholder endpoints now.
 
-Research has demonstrated slow-oscillation detection using in-ear EEG and brain-state-dependent auditory stimulation. Newer work continues to investigate timing informed by EEG and heart rhythms.
-
-This makes future state-responsive sleep support plausible. It does not justify coding adapters for hardware PySbagen does not possess or support.
-
-### Documented future path
-
-Potential future signals include:
-
-- in-ear or scalp EEG;
-- a supported consumer sleep headband;
-- movement or stillness;
-- heart rate and heart-rate variability;
-- breathing information;
-- phone interaction stopping;
-- agreement among several weaker signals.
-
-Hardware integration begins only when there is a real device, documented access path, test fixture, and end-to-end validation plan.
-
-**Primary sources:**
+Sources:
 
 - https://pubmed.ncbi.nlm.nih.gov/35124848/
 - https://pubmed.ncbi.nlm.nih.gov/41593748/
 
----
+### 7. H-box X should be translated into measurable structure
 
-## Research finding 7: H-box X should be translated into measurable signal structure
+The reconnaissance did not find “H-box X” as a standardized peer-reviewed intervention name. It remains useful as a synthesis structure, but research must describe its carrier count, frequencies, channel assignments, cross-ear and within-channel beat products, phase relationships, envelopes, modulation frequency/depth, and transitions.
 
-The reconnaissance did not find a peer-reviewed research field using “H-box,” “HboxX,” or “Harmonic Box X” as a standardized scientific intervention name.
+### 8. Original SBaGen was an experimenter’s laboratory
 
-That is not a reason to remove it. It is a reason to describe and test the actual signal rather than treating the label as proof.
+Original SBaGen documentation includes scheduled smooth changes, mixtures of frequencies, pink noise, background MP3/OGG, user soundtracks, randomized loops, analysis tools, and experimental tuning. PySbagen preserves that inspectability while adding a human front door, broad decoding, pleasant generation, exact recipe capture, and separate research operation.
 
-### Product implication
-
-Every H-box X recipe should be inspectable in ordinary DSP terms:
-
-- carrier count and carrier frequencies;
-- left/right assignment;
-- cross-ear frequency differences;
-- within-channel beat products;
-- phase relationships;
-- amplitude envelopes;
-- modulation frequency and depth;
-- transitions over time.
-
-Research conditions should compare the resulting structure with simpler controls.
-
----
-
-## Research finding 8: original SBaGen was an experimenter’s laboratory
-
-Original SBaGen documentation describes scheduled smooth changes, mixtures of multiple brain-wave frequencies, pink noise and background MP3/OGG audio, user-supplied soundtracks, randomized looping river sounds, analysis tools, and ideas for live-event response and independent channels.
-
-The lineage is broader than a static tone generator. It explicitly supports personal experimentation and precise tuning while warning users that the claims are not guaranteed.
-
-### Product implication
-
-PySbagen should preserve SBaGen’s inspectability and scheduling power while adding a human front door, broader audio handling, better composition, exact recipe capture, and a separate controlled-research environment.
-
-**Primary sources:**
+Sources:
 
 - https://uazu.net/sbagen/
 - https://uazu.net/sbagen/faq.html
 
----
+## Evidence position
 
-## Current evidence position
+There is no established universal chart where one frequency reliably creates one mental outcome for every person. Evidence supports careful comparison, precise recipes, individual tolerability, and attention to timing and state.
 
-The evidence does not support a universal chart where one frequency reliably causes one mental outcome in every person.
+A 2023 review found binaural-entrainment EEG results inconsistent across heterogeneous methods. A 2026 review reported promising findings across music and binaural interventions, but it covered only 10 heterogeneous trials involving young adults aged 19–24. It does not justify broad clinical or age-group generalization.
 
-The useful evidence supports a more careful product:
-
-- pleasant and personally acceptable sound matters;
-- audio composition may contribute reward and engagement;
-- timing and current brain state matter;
-- carrier and modulation details matter;
-- monaural, binaural, isochronic, noise, music, and multi-carrier structures should be compared rather than conflated;
-- effects can differ by person and context;
-- research recipes must be reproducible;
-- standard use and experimental use require separate environments.
-
-A 2023 systematic review found binaural-entrainment EEG results inconsistent across heterogeneous studies. A 2026 systematic review of music and binaural interventions reported promising outcomes across some sleep, anxiety, and cognition studies while emphasizing small samples and design heterogeneity. These are reasons to build better controlled tools, not reasons to make guaranteed medical claims.
-
-**Reviews:**
+Reviews:
 
 - https://pubmed.ncbi.nlm.nih.gov/37205669/
 - https://pubmed.ncbi.nlm.nih.gov/41656644/
 - https://pubmed.ncbi.nlm.nih.gov/34964434/
 
----
+## Research Dose Environment requirements
 
-## Proposed ordinary-user model
+A research dose preserves:
 
-A tired person should not be confronted with a laboratory console.
+- consent, eligibility, protocol and software versions;
+- blinded/control assignment where appropriate;
+- source-audio identity/hash and generated seed;
+- every carrier, modulation, channel, timing, fade, and volume parameter;
+- listening equipment and route;
+- pre/post measures and adverse-effect reports.
 
-The product asks what is happening, such as:
+Candidate comparisons include soundscape alone, identical soundscape plus each hidden layer, simple versus multi-carrier structures, static versus moving stimulation, generated versus selected audio, and fixed versus future state-responsive support.
 
-- “My mind keeps racing.”
-- “I feel relaxed, but I cannot cross into sleep.”
-- “I keep waking back up.”
-- “Pain or migraine is keeping me awake.”
-- “I am agitated or craving something and cannot settle.”
+## Safety and exclusion boundary
 
-PySbagen then chooses a complete journey using:
+Ordinary PySbagen sleep sessions are non-diagnostic sleep-preparation audio, not treatment for insomnia, migraine, chronic pain, substance use disorder, withdrawal, or another condition. They do not promise dopamine delivery or guaranteed outcomes.
 
-- an appropriate descent shape;
-- a generated or user-supplied pleasant audio bed;
-- independently layered beat and modulation structures;
-- tolerability settings;
-- a session duration and fade plan;
-- previous personal feedback when available.
+The product must:
 
-Advanced users may inspect and alter the recipe, but the normal listener should not have to engineer it.
+- use comfortable-volume guidance and an immediate stop path;
+- warn against use while driving or doing alertness-critical work;
+- direct severe, unusual, worsening, or persistent symptoms to ordinary professional care;
+- direct dangerous withdrawal, overdose, self-harm risk, or urgent crisis to real-world emergency or crisis support—not an audio session;
+- exclude unsupported populations or conditions from research protocols until appropriate review and evidence exist;
+- require explicit informed consent for research participation.
 
----
-
-## Proposed Research Dose Environment
-
-The separate research product should make it possible to compare:
-
-- pleasant soundscape alone;
-- identical soundscape plus binaural layers;
-- identical soundscape plus monaural layers;
-- identical soundscape plus isochronic modulation;
-- H-box X structures versus decomposed controls;
-- one carrier pair versus multi-carrier matrices;
-- static stimulation versus gradual movement;
-- generated audio versus participant-selected audio;
-- fixed-time descent versus future state-responsive support;
-- stimulation continuing after likely sleep versus an earlier fade.
-
-Each dose should preserve:
-
-- source-audio identity and hash;
-- generated-audio seed and composition parameters;
-- every carrier and modulation parameter;
-- exact timing and fades;
-- software and protocol versions;
-- listener volume calibration or reported level;
-- equipment and headphone/speaker route;
-- pre-session condition;
-- outcome and adverse-effect reports.
-
-The research environment should support control and sham conditions without making the ordinary app feel like an experiment.
-
----
-
-## Boundaries for the next build discussion
-
-Before implementation begins, the remaining product conversation should settle:
-
-1. How PySbagen asks about the user’s sleep problem without resembling a medical intake form.
-2. What the first generated pleasant sound worlds should sound like.
-3. How much user-supplied music is transformed versus left recognizable.
-4. Whether the first journey is selected from trusted recipes, generated from constraints, or built through a hybrid approach.
-5. How the listener reports “worked,” “did nothing,” or “made it worse.”
-6. How the system learns personal preference without turning each ordinary night into an uncontrolled experiment.
-7. What safety and exclusion language belongs in ordinary use versus the Research Dose Environment.
-
-No next build beadtrain begins until the conversation establishes the intended human experience.
+No next product train may erase these boundaries or quietly convert ordinary users into research participants.

--- a/gui.py
+++ b/gui.py
@@ -1,487 +1,491 @@
-import tkinter as tk
-from tkinter import ttk, messagebox
-import argparse
-from pysbagen import cli as pysbagen_cli
-from pysbagen.mixer import mix_generators
-from pysbagen.generators.generic import GenericToneSpec
-from pysbagen.parser import parse_sbg_from_string
-import visualization as viz
-import pyaudio
-import threading
-import drg_decoder
-from PIL import Image, ImageTk
+from __future__ import annotations
+
 import io
+import threading
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+
+import numpy as np
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+from PIL import Image, ImageTk
+
+import drg_decoder
+import visualization as viz
+from pysbagen.api import build_quick_specs, render_schedule, render_specs, write_audio
+from pysbagen.generators import FileSpec, GenericToneSpec, IsochronicSpec
+from pysbagen.mixer import build_session_generator
+from pysbagen.parser import parse_sbg_from_string
+
+try:
+    import pyaudio
+except ImportError:  # Audio export remains available without live playback extras.
+    pyaudio = None
+
 
 class SbagenController:
-    def generate(self, params):
+    def generate_quick(self, params: dict):
+        specs = build_quick_specs(
+            base=params.get("base"),
+            beat=params.get("beat"),
+            isochronic=params.get("isochronic"),
+            harmonic_box=params.get("harmonic_box"),
+            noise=params.get("noise"),
+            noise_kind=params.get("noise_kind", "white"),
+            music=params.get("music"),
+            music_amp=params.get("music_amp", 100.0),
+            loop_music=params.get("loop_music", False),
+        )
+        return write_audio(render_specs(specs, float(params["duration"])), params["outfile"])
+
+    def generate_schedule(self, path: str, outfile: str, duration: float | None = None):
+        return write_audio(render_schedule(path, duration), outfile)
+
+    def generate_loaded_schedule(self, tone_sets, schedule, outfile: str, duration: float | None):
+        return write_audio(build_session_generator(tone_sets, schedule, duration), outfile)
+
+    def generate_tones(
+        self,
+        specs: list[dict],
+        duration: float,
+        outfile: str,
+        soundscape: str | None = None,
+        soundscape_amp: float = 50.0,
+        loop_soundscape: bool = True,
+    ):
+        generators = [
+            GenericToneSpec(
+                freq=float(spec["freq"]),
+                amp=float(spec["amp"]),
+                waveform=spec["waveform"],
+            )
+            for spec in specs
+        ]
+        if soundscape:
+            generators.append(
+                FileSpec(
+                    path=soundscape,
+                    amp=float(soundscape_amp),
+                    loop=loop_soundscape,
+                )
+            )
+        return write_audio(render_specs(generators, duration), outfile)
+
+    def playback(self, specs, duration: float, on_chunk=None):
+        if pyaudio is None:
+            raise RuntimeError("Live playback requires the GUI extra: pip install 'pysbagen[gui]'")
+        audio = pyaudio.PyAudio()
+        stream = audio.open(format=pyaudio.paFloat32, channels=2, rate=44100, output=True)
         try:
-            # This is a bit of a hack to reuse the CLI parser
-            # A better solution would be to have a proper API
-            args = []
-            if params.get("outfile"):
-                args.extend(["-o", params["outfile"]])
-            if params.get("duration"):
-                args.extend(["-d", str(params["duration"])])
-            if params.get("base") and params.get("beat"):
-                args.extend(["--base", str(params["base"]), "--beat", str(params["beat"])])
-            if params.get("isochronic"):
-                args.extend(["--isochronic", str(params["isochronic"][0]), str(params["isochronic"][1])])
-            if params.get("harmonic_box"):
-                args.extend(["--harmonic-box", str(params["harmonic_box"][0]), str(params["harmonic_box"][1]), str(params["harmonic_box"][2])])
-            if params.get("noise"):
-                args.extend(["--noise", str(params["noise"])])
-            if params.get("music"):
-                args.extend(["--music", params["music"]])
-            if params.get("music_amp"):
-                args.extend(["--music-amp", str(params["music_amp"])])
-            if params.get("schedule"):
-                args.append(params["schedule"])
+            for chunk, info in render_specs(specs, duration):
+                stream.write(np.asarray(chunk, dtype=np.float32).tobytes())
+                if on_chunk:
+                    on_chunk(info)
+        finally:
+            stream.stop_stream()
+            stream.close()
+            audio.terminate()
 
-            # We need to temporarily replace sys.argv to use the parser
-            import sys
-            original_argv = sys.argv
-            sys.argv = ["sbgpy"] + args
-            pysbagen_cli.main()
-            sys.argv = original_argv
-
-            return f"Successfully generated {params.get('outfile', 'session.wav')}"
-
-        except Exception as e:
-            return f"An unexpected error occurred: {e}"
-
-    def generate_with_viz(self, params):
-        # This is also a hack. A proper API would be better.
-        gens = []
-        if params.get("isochronic"):
-            gens.append(GenericToneSpec(freq=params["isochronic"][0], amp=100.0, waveform="sine"))
-
-        yield from mix_generators(gens, params["duration"])
-
-
-    def generate_tones(self, specs, duration):
-        gens = []
-        for spec in specs:
-            gens.append(GenericToneSpec(
-                freq=spec["freq"],
-                amp=spec["amp"],
-                waveform=spec["waveform"]
-            ))
-        yield from mix_generators(gens, duration)
 
 class SbagenGui:
-    def __init__(self, root):
-        self.controller = SbagenController()
+    def __init__(self, root: tk.Tk):
         self.root = root
-        root.title("SBAGEN GUI")
+        self.controller = SbagenController()
+        self.tone_generators: list[dict] = []
+        self.loaded_drg = None
+        self.drg_photo = None
+        self.pattern_canvas = None
 
-        menubar = tk.Menu(root)
+        root.title("pysbagen Session Builder")
+        root.geometry("820x720")
+        self._build_menu()
+
+        ttk.Label(root, text="pysbagen Session Builder", font=("Helvetica", 17, "bold")).pack(pady=(10, 2))
+        ttk.Label(
+            root,
+            text="Build and export local binaural, isochronic, harmonic-box, noise, music, and SBG sessions.",
+        ).pack(pady=(0, 8))
+
+        self.notebook = ttk.Notebook(root)
+        self.notebook.pack(padx=10, pady=5, fill="both", expand=True)
+        self._build_quick_tab()
+        self._build_schedule_tab()
+        self._build_advanced_tab()
+        self._build_tone_tab()
+        self._build_visualization_tab()
+
+        self.status = tk.StringVar(value="Ready")
+        ttk.Label(root, textvariable=self.status, relief=tk.SUNKEN, anchor=tk.W).pack(side=tk.BOTTOM, fill=tk.X)
+
+    def _build_menu(self):
+        menubar = tk.Menu(self.root)
         filemenu = tk.Menu(menubar, tearoff=0)
-        filemenu.add_command(label="Open I-Doser file...", command=self.open_drg_file)
+        filemenu.add_command(label="Open I-Doser file…", command=self.open_drg_file)
         filemenu.add_separator()
-        filemenu.add_command(label="Exit", command=root.quit)
+        filemenu.add_command(label="Exit", command=self.root.destroy)
         menubar.add_cascade(label="File", menu=filemenu)
-        root.config(menu=menubar)
+        self.root.config(menu=menubar)
 
-        main_label = ttk.Label(root, text="SBAGEN GUI", font=("Helvetica", 16))
-        main_label.pack(pady=10)
+    def _tab(self, title: str):
+        tab = ttk.Frame(self.notebook, padding=10)
+        self.notebook.add(tab, text=title)
+        return tab
 
-        notebook = ttk.Notebook(root)
-        notebook.pack(padx=10, pady=10, fill="both", expand=True)
-
-        quick_tab = ttk.Frame(notebook)
-        schedule_tab = ttk.Frame(notebook)
-        advanced_tab = ttk.Frame(notebook)
-        self.viz_tab = ttk.Frame(notebook)
-        tone_gen_tab = ttk.Frame(notebook)
-
-        notebook.add(quick_tab, text="Quick Generate")
-        notebook.add(schedule_tab, text="Schedule File")
-        notebook.add(advanced_tab, text="Advanced")
-        notebook.add(self.viz_tab, text="Visualization")
-        notebook.add(tone_gen_tab, text="Tone Generator")
-
-        # --- Quick Generate Tab ---
-        # Input fields
-        self.base_freq = self.create_input(quick_tab, "Base Frequency (Hz):", "200")
-        self.beat_freq = self.create_input(quick_tab, "Beat Frequency (Hz):", "10")
-        self.duration = self.create_input(quick_tab, "Duration (s):", "60")
-        self.outfile = self.create_input(quick_tab, "Output File:", "session.wav")
-
-        # Generate button
-        generate_button = ttk.Button(quick_tab, text="Generate", command=self.run_generate)
-        generate_button.pack(pady=5)
-
-        # --- Schedule File Tab ---
-        self.image_label = ttk.Label(schedule_tab)
-        self.image_label.pack(pady=5)
-        self.schedule_file = tk.StringVar()
-        schedule_label = ttk.Label(schedule_tab, textvariable=self.schedule_file)
-        schedule_label.pack(side="left", fill="x", expand=True, padx=5, pady=5)
-        self.schedule_file.set("No file selected.")
-
-        browse_button = ttk.Button(schedule_tab, text="Browse...", command=self.browse_file)
-        browse_button.pack(side="left", padx=5)
-
-        schedule_generate_button = ttk.Button(schedule_tab, text="Generate from Schedule", command=self.run_generate_from_schedule)
-        schedule_generate_button.pack(side="left", padx=5)
-
-        # --- Advanced Tab ---
-        # Isochronic tones
-        iso_frame = ttk.LabelFrame(advanced_tab, text="Isochronic Tone")
-        iso_frame.pack(padx=10, pady=10, fill="x")
-        iso_desc = ttk.Label(iso_frame, text="A single tone that is turned on and off rapidly.")
-        iso_desc.pack(pady=5)
-        self.iso_freq = self.create_input(iso_frame, "Frequency (Hz):", "200")
-        self.iso_beat = self.create_input(iso_frame, "Beat (Hz):", "10")
-
-        # Harmonic Box X
-        hbox_frame = ttk.LabelFrame(advanced_tab, text="Harmonic Box X")
-        hbox_frame.pack(padx=10, pady=10, fill="x")
-        hbox_desc = ttk.Label(hbox_frame, text="A more complex tone with harmonic layers.")
-        hbox_desc.pack(pady=5)
-        self.hbox_base = self.create_input(hbox_frame, "Base Freq:", "180")
-        self.hbox_diff = self.create_input(hbox_frame, "Difference:", "5")
-        self.hbox_mod = self.create_input(hbox_frame, "Modulator:", "8")
-
-        # Noise
-        noise_frame = ttk.LabelFrame(advanced_tab, text="Noise")
-        noise_frame.pack(padx=10, pady=10, fill="x")
-        self.noise_amp = self.create_input(noise_frame, "White Noise Amp (%):", "0")
-
-        # Background music
-        music_frame = ttk.LabelFrame(advanced_tab, text="Background Music")
-        music_frame.pack(padx=10, pady=10, fill="x")
-        self.music_file = tk.StringVar()
-        music_label = ttk.Label(music_frame, textvariable=self.music_file)
-        music_label.pack(side="left", fill="x", expand=True, padx=5, pady=5)
-        self.music_file.set("No file selected.")
-        music_browse_button = ttk.Button(music_frame, text="Browse...", command=self.browse_music_file)
-        music_browse_button.pack(side="left", padx=5)
-        self.music_amp = self.create_input(music_frame, "Volume (%):", "50")
-
-        # FFMPEG Path
-        ffmpeg_frame = ttk.LabelFrame(advanced_tab, text="FFMPEG Path")
-        ffmpeg_frame.pack(padx=10, pady=10, fill="x")
-        self.ffmpeg_path = self.create_input(ffmpeg_frame, "FFMPEG Executable:", "")
-        ffmpeg_browse_button = ttk.Button(ffmpeg_frame, text="Browse...", command=self.browse_ffmpeg)
-        ffmpeg_browse_button.pack(side="left", padx=5)
-
-
-        advanced_generate_button = ttk.Button(advanced_tab, text="Generate Advanced", command=self.run_generate_advanced)
-        advanced_generate_button.pack(pady=10)
-
-        # --- Tone Generator Tab ---
-        self.tone_generators = []
-        self.tone_canvas = tk.Canvas(tone_gen_tab)
-        self.tone_frame = ttk.Frame(self.tone_canvas)
-        self.tone_scrollbar = ttk.Scrollbar(tone_gen_tab, orient="vertical", command=self.tone_canvas.yview)
-        self.tone_canvas.configure(yscrollcommand=self.tone_scrollbar.set)
-
-        self.tone_scrollbar.pack(side="right", fill="y")
-        self.tone_canvas.pack(side="left", fill="both", expand=True)
-        self.tone_canvas.create_window((0,0), window=self.tone_frame, anchor="nw")
-
-        self.tone_frame.bind("<Configure>", lambda e: self.tone_canvas.configure(scrollregion=self.tone_canvas.bbox("all")))
-
-        soundscape_frame = ttk.LabelFrame(tone_gen_tab, text="Background Soundscape")
-        soundscape_frame.pack(padx=10, pady=10, fill="x")
-        self.soundscape_file = tk.StringVar()
-        soundscape_label = ttk.Label(soundscape_frame, textvariable=self.soundscape_file)
-        soundscape_label.pack(side="left", fill="x", expand=True, padx=5, pady=5)
-        self.soundscape_file.set("No file selected.")
-        load_soundscape_button = ttk.Button(soundscape_frame, text="Load...", command=self.load_soundscape)
-        load_soundscape_button.pack(side="left", padx=5)
-        self.soundscape_amp = tk.Scale(soundscape_frame, from_=0, to=100, orient="horizontal", label="Volume (%)")
-        self.soundscape_amp.set(50)
-        self.soundscape_amp.pack(side="left", padx=5)
-
-        add_tone_button = ttk.Button(tone_gen_tab, text="Add Tone", command=self.add_tone_generator)
-        add_tone_button.pack(pady=5)
-
-        generate_tones_button = ttk.Button(tone_gen_tab, text="Generate Tones", command=self.run_generate_tones)
-        generate_tones_button.pack(pady=5)
-
-        # --- Visualization Tab ---
-        self.fig = Figure(figsize=(5, 5), dpi=100)
-        self.canvas = FigureCanvasTkAgg(self.fig, master=self.viz_tab)
-        self.canvas.draw()
-        self.canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=1)
-
-        viz_button = ttk.Button(self.viz_tab, text="Play with Visualization", command=self.run_generate_and_viz)
-        viz_button.pack(pady=10)
-
-        # Status bar
-        self.status = tk.StringVar()
-        self.status.set("Ready")
-        status_bar = ttk.Label(root, textvariable=self.status, relief=tk.SUNKEN, anchor=tk.W)
-        status_bar.pack(side=tk.BOTTOM, fill=tk.X)
-
-
-    def create_input(self, parent, label_text, default_value):
-        frame = ttk.Frame(parent)
-        frame.pack(fill="x", padx=5, pady=2)
-        label = ttk.Label(frame, text=label_text, width=20)
-        label.pack(side="left")
-        entry = ttk.Entry(frame)
-        entry.pack(side="left", expand=True, fill="x")
-        entry.insert(0, default_value)
+    @staticmethod
+    def _entry(parent, label: str, default: str = "", width: int = 24):
+        row = ttk.Frame(parent)
+        row.pack(fill="x", pady=3)
+        ttk.Label(row, text=label, width=24).pack(side="left")
+        entry = ttk.Entry(row, width=width)
+        entry.insert(0, default)
+        entry.pack(side="left", fill="x", expand=True)
         return entry
 
-    def run_generate(self):
-        self.status.set("Generating audio...")
-        params = {
-            "base": self.base_freq.get(),
-            "beat": self.beat_freq.get(),
-            "duration": self.duration.get(),
-            "outfile": self.outfile.get()
-        }
-        result = self.controller.generate(params)
-        self.status.set(result)
-        if "Error" in result:
-            messagebox.showerror("Error", result)
-        else:
-            messagebox.showinfo("Success", result)
+    def _path_row(self, parent, label: str, save: bool, filetypes):
+        row = ttk.Frame(parent)
+        row.pack(fill="x", pady=3)
+        ttk.Label(row, text=label, width=24).pack(side="left")
+        variable = tk.StringVar()
+        ttk.Entry(row, textvariable=variable).pack(side="left", fill="x", expand=True)
 
-    def run_generate_advanced(self):
-        self.status.set("Generating advanced audio...")
-        params = {
-            "duration": self.duration.get(),
-            "outfile": self.outfile.get(),
-            "isochronic": (float(self.iso_freq.get()), float(self.iso_beat.get())),
-            "harmonic_box": (float(self.hbox_base.get()), float(self.hbox_diff.get()), float(self.hbox_mod.get())),
-            "music": self.music_file.get() if self.music_file.get() != "No file selected." else None,
-            "music_amp": self.music_amp.get(),
-            "ffmpeg_path": self.ffmpeg_path.get(),
-            "noise": float(self.noise_amp.get()) if self.noise_amp.get() else None
-        }
-        result = self.controller.generate(params)
-        self.status.set(result)
-        if "Error" in result:
-            messagebox.showerror("Error", result)
-        else:
-            messagebox.showinfo("Success", result)
+        def browse():
+            chooser = filedialog.asksaveasfilename if save else filedialog.askopenfilename
+            selected = chooser(filetypes=filetypes)
+            if selected:
+                variable.set(selected)
 
-    def run_generate_and_viz(self):
-        self.status.set("Starting visualization thread...")
-        thread = threading.Thread(target=self._generate_and_viz_thread)
-        thread.daemon = True
-        thread.start()
+        ttk.Button(row, text="Browse…", command=browse).pack(side="left", padx=(5, 0))
+        return variable
 
-    def _generate_and_viz_thread(self):
-        p = pyaudio.PyAudio()
-        stream = p.open(format=pyaudio.paFloat32,
-                        channels=2,
-                        rate=44100, # Use constant
-                        output=True)
-
-        params = {
-            "duration": float(self.duration.get()),
-            "outfile": self.outfile.get(),
-            "isochronic": (float(self.iso_freq.get()), float(self.iso_beat.get())),
-            "harmonic_box": (float(self.hbox_base.get()), float(self.hbox_diff.get()), float(self.hbox_mod.get())),
-            "music": self.music_file.get() if self.music_file.get() != "No file selected." else None,
-            "music_amp": self.music_amp.get(),
-            "ffmpeg_path": self.ffmpeg_path.get(),
-            "noise": float(self.noise_amp.get()) if self.noise_amp.get() else None
-        }
-
-        try:
-            for chunk, info in self.controller.generate_with_viz(params):
-                stream.write(chunk.astype(np.float32).tobytes())
-
-                # Map the frequency to (n, m) parameters
-                if info and info[0]['type'] == 'isochronic':
-                    freq = info[0]['freq']
-                    n, m = viz.map_freq_to_params(freq)
-
-                    self.fig.clear()
-                    new_fig = viz.generate_chladni_pattern(n, m)
-                    self.canvas.figure = new_fig
-                    self.canvas.draw()
-
-            self.status.set("Visualization complete.")
-        except Exception as e:
-            self.status.set(f"Error: {e}")
-            # Since this is in a thread, messagebox will not work well.
-            # We will just print the error for now.
-            print(f"Error in visualization thread: {e}")
-        finally:
-            stream.stop_stream()
-            stream.close()
-            p.terminate()
-
-    def browse_file(self):
-        from tkinter import filedialog
-        filepath = filedialog.askopenfilename(
-            title="Select an SBG file",
-            filetypes=(("SBG files", "*.sbg"), ("All files", "*.*"))
+    def _build_quick_tab(self):
+        tab = self._tab("Quick Generate")
+        self.quick_base = self._entry(tab, "Base frequency (Hz)", "200")
+        self.quick_beat = self._entry(tab, "Beat frequency (Hz)", "10")
+        self.quick_duration = self._entry(tab, "Duration (seconds)", "60")
+        self.quick_outfile = self._path_row(
+            tab,
+            "Output WAV",
+            True,
+            (("WAV audio", "*.wav"), ("All files", "*.*")),
         )
-        if filepath:
-            self.schedule_file.set(filepath)
+        self.quick_outfile.set("session.wav")
+        ttk.Button(tab, text="Generate binaural session", command=self.run_quick).pack(pady=10)
 
-    def browse_music_file(self):
-        from tkinter import filedialog
-        filepath = filedialog.askopenfilename(
-            title="Select a music file",
-            filetypes=(("Audio files", "*.wav *.ogg *.mp3"), ("All files", "*.*"))
+    def _build_schedule_tab(self):
+        tab = self._tab("Schedule / I-Doser")
+        self.schedule_file = self._path_row(
+            tab,
+            "SBG schedule",
+            False,
+            (("SBG schedules", "*.sbg"), ("All files", "*.*")),
         )
-        if filepath:
-            self.music_file.set(filepath)
+        self.schedule_duration = self._entry(tab, "Override duration (optional)", "")
+        self.schedule_outfile = self._path_row(
+            tab,
+            "Output WAV",
+            True,
+            (("WAV audio", "*.wav"), ("All files", "*.*")),
+        )
+        self.schedule_outfile.set("scheduled-session.wav")
+        actions = ttk.Frame(tab)
+        actions.pack(pady=8)
+        ttk.Button(actions, text="Generate selected SBG", command=self.run_schedule).pack(side="left", padx=4)
+        self.generate_drg_button = ttk.Button(
+            actions,
+            text="Generate loaded I-Doser",
+            command=self.run_loaded_drg,
+            state="disabled",
+        )
+        self.generate_drg_button.pack(side="left", padx=4)
+        self.drg_label = ttk.Label(tab, text="No I-Doser file loaded.")
+        self.drg_label.pack(pady=4)
+        self.drg_image_label = ttk.Label(tab)
+        self.drg_image_label.pack(pady=4)
 
-    def browse_ffmpeg(self):
-        from tkinter import filedialog
-        filepath = filedialog.askopenfilename(title="Select FFMPEG executable")
-        if filepath:
-            self.ffmpeg_path.delete(0, tk.END)
-            self.ffmpeg_path.insert(0, filepath)
+    def _build_advanced_tab(self):
+        tab = self._tab("Advanced")
+        self.advanced_duration = self._entry(tab, "Duration (seconds)", "60")
+        self.iso_freq = self._entry(tab, "Isochronic frequency", "200")
+        self.iso_beat = self._entry(tab, "Isochronic beat", "10")
+        self.hbox_base = self._entry(tab, "Harmonic-box base", "180")
+        self.hbox_diff = self._entry(tab, "Harmonic-box difference", "5")
+        self.hbox_mod = self._entry(tab, "Harmonic-box modulation", "8")
+        self.noise_amp = self._entry(tab, "Noise amplitude (%)", "0")
+        self.noise_kind = tk.StringVar(value="white")
+        row = ttk.Frame(tab)
+        row.pack(fill="x", pady=3)
+        ttk.Label(row, text="Noise kind", width=24).pack(side="left")
+        ttk.Combobox(row, textvariable=self.noise_kind, values=("white", "pink"), state="readonly").pack(side="left")
+        self.music_file = self._path_row(
+            tab,
+            "Background audio",
+            False,
+            (("Audio", "*.wav *.ogg *.flac *.mp3"), ("All files", "*.*")),
+        )
+        self.music_amp = self._entry(tab, "Background volume (%)", "50")
+        self.loop_music = tk.BooleanVar(value=True)
+        ttk.Checkbutton(tab, text="Loop background audio to session length", variable=self.loop_music).pack(anchor="w", padx=24)
+        self.advanced_outfile = self._path_row(
+            tab,
+            "Output WAV",
+            True,
+            (("WAV audio", "*.wav"), ("All files", "*.*")),
+        )
+        self.advanced_outfile.set("advanced-session.wav")
+        ttk.Button(tab, text="Generate advanced session", command=self.run_advanced).pack(pady=10)
+
+    def _build_tone_tab(self):
+        tab = self._tab("Tone Builder")
+        controls = ttk.Frame(tab)
+        controls.pack(fill="x")
+        self.tone_duration = self._entry(controls, "Duration (seconds)", "10")
+        self.tone_outfile = self._path_row(
+            controls,
+            "Output WAV",
+            True,
+            (("WAV audio", "*.wav"), ("All files", "*.*")),
+        )
+        self.tone_outfile.set("tone-builder.wav")
+        self.soundscape_file = self._path_row(
+            controls,
+            "Soundscape",
+            False,
+            (("Audio", "*.wav *.ogg *.flac *.mp3"), ("All files", "*.*")),
+        )
+        self.soundscape_amp = self._entry(controls, "Soundscape volume (%)", "50")
+
+        self.tone_rows = ttk.Frame(tab)
+        self.tone_rows.pack(fill="both", expand=True, pady=8)
+        buttons = ttk.Frame(tab)
+        buttons.pack()
+        ttk.Button(buttons, text="Add tone", command=self.add_tone_generator).pack(side="left", padx=4)
+        ttk.Button(buttons, text="Export tone session", command=self.run_tones).pack(side="left", padx=4)
+        ttk.Button(buttons, text="Preview tone session", command=self.preview_tones).pack(side="left", padx=4)
+        self.add_tone_generator()
+
+    def _build_visualization_tab(self):
+        tab = self._tab("Visualization")
+        self.visual_frequency = self._entry(tab, "Frequency (Hz)", "200")
+        self.visual_beat = self._entry(tab, "Beat (Hz)", "10")
+        self.visual_duration = self._entry(tab, "Preview seconds", "10")
+        actions = ttk.Frame(tab)
+        actions.pack(pady=5)
+        ttk.Button(actions, text="Draw Chladni pattern", command=self.draw_pattern).pack(side="left", padx=4)
+        ttk.Button(actions, text="Play isochronic preview", command=self.preview_visualization).pack(side="left", padx=4)
+        self.pattern_host = ttk.Frame(tab)
+        self.pattern_host.pack(fill="both", expand=True)
+
+    def _run_background(self, working_message: str, job):
+        self.status.set(working_message)
+
+        def worker():
+            try:
+                result = job()
+            except Exception as exc:
+                self.root.after(0, self._finish_error, str(exc))
+            else:
+                self.root.after(0, self._finish_success, result)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _finish_success(self, result):
+        message = f"Wrote {result.duration:.2f}s to {result.outfile}"
+        self.status.set(message)
+        messagebox.showinfo("Generation complete", message)
+
+    def _finish_error(self, message: str):
+        self.status.set(f"Error: {message}")
+        messagebox.showerror("pysbagen", message)
+
+    @staticmethod
+    def _optional_float(entry: ttk.Entry):
+        value = entry.get().strip()
+        return float(value) if value else None
+
+    def run_quick(self):
+        self._run_background(
+            "Generating binaural session…",
+            lambda: self.controller.generate_quick(
+                {
+                    "base": float(self.quick_base.get()),
+                    "beat": float(self.quick_beat.get()),
+                    "duration": float(self.quick_duration.get()),
+                    "outfile": self.quick_outfile.get(),
+                }
+            ),
+        )
+
+    def _advanced_params(self):
+        music = self.music_file.get().strip() or None
+        return {
+            "duration": float(self.advanced_duration.get()),
+            "outfile": self.advanced_outfile.get(),
+            "isochronic": (float(self.iso_freq.get()), float(self.iso_beat.get())),
+            "harmonic_box": (
+                float(self.hbox_base.get()),
+                float(self.hbox_diff.get()),
+                float(self.hbox_mod.get()),
+            ),
+            "noise": float(self.noise_amp.get()) if float(self.noise_amp.get()) > 0 else None,
+            "noise_kind": self.noise_kind.get(),
+            "music": music,
+            "music_amp": float(self.music_amp.get()),
+            "loop_music": self.loop_music.get(),
+        }
+
+    def run_advanced(self):
+        self._run_background(
+            "Generating advanced session…",
+            lambda: self.controller.generate_quick(self._advanced_params()),
+        )
+
+    def run_schedule(self):
+        path = self.schedule_file.get().strip()
+        if not path:
+            self._finish_error("Select an SBG schedule first")
+            return
+        self._run_background(
+            "Generating scheduled session…",
+            lambda: self.controller.generate_schedule(
+                path,
+                self.schedule_outfile.get(),
+                self._optional_float(self.schedule_duration),
+            ),
+        )
+
+    def run_loaded_drg(self):
+        if self.loaded_drg is None:
+            self._finish_error("Load an I-Doser file first")
+            return
+        tone_sets, schedule = self.loaded_drg
+        self._run_background(
+            "Generating loaded I-Doser session…",
+            lambda: self.controller.generate_loaded_schedule(
+                tone_sets,
+                schedule,
+                self.schedule_outfile.get(),
+                self._optional_float(self.schedule_duration),
+            ),
+        )
 
     def open_drg_file(self):
-        from tkinter import filedialog
-        filepath = filedialog.askopenfilename(
+        path = filedialog.askopenfilename(
             title="Select an I-Doser file",
-            filetypes=(("I-Doser files", "*.drg"), ("All files", "*.*"))
+            filetypes=(("I-Doser files", "*.drg"), ("All files", "*.*")),
         )
-        if not filepath:
+        if not path:
             return
-
         try:
-            sbg_string, image_data = drg_decoder.decode_drg(filepath)
-            tones, sched = parse_sbg_from_string(sbg_string)
-
+            sbg_source, image_data = drg_decoder.decode_drg(path)
+            self.loaded_drg = parse_sbg_from_string(sbg_source, base_dir=Path(path).parent)
+            self.generate_drg_button.config(state="normal")
+            self.drg_label.config(text=f"Loaded: {Path(path).name}")
             if image_data:
                 image = Image.open(io.BytesIO(image_data))
-                photo = ImageTk.PhotoImage(image)
-                self.image_label.config(image=photo)
-                self.image_label.image = photo # Keep a reference
-            else:
-                self.image_label.config(image="")
-                self.image_label.image = None
-
-            # For now, just print the parsed data
-            print("Successfully parsed .drg file:")
-            print("Tones:", tones)
-            print("Schedule:", sched)
-            self.status.set(f"Successfully parsed {filepath}")
-        except Exception as e:
-            self.status.set(f"Error parsing .drg file: {e}")
-            messagebox.showerror("Error", f"Could not parse .drg file: {e}")
+                image.thumbnail((320, 240))
+                self.drg_photo = ImageTk.PhotoImage(image)
+                self.drg_image_label.config(image=self.drg_photo)
+            self.status.set(f"Loaded I-Doser schedule: {Path(path).name}")
+        except Exception as exc:
+            self._finish_error(f"Could not decode I-Doser file: {exc}")
 
     def add_tone_generator(self):
-        frame = ttk.Frame(self.tone_frame, padding=5, relief="groove", borderwidth=2)
-        frame.pack(fill="x", pady=5)
+        row = ttk.LabelFrame(self.tone_rows, text=f"Tone {len(self.tone_generators) + 1}", padding=6)
+        row.pack(fill="x", pady=3)
+        frequency = self._entry(row, "Frequency (Hz)", "200")
+        amplitude = self._entry(row, "Amplitude (%)", "50")
+        waveform = tk.StringVar(value="sine")
+        selector = ttk.Combobox(
+            row,
+            textvariable=waveform,
+            values=("sine", "square", "triangle", "sawtooth"),
+            state="readonly",
+        )
+        selector.pack(anchor="w", padx=24, pady=2)
+        record = {"frame": row, "freq": frequency, "amp": amplitude, "waveform": waveform}
+        ttk.Button(row, text="Remove", command=lambda: self.remove_tone_generator(record)).pack(anchor="e")
+        self.tone_generators.append(record)
 
-        tone_num = len(self.tone_generators) + 1
-        label = ttk.Label(frame, text=f"Tone {tone_num}")
-        label.pack()
+    def remove_tone_generator(self, record):
+        record["frame"].destroy()
+        self.tone_generators.remove(record)
 
-        freq_slider = tk.Scale(frame, from_=20, to=1000, orient="horizontal", label="Frequency (Hz)")
-        freq_slider.set(200)
-        freq_slider.pack(fill="x")
-
-        amp_slider = tk.Scale(frame, from_=0, to=100, orient="horizontal", label="Amplitude (%)")
-        amp_slider.set(50)
-        amp_slider.pack(fill="x")
-
-        waveform = tk.StringVar(frame)
-        waveform.set("sine")
-        waveform_menu = ttk.OptionMenu(frame, waveform, "sine", "square", "triangle", "sawtooth")
-        waveform_menu.pack()
-
-        remove_button = ttk.Button(frame, text="Remove", command=lambda: self.remove_tone_generator(frame))
-        remove_button.pack()
-
-        self.tone_generators.append({
-            "frame": frame,
-            "freq": freq_slider,
-            "amp": amp_slider,
-            "waveform": waveform
-        })
-
-    def run_generate_tones(self):
-        self.status.set("Generating tones...")
-
-        specs = []
-        for gen in self.tone_generators:
-            spec = {
-                "freq": gen["freq"].get(),
-                "amp": gen["amp"].get(),
-                "waveform": gen["waveform"].get()
+    def _tone_specs(self):
+        return [
+            {
+                "freq": float(item["freq"].get()),
+                "amp": float(item["amp"].get()),
+                "waveform": item["waveform"].get(),
             }
-            specs.append(spec)
+            for item in self.tone_generators
+        ]
 
+    def run_tones(self):
+        specs = self._tone_specs()
         if not specs:
-            self.status.set("No tones to generate.")
+            self._finish_error("Add at least one tone")
             return
+        soundscape = self.soundscape_file.get().strip() or None
+        self._run_background(
+            "Generating tone-builder session…",
+            lambda: self.controller.generate_tones(
+                specs,
+                float(self.tone_duration.get()),
+                self.tone_outfile.get(),
+                soundscape,
+                float(self.soundscape_amp.get()),
+            ),
+        )
 
-        thread = threading.Thread(target=self._generate_tones_thread, args=(specs,))
-        thread.daemon = True
-        thread.start()
+    def preview_tones(self):
+        specs = [
+            GenericToneSpec(
+                freq=float(item["freq"].get()),
+                amp=float(item["amp"].get()),
+                waveform=item["waveform"].get(),
+            )
+            for item in self.tone_generators
+        ]
+        soundscape = self.soundscape_file.get().strip()
+        if soundscape:
+            specs.append(FileSpec(path=soundscape, amp=float(self.soundscape_amp.get()), loop=True))
+        self._preview(specs, float(self.tone_duration.get()))
 
-    def _generate_tones_thread(self, specs):
-        # This is a simplified version of the viz thread for now
-        # It just plays the audio without visualization
-        p = pyaudio.PyAudio()
-        stream = p.open(format=pyaudio.paFloat32,
-                        channels=2,
-                        rate=44100, # Use constant
-                        output=True)
+    def draw_pattern(self):
+        frequency = float(self.visual_frequency.get())
+        n, m = viz.map_freq_to_params(frequency)
+        figure = viz.generate_chladni_pattern(n, m)
+        if self.pattern_canvas is not None:
+            self.pattern_canvas.get_tk_widget().destroy()
+        self.pattern_canvas = FigureCanvasTkAgg(figure, master=self.pattern_host)
+        self.pattern_canvas.draw()
+        self.pattern_canvas.get_tk_widget().pack(fill="both", expand=True)
+        self.status.set(f"Pattern ({n}, {m}) for {frequency:g} Hz")
 
-        try:
-            # Duration is fixed for now
-            duration = 10
-            generator = self.controller.generate_tones(specs, duration)
+    def preview_visualization(self):
+        self.draw_pattern()
+        spec = IsochronicSpec(freq=float(self.visual_frequency.get()), beat=float(self.visual_beat.get()))
+        self._preview([spec], float(self.visual_duration.get()))
 
-            soundscape_path = self.soundscape_file.get()
-            if soundscape_path and soundscape_path != "No file selected.":
-                soundscape_amp = self.soundscape_amp.get()
-                soundscape_spec = pysbagen.generators.file.FileSpec(soundscape_path, soundscape_amp)
-                soundscape_gen = soundscape_spec.generator(duration, loop=True)
+    def _preview(self, specs, duration: float):
+        self.status.set("Playing preview…")
 
-                for chunk, info in generator:
-                    soundscape_chunk, _ = next(soundscape_gen)
-                    mixed_chunk = chunk + soundscape_chunk
-                    stream.write(mixed_chunk.astype(np.float32).tobytes())
+        def worker():
+            try:
+                self.controller.playback(specs, duration)
+            except Exception as exc:
+                self.root.after(0, self._finish_error, str(exc))
             else:
-                for chunk, info in generator:
-                    stream.write(chunk.astype(np.float32).tobytes())
+                self.root.after(0, self.status.set, "Preview complete")
 
-            self.status.set("Tone generation complete.")
-        except Exception as e:
-            self.status.set(f"Error: {e}")
-            print(f"Error in tone generation thread: {e}")
-        finally:
-            stream.stop_stream()
-            stream.close()
-            p.terminate()
+        threading.Thread(target=worker, daemon=True).start()
 
-    def remove_tone_generator(self, frame):
-        for i, gen in enumerate(self.tone_generators):
-            if gen["frame"] == frame:
-                gen["frame"].destroy()
-                self.tone_generators.pop(i)
-                break
 
-    def run_generate_from_schedule(self):
-        filepath = self.schedule_file.get()
-        if not filepath or filepath == "No file selected.":
-            messagebox.showwarning("Warning", "Please select a schedule file first.")
-            return
-
-        self.status.set("Generating from schedule...")
-        params = {
-            "schedule": filepath,
-            "outfile": self.outfile.get(),
-            # Duration is typically determined by the schedule itself
-        }
-        result = self.controller.generate(params)
-        self.status.set(result)
-        if "Error" in result:
-            messagebox.showerror("Error", result)
-        else:
-            messagebox.showinfo("Success", result)
+def main():
+    root = tk.Tk()
+    SbagenGui(root)
+    root.mainloop()
 
 
 if __name__ == "__main__":
-    root = tk.Tk()
-    app = SbagenGui(root)
-    root.mainloop()
+    main()

--- a/gui_safe.py
+++ b/gui_safe.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import threading
+import tkinter as tk
+from pathlib import Path
+from tkinter import messagebox
+
+import matplotlib.pyplot as plt
+
+import gui as legacy
+from pysbagen.generators import FileSpec, GenericToneSpec
+
+
+class SafeSbagenGui(legacy.SbagenGui):
+    """Canonical advanced studio wrapper with single-job and Tk-thread safety."""
+
+    def __init__(self, root: tk.Tk):
+        super().__init__(root)
+        self._generation_running = False
+        self._preview_running = False
+        self.root.title("pysbagen Advanced Studio")
+
+    def _set_generation_running(self, running: bool) -> None:
+        self._generation_running = running
+        state = "disabled" if running else "normal"
+        for child in self.notebook.winfo_children():
+            for widget in child.winfo_children():
+                if isinstance(widget, legacy.ttk.Button):
+                    try:
+                        widget.configure(state=state)
+                    except tk.TclError:
+                        pass
+        if self.loaded_drg is None:
+            self.generate_drg_button.configure(state="disabled")
+
+    def _run_background(self, working_message: str, job):
+        if self._generation_running:
+            self._finish_error("An export is already running")
+            return
+        self._set_generation_running(True)
+        self.status.set(working_message)
+
+        def worker():
+            try:
+                result = job()
+            except Exception as exc:
+                self.root.after(0, self._background_failed, str(exc))
+            else:
+                self.root.after(0, self._background_succeeded, result)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _background_succeeded(self, result):
+        self._set_generation_running(False)
+        self._finish_success(result)
+
+    def _background_failed(self, message: str):
+        self._set_generation_running(False)
+        self._finish_error(message)
+
+    def run_quick(self):
+        try:
+            params = {
+                "base": float(self.quick_base.get()),
+                "beat": float(self.quick_beat.get()),
+                "duration": float(self.quick_duration.get()),
+                "outfile": self.quick_outfile.get(),
+            }
+        except ValueError as exc:
+            self._finish_error(f"Invalid quick-session value: {exc}")
+            return
+        self._run_background(
+            "Generating binaural session…",
+            lambda: self.controller.generate_quick(params),
+        )
+
+    def run_advanced(self):
+        try:
+            params = self._advanced_params()
+        except ValueError as exc:
+            self._finish_error(f"Invalid advanced-session value: {exc}")
+            return
+        self._run_background(
+            "Generating advanced session…",
+            lambda: self.controller.generate_quick(params),
+        )
+
+    def run_schedule(self):
+        path = self.schedule_file.get().strip()
+        if not path:
+            self._finish_error("Select an SBG schedule first")
+            return
+        try:
+            outfile = self.schedule_outfile.get()
+            duration = self._optional_float(self.schedule_duration)
+        except ValueError as exc:
+            self._finish_error(f"Invalid schedule duration: {exc}")
+            return
+        self._run_background(
+            "Generating scheduled session…",
+            lambda: self.controller.generate_schedule(path, outfile, duration),
+        )
+
+    def run_loaded_drg(self):
+        if self.loaded_drg is None:
+            self._finish_error,"Load an I-Doser file first"
+            return
+        tone_sets, schedule = self.loaded_drg
+        try:
+            outfile = self.schedule_outfile.get()
+            duration = self._optional_float(self.schedule_duration)
+        except ValueError as exc:
+            self._finish_error(f"Invalid schedule duration: {exc}")
+            return
+        self._run_background(
+            "Generating loaded I-Doser session…",
+            lambda: self.controller.generate_loaded_schedule(
+                tone_sets, schedule, outfile, duration
+            ),
+        )
+
+    def run_tones(self):
+        try:
+            specs = self._tone_specs()
+            duration = float(self.tone_duration.get())
+            outfile = self.tone_outfile.get()
+            soundscape = self.soundscape_file.get().strip() or None
+            soundscape_amp = float(self.soundscape_amp.get())
+        except ValueError as exc:
+            self._finish_error(f"Invalid tone-builder value: {exc}")
+            return
+        if not specs:
+            self._finish_error("Add at least one tone")
+            return
+        self._run_background(
+            "Generating tone-builder session…",
+            lambda: self.controller.generate_tones(
+                specs, duration, outfile, soundscape, soundscape_amp
+            ),
+        )
+
+    def preview_tones(self):
+        try:
+            specs = [
+                GenericToneSpec(
+                    freq=float(item["freq"].get()),
+                    amp=float(item["amp"].get()),
+                    waveform=item["waveform"].get(),
+                )
+                for item in self.tone_generators
+            ]
+            soundscape = self.soundscape_file.get().strip()
+            if soundscape:
+                specs.append(
+                    FileSpec(
+                        path=soundscape,
+                        amp=float(self.soundscape_amp.get()),
+                        loop=True,
+                    )
+                )
+            duration = float(self.tone_duration.get())
+        except ValueError as exc:
+            self._finish_error(f"Invalid preview value: {exc}")
+            return
+        self._preview(specs, duration)
+
+    def draw_pattern(self):
+        try:
+            frequency = float(self.visual_frequency.get())
+        except ValueError as exc:
+            self._finish_error(f"Invalid visualization frequency: {exc}")
+            return
+        n, m = legacy.viz.map_freq_to_params(frequency)
+        figure = legacy.viz.generate_chladni_pattern(n, m)
+        if self.pattern_canvas is not None:
+            old_figure = self.pattern_canvas.figure
+            self.pattern_canvas.get_tk_widget().destroy()
+            plt.close(old_figure)
+        self.pattern_canvas = legacy.FigureCanvasTkAgg(figure, master=self.pattern_host)
+        self.pattern_canvas.draw()
+        self.pattern_canvas.get_tk_widget().pack(fill="both", expand=True)
+        self.status.set(f"Pattern ({n}, {m}) for {frequency:g} Hz")
+
+    def _preview(self, specs, duration: float):
+        if self._preview_running:
+            self._finish_error("A preview is already playing")
+            return
+        self._preview_running = True
+        self.status.set("Playing preview…")
+
+        def finish(message: str, error: bool = False):
+            self._preview_running = False
+            self.status.set(message)
+            if error:
+                messagebox.showerror("pysbagen", message)
+
+        def worker():
+            try:
+                self.controller.playback(specs, duration)
+            except Exception as exc:
+                self.root.after(0, finish, f"Preview error: {exc}", True)
+            else:
+                self.root.after(0, finish, "Preview complete")
+
+        threading.Thread(target=worker, daemon=True).start()
+
+
+def main():
+    root = tk.Tk()
+    SafeSbagenGui(root)
+    root.mainloop()
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysbagen"
-version = "0.2.0"
-description = "Modern Python reimplementation of SBaGen with plugin generators"
+version = "0.3.0"
+description = "Layered sleep-audio guide and modern SBaGen-compatible session studio"
 readme = "README.md"
 license = {text = "GPL-2.0-only"}
 authors = [{name="Justin (acrinym)"}]
@@ -23,12 +23,14 @@ gui = ["matplotlib>=3.8", "pillow>=10", "pyaudio>=0.2.14"]
 [project.scripts]
 sbgpy = "pysbagen.cli:main"
 sbgpy-gui = "gui:main"
+sbgpy-sleep = "pysbagen.sleep_cli:main"
+sbgpy-sleep-gui = "sleep_gui:main"
 
 [project.entry-points."pysbagen.generators"]
 # Third parties can register generator plugins in this group.
 
 [tool.setuptools]
-py-modules = ["gui", "visualization", "drg_decoder"]
+py-modules = ["gui", "sleep_gui", "visualization", "drg_decoder"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ requires-python = ">=3.10"
 dependencies = [
   "numpy>=1.26",
   "soundfile>=0.12",
-  "pydub>=0.25",
   "scipy>=1.13"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysbagen"
-version = "0.1.0"
+version = "0.2.0"
 description = "Modern Python reimplementation of SBaGen with plugin generators"
 readme = "README.md"
 license = {text = "GPL-2.0-only"}
@@ -14,11 +14,28 @@ dependencies = [
   "numpy>=1.26",
   "soundfile>=0.12",
   "pydub>=0.25",
-  "scipy>=1.13"      # for resampling & pink noise filter
+  "scipy>=1.13"
 ]
+
+[project.optional-dependencies]
+dev = ["pytest>=8", "build>=1.2"]
+gui = ["matplotlib>=3.8", "pillow>=10", "pyaudio>=0.2.14"]
 
 [project.scripts]
 sbgpy = "pysbagen.cli:main"
+sbgpy-gui = "gui:main"
 
 [project.entry-points."pysbagen.generators"]
-# third-parties can add theirs here by defining the same group
+# Third parties can register generator plugins in this group.
+
+[tool.setuptools]
+py-modules = ["gui", "visualization", "drg_decoder"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["pysbagen", "pysbagen.*"]
+exclude = ["pysbagen.src", "pysbagen.src.*", "pysbagen.tests", "pysbagen.tests.*"]
+
+[tool.pytest.ini_options]
+testpaths = ["pysbagen/tests"]
+addopts = "-q"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,13 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=8", "build>=1.2"]
-gui = ["matplotlib>=3.8", "pillow>=10", "pyaudio>=0.2.14"]
+gui = ["matplotlib>=3.8", "pillow>=10"]
+playback = ["pyaudio>=0.2.14"]
+desktop = ["matplotlib>=3.8", "pillow>=10", "pyaudio>=0.2.14"]
 
 [project.scripts]
 sbgpy = "pysbagen.cli:main"
-sbgpy-gui = "gui:main"
+sbgpy-gui = "gui_safe:main"
 sbgpy-sleep = "pysbagen.sleep_cli:main"
 sbgpy-sleep-gui = "sleep_gui:main"
 
@@ -30,7 +32,7 @@ sbgpy-sleep-gui = "sleep_gui:main"
 # Third parties can register generator plugins in this group.
 
 [tool.setuptools]
-py-modules = ["gui", "sleep_gui", "visualization", "drg_decoder"]
+py-modules = ["gui", "gui_safe", "sleep_gui", "visualization", "drg_decoder"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pysbagen/__init__.py
+++ b/pysbagen/__init__.py
@@ -1,6 +1,17 @@
 """pysbagen public package."""
 
-from .api import RenderResult, render_schedule, render_specs, write_audio
+from .api import RenderResult, render_schedule, render_sleep, render_specs, write_audio
+from .sleep import SleepLayers, SleepRecipe, SleepRequest, build_sleep_recipe
 
-__all__ = ["RenderResult", "render_schedule", "render_specs", "write_audio"]
-__version__ = "0.2.0"
+__all__ = [
+    "RenderResult",
+    "SleepLayers",
+    "SleepRecipe",
+    "SleepRequest",
+    "build_sleep_recipe",
+    "render_schedule",
+    "render_sleep",
+    "render_specs",
+    "write_audio",
+]
+__version__ = "0.3.0"

--- a/pysbagen/__init__.py
+++ b/pysbagen/__init__.py
@@ -1,0 +1,6 @@
+"""pysbagen public package."""
+
+from .api import RenderResult, render_schedule, render_specs, write_audio
+
+__all__ = ["RenderResult", "render_schedule", "render_specs", "write_audio"]
+__version__ = "0.2.0"

--- a/pysbagen/api.py
+++ b/pysbagen/api.py
@@ -10,6 +10,7 @@ import soundfile as sf
 from .generators import FileSpec, HarmonicBoxSpec, IsochronicSpec, NoiseSpec, ToneSpec
 from .mixer import SR, build_session_generator, mix_generators
 from .parser import parse_sbg
+from .sleep import SleepRequest, build_sleep_spec
 
 
 @dataclass(frozen=True)
@@ -31,6 +32,10 @@ def render_specs(specs: Iterable, duration: float):
 def render_schedule(path: str | Path, duration: float | None = None):
     tone_sets, schedule = parse_sbg(path)
     return build_session_generator(tone_sets, schedule, duration)
+
+
+def render_sleep(request: SleepRequest):
+    return render_specs([build_sleep_spec(request)], request.duration_seconds)
 
 
 def build_quick_specs(

--- a/pysbagen/api.py
+++ b/pysbagen/api.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator
+
+import numpy as np
+import soundfile as sf
+
+from .generators import FileSpec, HarmonicBoxSpec, IsochronicSpec, NoiseSpec, ToneSpec
+from .mixer import SR, build_session_generator, mix_generators
+from .parser import parse_sbg
+
+
+@dataclass(frozen=True)
+class RenderResult:
+    outfile: Path
+    frames: int
+    sample_rate: int
+    peak: float
+
+    @property
+    def duration(self) -> float:
+        return self.frames / self.sample_rate
+
+
+def render_specs(specs: Iterable, duration: float):
+    return mix_generators(specs, duration)
+
+
+def render_schedule(path: str | Path, duration: float | None = None):
+    tone_sets, schedule = parse_sbg(path)
+    return build_session_generator(tone_sets, schedule, duration)
+
+
+def build_quick_specs(
+    *,
+    base: float | None = None,
+    beat: float | None = None,
+    isochronic: tuple[float, float] | None = None,
+    harmonic_box: tuple[float, float, float] | None = None,
+    noise: float | None = None,
+    noise_kind: str = "white",
+    music: str | None = None,
+    music_amp: float = 100.0,
+    loop_music: bool = False,
+):
+    if (base is None) != (beat is None):
+        raise ValueError("base and beat must be supplied together")
+
+    specs = []
+    if base is not None and beat is not None:
+        specs.append(ToneSpec(base=float(base), beat=float(beat)))
+    if isochronic is not None:
+        specs.append(IsochronicSpec(freq=float(isochronic[0]), beat=float(isochronic[1])))
+    if harmonic_box is not None:
+        specs.append(
+            HarmonicBoxSpec(
+                base=float(harmonic_box[0]),
+                diff=float(harmonic_box[1]),
+                mod=float(harmonic_box[2]),
+            )
+        )
+    if noise is not None:
+        specs.append(NoiseSpec(amp=float(noise), kind=noise_kind))
+    if music:
+        specs.append(FileSpec(path=music, amp=float(music_amp), loop=loop_music))
+    if not specs:
+        raise ValueError("At least one generator must be selected")
+    return specs
+
+
+def write_audio(
+    chunks: Iterator[tuple[np.ndarray, list[dict]]],
+    outfile: str | Path,
+    sample_rate: int = SR,
+) -> RenderResult:
+    path = Path(outfile).expanduser()
+    if path.parent != Path("."):
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+    frames = 0
+    peak = 0.0
+    with sf.SoundFile(path, mode="w", samplerate=sample_rate, channels=2) as output:
+        for chunk, _ in chunks:
+            normalized = np.asarray(chunk, dtype=np.float32)
+            if normalized.ndim != 2 or normalized.shape[1] != 2:
+                raise ValueError(f"Writer expected stereo chunks, got {normalized.shape}")
+            output.write(normalized)
+            frames += len(normalized)
+            if len(normalized):
+                peak = max(peak, float(np.max(np.abs(normalized))))
+
+    if frames == 0:
+        path.unlink(missing_ok=True)
+        raise ValueError("No audio was generated")
+    return RenderResult(path.resolve(), frames, sample_rate, peak)

--- a/pysbagen/api.py
+++ b/pysbagen/api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Iterator
@@ -80,23 +82,44 @@ def write_audio(
     outfile: str | Path,
     sample_rate: int = SR,
 ) -> RenderResult:
+    """Write atomically so a failed render never destroys an existing destination."""
     path = Path(outfile).expanduser()
     if path.parent != Path("."):
         path.parent.mkdir(parents=True, exist_ok=True)
+    parent = path.parent if path.parent != Path("") else Path(".")
+    suffix = path.suffix or ".wav"
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.stem or 'pysbagen'}-",
+        suffix=f".tmp{suffix}",
+        dir=parent,
+    )
+    os.close(descriptor)
+    temporary_path = Path(temporary_name)
 
     frames = 0
     peak = 0.0
-    with sf.SoundFile(path, mode="w", samplerate=sample_rate, channels=2) as output:
-        for chunk, _ in chunks:
-            normalized = np.asarray(chunk, dtype=np.float32)
-            if normalized.ndim != 2 or normalized.shape[1] != 2:
-                raise ValueError(f"Writer expected stereo chunks, got {normalized.shape}")
-            output.write(normalized)
-            frames += len(normalized)
-            if len(normalized):
-                peak = max(peak, float(np.max(np.abs(normalized))))
+    try:
+        with sf.SoundFile(
+            temporary_path,
+            mode="w",
+            samplerate=sample_rate,
+            channels=2,
+            format="WAV" if not path.suffix else None,
+        ) as output:
+            for chunk, _ in chunks:
+                normalized = np.asarray(chunk, dtype=np.float32)
+                if normalized.ndim != 2 or normalized.shape[1] != 2:
+                    raise ValueError(f"Writer expected stereo chunks, got {normalized.shape}")
+                output.write(normalized)
+                frames += len(normalized)
+                if len(normalized):
+                    peak = max(peak, float(np.max(np.abs(normalized))))
 
-    if frames == 0:
-        path.unlink(missing_ok=True)
-        raise ValueError("No audio was generated")
+        if frames == 0:
+            raise ValueError("No audio was generated")
+        os.replace(temporary_path, path)
+    except Exception:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
     return RenderResult(path.resolve(), frames, sample_rate, peak)

--- a/pysbagen/cli.py
+++ b/pysbagen/cli.py
@@ -1,59 +1,57 @@
-import argparse, os, numpy as np, soundfile as sf
-from .parser import parse_sbg
-from .mixer import build_session_generator
-from .generators.binaural import ToneSpec
-from .generators.noise import NoiseSpec
-from .generators.file import FileSpec
-from .generators.isochronic import IsochronicSpec
-from .generators.harmonic_box import HarmonicBoxSpec
+from __future__ import annotations
 
-SR = 44100
+import argparse
 
-def main():
-    p = argparse.ArgumentParser(description="SBaGen-compatible generator (Python)")
-    p.add_argument("schedule", nargs="?", help=".sbg schedule file")
-    p.add_argument("-o","--outfile", required=True)
-    p.add_argument("-d","--duration", type=float)
-    p.add_argument("--base", type=float)
-    p.add_argument("--beat", type=float)
-    p.add_argument("--noise", type=float, metavar="AMP")
-    p.add_argument("--noise-kind", default="white", choices=["white","pink"])
-    p.add_argument("--isochronic", nargs=2, metavar=("FREQ","BEAT"), type=float)
-    p.add_argument("--harmonic-box", nargs=3, metavar=("BASE","DIFF","MOD"), type=float)
-    p.add_argument("--music", help="Background file")
-    p.add_argument("--music-amp", type=float, default=100.0)
-    args = p.parse_args()
+from .api import build_quick_specs, render_schedule, render_specs, write_audio
 
-    if args.schedule:
-        tones, sched = parse_sbg(args.schedule)
-        gen = build_session_generator(tones, sched, args.duration)
-    else:
-        if args.duration is None:
-            p.error("--duration is required without a schedule")
-        gens = []
-        if args.base is not None and args.beat is not None:
-            gens.append(ToneSpec(base=args.base, beat=args.beat, amp=100.0))
-        if args.isochronic is not None:
-            gens.append(IsochronicSpec(freq=args.isochronic[0], beat=args.isochronic[1], amp=100.0))
-        if args.harmonic_box is not None:
-            gens.append(HarmonicBoxSpec(base=args.harmonic_box[0], diff=args.harmonic_box[1], mod=args.harmonic_box[2], amp=100.0))
-        if args.noise is not None:
-            gens.append(NoiseSpec(amp=args.noise, kind=args.noise_kind))
-        if args.music:
-            gens.append(FileSpec(path=args.music, amp=args.music_amp))
-        if not gens:
-            p.error("No generators specified.")
-        from .mixer import mix_generators
-        gen = mix_generators(gens, args.duration)
 
-    # stream -> buffer -> write
-    chunks = [c for c,_ in gen]
-    if not chunks:
-        print("No audio generated.")
-        return
-    audio = np.vstack(chunks)
-    peak = np.max(np.abs(audio))
-    if peak > 1.0:
-        audio /= peak
-    sf.write(args.outfile, audio, SR)
-    print(f"Wrote {len(audio)/SR:.2f}s to {args.outfile}")
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="SBaGen-compatible generator (Python)")
+    parser.add_argument("schedule", nargs="?", help=".sbg schedule file")
+    parser.add_argument("-o", "--outfile", required=True)
+    parser.add_argument("-d", "--duration", type=float)
+    parser.add_argument("--base", type=float)
+    parser.add_argument("--beat", type=float)
+    parser.add_argument("--noise", type=float, metavar="AMP")
+    parser.add_argument("--noise-kind", default="white", choices=["white", "pink"])
+    parser.add_argument("--isochronic", nargs=2, metavar=("FREQ", "BEAT"), type=float)
+    parser.add_argument("--harmonic-box", nargs=3, metavar=("BASE", "DIFF", "MOD"), type=float)
+    parser.add_argument("--music", help="Background audio file")
+    parser.add_argument("--music-amp", type=float, default=100.0)
+    parser.add_argument("--loop-music", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.schedule:
+            chunks = render_schedule(args.schedule, args.duration)
+        else:
+            if args.duration is None or args.duration <= 0:
+                parser.error("--duration must be positive without a schedule")
+            specs = build_quick_specs(
+                base=args.base,
+                beat=args.beat,
+                isochronic=tuple(args.isochronic) if args.isochronic else None,
+                harmonic_box=tuple(args.harmonic_box) if args.harmonic_box else None,
+                noise=args.noise,
+                noise_kind=args.noise_kind,
+                music=args.music,
+                music_amp=args.music_amp,
+                loop_music=args.loop_music,
+            )
+            chunks = render_specs(specs, args.duration)
+
+        result = write_audio(chunks, args.outfile)
+    except (OSError, ValueError) as exc:
+        parser.error(str(exc))
+
+    print(f"Wrote {result.duration:.2f}s to {result.outfile}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pysbagen/generators/__init__.py
+++ b/pysbagen/generators/__init__.py
@@ -1,15 +1,18 @@
 from .binaural import ToneSpec
 from .noise import NoiseSpec
-from .file import FileSpec
+from .file import FileSpec, load_audio
 from .isochronic import IsochronicSpec
 from .harmonic_box import HarmonicBoxSpec
 from .generic import GenericToneSpec
+from .sleep import SleepJourneySpec
 
 __all__ = [
     "ToneSpec",
     "NoiseSpec",
     "FileSpec",
+    "load_audio",
     "IsochronicSpec",
     "HarmonicBoxSpec",
-    "GenericToneSpec"
+    "GenericToneSpec",
+    "SleepJourneySpec",
 ]

--- a/pysbagen/generators/file.py
+++ b/pysbagen/generators/file.py
@@ -11,68 +11,72 @@ from scipy.signal import resample_poly
 from .base import GenBase
 
 
+def _decode_with_ffmpeg(path: Path, sample_rate: int) -> np.ndarray:
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError(
+            f"Decoding {path.suffix or 'this audio format'} requires FFmpeg to be installed and available on PATH"
+        )
+    command = [
+        ffmpeg,
+        "-v", "error",
+        "-i", str(path),
+        "-f", "f32le",
+        "-acodec", "pcm_f32le",
+        "-ac", "2",
+        "-ar", str(sample_rate),
+        "pipe:1",
+    ]
+    result = subprocess.run(command, capture_output=True, check=False)
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise ValueError(f"FFmpeg could not decode {path.name}: {detail or 'unknown error'}")
+    samples = np.frombuffer(result.stdout, dtype="<f4")
+    if samples.size % 2:
+        raise ValueError(f"FFmpeg returned malformed stereo audio for {path.name}")
+    return samples.reshape((-1, 2)).copy()
+
+
+def _stereo_data(data: np.ndarray) -> np.ndarray:
+    if data.ndim == 1:
+        data = data[:, None]
+    if data.ndim != 2:
+        raise ValueError(f"Audio data must be one- or two-dimensional, got {data.shape}")
+    if data.shape[1] == 1:
+        return np.repeat(data, 2, axis=1)
+    return data[:, :2]
+
+
+def load_audio(path_value: str | Path, sample_rate: int = 44100) -> np.ndarray:
+    """Load any audio format supported by SoundFile or the local FFmpeg installation."""
+    path = Path(path_value).expanduser()
+    if not path.is_file():
+        raise FileNotFoundError(f"Audio file not found: {path}")
+
+    try:
+        data, rate = sf.read(path, dtype="float32", always_2d=True)
+    except (RuntimeError, TypeError, ValueError):
+        return _decode_with_ffmpeg(path, sample_rate)
+
+    data = _stereo_data(data)
+    if rate != sample_rate:
+        factor = gcd(rate, sample_rate)
+        data = resample_poly(
+            data,
+            sample_rate // factor,
+            rate // factor,
+            axis=0,
+        ).astype(np.float32)
+    return data.astype(np.float32, copy=False)
+
+
 @dataclass
 class FileSpec(GenBase):
     path: str = ""
     loop: bool = False
 
-    def _load_mp3(self, path: Path) -> np.ndarray:
-        ffmpeg = shutil.which("ffmpeg")
-        if ffmpeg is None:
-            raise RuntimeError("MP3 decoding requires FFmpeg to be installed and available on PATH")
-
-        command = [
-            ffmpeg,
-            "-v",
-            "error",
-            "-i",
-            str(path),
-            "-f",
-            "f32le",
-            "-acodec",
-            "pcm_f32le",
-            "-ac",
-            "2",
-            "-ar",
-            str(self.sample_rate),
-            "pipe:1",
-        ]
-        result = subprocess.run(command, capture_output=True, check=False)
-        if result.returncode != 0:
-            detail = result.stderr.decode("utf-8", errors="replace").strip()
-            raise ValueError(f"FFmpeg could not decode {path.name}: {detail or 'unknown error'}")
-
-        samples = np.frombuffer(result.stdout, dtype="<f4")
-        if samples.size % 2:
-            raise ValueError(f"FFmpeg returned malformed stereo audio for {path.name}")
-        return samples.reshape((-1, 2)).copy()
-
-    @staticmethod
-    def _stereo_data(data: np.ndarray) -> np.ndarray:
-        if data.ndim == 1:
-            data = data[:, None]
-        if data.shape[1] == 1:
-            return np.repeat(data, 2, axis=1)
-        return data[:, :2]
-
     def _load(self) -> np.ndarray:
-        path = Path(self.path).expanduser()
-        if not path.is_file():
-            raise FileNotFoundError(f"Audio file not found: {path}")
-        if path.suffix.lower() == ".mp3":
-            return self._load_mp3(path)
-
-        data, rate = sf.read(path, dtype="float32", always_2d=True)
-        data = self._stereo_data(data)
-        if rate != self.sample_rate:
-            factor = gcd(rate, self.sample_rate)
-            data = resample_poly(
-                data,
-                self.sample_rate // factor,
-                rate // factor,
-                axis=0,
-            ).astype(np.float32)
-        return data
+        return load_audio(self.path, self.sample_rate)
 
     def generator(self, duration: float):
         data = self._load()

--- a/pysbagen/generators/file.py
+++ b/pysbagen/generators/file.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
 from math import gcd
 from pathlib import Path
+import shutil
+import subprocess
 
 import numpy as np
 import soundfile as sf
-from pydub import AudioSegment
 from scipy.signal import resample_poly
 
 from .base import GenBase
@@ -16,12 +17,35 @@ class FileSpec(GenBase):
     loop: bool = False
 
     def _load_mp3(self, path: Path) -> np.ndarray:
-        segment = AudioSegment.from_mp3(path)
-        segment = segment.set_frame_rate(self.sample_rate).set_channels(2)
-        raw = np.asarray(segment.get_array_of_samples())
-        data = raw.reshape((-1, 2)).astype(np.float32)
-        scale = float(1 << (8 * segment.sample_width - 1))
-        return data / scale
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg is None:
+            raise RuntimeError("MP3 decoding requires FFmpeg to be installed and available on PATH")
+
+        command = [
+            ffmpeg,
+            "-v",
+            "error",
+            "-i",
+            str(path),
+            "-f",
+            "f32le",
+            "-acodec",
+            "pcm_f32le",
+            "-ac",
+            "2",
+            "-ar",
+            str(self.sample_rate),
+            "pipe:1",
+        ]
+        result = subprocess.run(command, capture_output=True, check=False)
+        if result.returncode != 0:
+            detail = result.stderr.decode("utf-8", errors="replace").strip()
+            raise ValueError(f"FFmpeg could not decode {path.name}: {detail or 'unknown error'}")
+
+        samples = np.frombuffer(result.stdout, dtype="<f4")
+        if samples.size % 2:
+            raise ValueError(f"FFmpeg returned malformed stereo audio for {path.name}")
+        return samples.reshape((-1, 2)).copy()
 
     @staticmethod
     def _stereo_data(data: np.ndarray) -> np.ndarray:

--- a/pysbagen/generators/file.py
+++ b/pysbagen/generators/file.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from math import gcd
 from pathlib import Path
+from typing import Iterator
 import shutil
 import subprocess
 
@@ -11,13 +14,13 @@ from scipy.signal import resample_poly
 from .base import GenBase
 
 
-def _decode_with_ffmpeg(path: Path, sample_rate: int) -> np.ndarray:
+def _ffmpeg_command(path: Path, sample_rate: int) -> list[str]:
     ffmpeg = shutil.which("ffmpeg")
     if ffmpeg is None:
         raise RuntimeError(
             f"Decoding {path.suffix or 'this audio format'} requires FFmpeg to be installed and available on PATH"
         )
-    command = [
+    return [
         ffmpeg,
         "-v", "error",
         "-i", str(path),
@@ -27,7 +30,10 @@ def _decode_with_ffmpeg(path: Path, sample_rate: int) -> np.ndarray:
         "-ar", str(sample_rate),
         "pipe:1",
     ]
-    result = subprocess.run(command, capture_output=True, check=False)
+
+
+def _decode_with_ffmpeg(path: Path, sample_rate: int) -> np.ndarray:
+    result = subprocess.run(_ffmpeg_command(path, sample_rate), capture_output=True, check=False)
     if result.returncode != 0:
         detail = result.stderr.decode("utf-8", errors="replace").strip()
         raise ValueError(f"FFmpeg could not decode {path.name}: {detail or 'unknown error'}")
@@ -48,7 +54,7 @@ def _stereo_data(data: np.ndarray) -> np.ndarray:
 
 
 def load_audio(path_value: str | Path, sample_rate: int = 44100) -> np.ndarray:
-    """Load any audio format supported by SoundFile or the local FFmpeg installation."""
+    """Load an entire file for callers that explicitly need a complete array."""
     path = Path(path_value).expanduser()
     if not path.is_file():
         raise FileNotFoundError(f"Audio file not found: {path}")
@@ -70,6 +76,141 @@ def load_audio(path_value: str | Path, sample_rate: int = 44100) -> np.ndarray:
     return data.astype(np.float32, copy=False)
 
 
+def _iter_array(
+    data: np.ndarray,
+    total_frames: int,
+    frame_size: int,
+    *,
+    loop: bool,
+) -> Iterator[np.ndarray]:
+    if len(data) == 0:
+        raise ValueError("Audio source is empty")
+    produced = 0
+    while produced < total_frames:
+        take = min(frame_size, total_frames - produced)
+        if loop:
+            indices = (np.arange(take) + produced) % len(data)
+            chunk = data[indices]
+        else:
+            chunk = data[produced : produced + take]
+            if len(chunk) == 0:
+                break
+        produced += len(chunk)
+        yield chunk.astype(np.float32, copy=False)
+        if not loop and len(chunk) < take:
+            break
+
+
+def _iter_ffmpeg(
+    path: Path,
+    total_frames: int,
+    frame_size: int,
+    sample_rate: int,
+    *,
+    loop: bool,
+) -> Iterator[np.ndarray]:
+    produced = 0
+    bytes_per_frame = 2 * np.dtype("<f4").itemsize
+    while produced < total_frames:
+        process = subprocess.Popen(
+            _ffmpeg_command(path, sample_rate),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if process.stdout is None or process.stderr is None:
+            process.kill()
+            raise RuntimeError("Could not open FFmpeg audio pipes")
+        decoded_this_pass = 0
+        try:
+            while produced < total_frames:
+                take = min(frame_size, total_frames - produced)
+                wanted = take * bytes_per_frame
+                payload = bytearray()
+                while len(payload) < wanted:
+                    block = process.stdout.read(wanted - len(payload))
+                    if not block:
+                        break
+                    payload.extend(block)
+                usable = len(payload) - (len(payload) % bytes_per_frame)
+                if usable == 0:
+                    break
+                samples = np.frombuffer(memoryview(payload)[:usable], dtype="<f4")
+                chunk = samples.reshape((-1, 2)).copy()
+                produced += len(chunk)
+                decoded_this_pass += len(chunk)
+                yield chunk
+                if len(chunk) < take:
+                    break
+        finally:
+            if process.poll() is None:
+                if produced >= total_frames:
+                    process.terminate()
+                try:
+                    _, stderr = process.communicate(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    _, stderr = process.communicate()
+            else:
+                stderr = process.stderr.read()
+
+        if process.returncode not in (0, -15) and produced < total_frames:
+            detail = stderr.decode("utf-8", errors="replace").strip()
+            raise ValueError(f"FFmpeg could not decode {path.name}: {detail or 'unknown error'}")
+        if decoded_this_pass == 0:
+            raise ValueError(f"Audio file is empty or undecodable: {path}")
+        if not loop:
+            break
+
+
+def iter_audio_chunks(
+    path_value: str | Path,
+    total_frames: int,
+    frame_size: int,
+    sample_rate: int = 44100,
+    *,
+    loop: bool = False,
+) -> Iterator[np.ndarray]:
+    """Stream decoded stereo chunks with bounded memory, restarting only when looping."""
+    path = Path(path_value).expanduser()
+    if not path.is_file():
+        raise FileNotFoundError(f"Audio file not found: {path}")
+    if total_frames <= 0:
+        return
+
+    source: sf.SoundFile | None = None
+    try:
+        source = sf.SoundFile(path)
+    except (RuntimeError, TypeError, ValueError):
+        yield from _iter_ffmpeg(path, total_frames, frame_size, sample_rate, loop=loop)
+        return
+
+    with source:
+        if source.samplerate != sample_rate:
+            if shutil.which("ffmpeg") is not None:
+                yield from _iter_ffmpeg(path, total_frames, frame_size, sample_rate, loop=loop)
+                return
+            data = load_audio(path, sample_rate)
+            yield from _iter_array(data, total_frames, frame_size, loop=loop)
+            return
+
+        produced = 0
+        decoded_any = False
+        while produced < total_frames:
+            take = min(frame_size, total_frames - produced)
+            chunk = source.read(take, dtype="float32", always_2d=True)
+            chunk = _stereo_data(chunk)
+            if len(chunk) == 0:
+                if loop and decoded_any:
+                    source.seek(0)
+                    continue
+                break
+            decoded_any = True
+            produced += len(chunk)
+            yield chunk.astype(np.float32, copy=False)
+        if not decoded_any:
+            raise ValueError(f"Audio file is empty: {path}")
+
+
 @dataclass
 class FileSpec(GenBase):
     path: str = ""
@@ -79,17 +220,15 @@ class FileSpec(GenBase):
         return load_audio(self.path, self.sample_rate)
 
     def generator(self, duration: float):
-        data = self._load()
-        if len(data) == 0:
-            raise ValueError(f"Audio file is empty: {self.path}")
-        num = max(0, int(self.sample_rate * duration))
-        if len(data) < num and self.loop:
-            reps = int(np.ceil(num / len(data)))
-            data = np.tile(data, (reps, 1))
-        data = data[:num] * self._amp_scale()
-        for i in range(0, len(data), self.frame):
-            chunk = data[i : i + self.frame]
-            yield chunk.astype(np.float32), {
+        total_frames = max(0, int(self.sample_rate * duration))
+        for chunk in iter_audio_chunks(
+            self.path,
+            total_frames,
+            self.frame,
+            self.sample_rate,
+            loop=self.loop,
+        ):
+            yield (chunk * self._amp_scale()).astype(np.float32), {
                 "type": "file",
                 "path": Path(self.path).name,
             }

--- a/pysbagen/generators/file.py
+++ b/pysbagen/generators/file.py
@@ -1,35 +1,67 @@
-import os
+from dataclasses import dataclass
+from math import gcd
+from pathlib import Path
+
 import numpy as np
 import soundfile as sf
 from pydub import AudioSegment
-from dataclasses import dataclass
+from scipy.signal import resample_poly
+
 from .base import GenBase
+
 
 @dataclass
 class FileSpec(GenBase):
     path: str = ""
     loop: bool = False
 
-    def _load(self):
-        if self.path.lower().endswith(".mp3"):
-            seg = AudioSegment.from_mp3(self.path)
-            seg = seg.set_frame_rate(self.sample_rate).set_channels(2)
-            data = np.array(seg.get_array_of_samples(), dtype=np.int16).reshape(-1, 2)
-            data = data.astype(np.float32) / 32768.0
-            return data
-        data, rate = sf.read(self.path, dtype="float32", always_2d=True)
+    def _load_mp3(self) -> np.ndarray:
+        segment = AudioSegment.from_mp3(self.path)
+        segment = segment.set_frame_rate(self.sample_rate).set_channels(2)
+        raw = np.asarray(segment.get_array_of_samples())
+        data = raw.reshape((-1, 2)).astype(np.float32)
+        scale = float(1 << (8 * segment.sample_width - 1))
+        return data / scale
+
+    @staticmethod
+    def _stereo_data(data: np.ndarray) -> np.ndarray:
+        if data.ndim == 1:
+            data = data[:, None]
+        if data.shape[1] == 1:
+            return np.repeat(data, 2, axis=1)
+        return data[:, :2]
+
+    def _load(self) -> np.ndarray:
+        path = Path(self.path).expanduser()
+        if not path.is_file():
+            raise FileNotFoundError(f"Audio file not found: {path}")
+        if path.suffix.lower() == ".mp3":
+            return self._load_mp3()
+
+        data, rate = sf.read(path, dtype="float32", always_2d=True)
+        data = self._stereo_data(data)
         if rate != self.sample_rate:
-            raise ValueError(f"Sample rate mismatch: {rate} != {self.sample_rate}")
+            factor = gcd(rate, self.sample_rate)
+            data = resample_poly(
+                data,
+                self.sample_rate // factor,
+                rate // factor,
+                axis=0,
+            ).astype(np.float32)
         return data
 
     def generator(self, duration: float):
         data = self._load()
-        num = int(self.sample_rate * duration)
+        if len(data) == 0:
+            raise ValueError(f"Audio file is empty: {self.path}")
+        num = max(0, int(self.sample_rate * duration))
         if len(data) < num and self.loop:
             reps = int(np.ceil(num / len(data)))
             data = np.tile(data, (reps, 1))
         data = data[:num] * self._amp_scale()
         for i in range(0, len(data), self.frame):
-            chunk = data[i:i+self.frame]
-            if chunk.shape[0] == 0: break
-            yield chunk.astype(np.float32), {"type": "file", "path": os.path.basename(self.path)}
+            chunk = data[i : i + self.frame]
+            yield chunk.astype(np.float32), {
+                "type": "file",
+                "path": Path(self.path).name,
+            }

--- a/pysbagen/generators/file.py
+++ b/pysbagen/generators/file.py
@@ -15,8 +15,8 @@ class FileSpec(GenBase):
     path: str = ""
     loop: bool = False
 
-    def _load_mp3(self) -> np.ndarray:
-        segment = AudioSegment.from_mp3(self.path)
+    def _load_mp3(self, path: Path) -> np.ndarray:
+        segment = AudioSegment.from_mp3(path)
         segment = segment.set_frame_rate(self.sample_rate).set_channels(2)
         raw = np.asarray(segment.get_array_of_samples())
         data = raw.reshape((-1, 2)).astype(np.float32)
@@ -36,7 +36,7 @@ class FileSpec(GenBase):
         if not path.is_file():
             raise FileNotFoundError(f"Audio file not found: {path}")
         if path.suffix.lower() == ".mp3":
-            return self._load_mp3()
+            return self._load_mp3(path)
 
         data, rate = sf.read(path, dtype="float32", always_2d=True)
         data = self._stereo_data(data)

--- a/pysbagen/generators/noise.py
+++ b/pysbagen/generators/noise.py
@@ -1,22 +1,36 @@
-import numpy as np
 from dataclasses import dataclass
+
+import numpy as np
 from scipy.signal import lfilter
+
 from .base import GenBase
+
 
 @dataclass
 class NoiseSpec(GenBase):
-    kind: str = "white"  # "white" | "pink"
+    kind: str = "white"
+    seed: int | None = None
 
     def generator(self, duration: float):
-        num = int(self.sample_rate * duration)
-        a = self._amp_scale()
-        # simple Voss-McCartney-ish pink: 1st-order filter (approx)
-        b = [1.0]; a_pink = [1.0, -0.985]  # crude, fast
+        num = max(0, int(self.sample_rate * duration))
+        kind = self.kind.lower()
+        if kind not in {"white", "pink"}:
+            raise ValueError(f"Unsupported noise kind: {self.kind}")
+
+        rng = np.random.default_rng(self.seed)
+        b = np.array([1.0], dtype=np.float64)
+        a_pink = np.array([1.0, -0.985], dtype=np.float64)
+        zi = [np.zeros(max(len(a_pink), len(b)) - 1) for _ in range(2)]
+
         for i in range(0, num, self.frame):
             n = min(self.frame, num - i)
-            w = np.random.normal(0, 1, (n, 2))
-            if self.kind.lower() == "pink":
-                # filter each channel
-                w[:,0] = lfilter(b, a_pink, w[:,0])
-                w[:,1] = lfilter(b, a_pink, w[:,1])
-            yield (w * a).astype(np.float32), {"type": "noise", "kind": self.kind}
+            samples = rng.normal(0, 1, (n, 2))
+            if kind == "pink":
+                for channel in range(2):
+                    samples[:, channel], zi[channel] = lfilter(
+                        b, a_pink, samples[:, channel], zi=zi[channel]
+                    )
+            yield (samples * self._amp_scale()).astype(np.float32), {
+                "type": "noise",
+                "kind": kind,
+            }

--- a/pysbagen/generators/sleep.py
+++ b/pysbagen/generators/sleep.py
@@ -7,7 +7,7 @@ import numpy as np
 from scipy.signal import lfilter
 
 from .base import GenBase
-from .file import load_audio
+from .file import iter_audio_chunks
 
 if TYPE_CHECKING:
     from pysbagen.sleep import SleepRecipe
@@ -18,9 +18,6 @@ def _smoothstep(value: np.ndarray | float) -> np.ndarray:
     return x * x * (3.0 - 2.0 * x)
 
 
-def _looped_slice(data: np.ndarray, start: int, length: int) -> np.ndarray:
-    indices = (np.arange(length) + start) % len(data)
-    return data[indices]
 
 
 @dataclass
@@ -108,7 +105,7 @@ class SleepJourneySpec(GenBase):
         recipe = self.recipe
         request = recipe.request
         request.validate()
-        if request.layers is None:
+        if request.layers is None:  # build_sleep_recipe always resolves this.
             raise ValueError("Sleep recipe has no resolved layer selection")
         requested_duration = recipe.duration_seconds
         if abs(duration - requested_duration) > 1.0 / self.sample_rate:
@@ -119,11 +116,15 @@ class SleepJourneySpec(GenBase):
         total_frames = int(self.sample_rate * duration)
         descent = max(recipe.descent_seconds, 1.0)
         fade_in_seconds = min(30.0, duration * 0.08)
-        user_audio = None
+        user_audio_chunks = None
         if request.user_audio:
-            user_audio = load_audio(request.user_audio, self.sample_rate)
-            if len(user_audio) == 0:
-                raise ValueError(f"Audio file is empty: {request.user_audio}")
+            user_audio_chunks = iter_audio_chunks(
+                request.user_audio,
+                total_frames,
+                self.frame,
+                self.sample_rate,
+                loop=True,
+            )
 
         intensity = {
             "gentle": {"bed": 0.42, "binaural": 0.035, "monaural": 0.018, "iso": 0.012, "hbox": 0.014},
@@ -152,8 +153,12 @@ class SleepJourneySpec(GenBase):
 
             generated_world = "deep_night" if request.sound_world == "user_audio" else request.sound_world
             bed = self._generated_bed(t, generated_world, rng, filter_state, novelty, phases)
-            if user_audio is not None:
-                supplied = _looped_slice(user_audio, offset, n)
+            if user_audio_chunks is not None:
+                supplied = next(user_audio_chunks)
+                if len(supplied) != n:
+                    raise ValueError(
+                        f"User audio returned {len(supplied)} frames where {n} were required"
+                    )
                 bed = supplied * 0.92 + bed * 0.08
             output = bed * (intensity["bed"] * bed_envelope[:, None])
 

--- a/pysbagen/generators/sleep.py
+++ b/pysbagen/generators/sleep.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy.signal import lfilter
+
+from .base import GenBase
+from .file import load_audio
+
+if TYPE_CHECKING:
+    from pysbagen.sleep import SleepRecipe
+
+
+def _smoothstep(value: np.ndarray | float) -> np.ndarray:
+    x = np.clip(value, 0.0, 1.0)
+    return x * x * (3.0 - 2.0 * x)
+
+
+def _looped_slice(data: np.ndarray, start: int, length: int) -> np.ndarray:
+    indices = (np.arange(length) + start) % len(data)
+    return data[indices]
+
+
+@dataclass
+class SleepJourneySpec(GenBase):
+    recipe: "SleepRecipe | None" = None
+
+    def _generated_bed(
+        self,
+        t: np.ndarray,
+        world: str,
+        rng: np.random.Generator,
+        filter_state: list[np.ndarray],
+        novelty: np.ndarray,
+        phases: np.ndarray,
+    ) -> np.ndarray:
+        if world == "warm_ambient":
+            left = (
+                0.36 * np.sin(2 * np.pi * 82.41 * t + phases[0] + 0.18 * np.sin(2 * np.pi * 0.009 * t))
+                + 0.24 * np.sin(2 * np.pi * 123.47 * t + phases[1] + 0.12 * np.sin(2 * np.pi * 0.006 * t + 0.8))
+                + 0.14 * np.sin(2 * np.pi * 164.81 * t + phases[2] + 0.10 * np.sin(2 * np.pi * 0.004 * t + 1.7))
+            )
+            right = (
+                0.36 * np.sin(2 * np.pi * 82.55 * t + phases[3] + 0.18 * np.sin(2 * np.pi * 0.008 * t + 0.4))
+                + 0.24 * np.sin(2 * np.pi * 123.32 * t + phases[4] + 0.12 * np.sin(2 * np.pi * 0.0065 * t + 1.1))
+                + 0.14 * np.sin(2 * np.pi * 164.95 * t + phases[5] + 0.10 * np.sin(2 * np.pi * 0.0045 * t + 2.0))
+            )
+            shimmer = 0.04 * novelty * np.sin(2 * np.pi * 246.94 * t + 0.7 * np.sin(2 * np.pi * 0.012 * t))
+            return np.column_stack((left + shimmer, right + shimmer))
+
+        if world == "slow_night_music":
+            chords = np.array([
+                [65.41, 98.00, 130.81],
+                [55.00, 82.41, 110.00],
+                [73.42, 110.00, 146.83],
+                [49.00, 73.42, 98.00],
+            ])
+            chord_position = t / 80.0
+            chord_index = np.floor(chord_position).astype(int) % len(chords)
+            next_index = (chord_index + 1) % len(chords)
+            crossfade = _smoothstep((np.mod(chord_position, 1.0) - 0.68) / 0.32)
+            left = np.zeros(len(t))
+            right = np.zeros(len(t))
+            for voice in range(3):
+                current = chords[chord_index, voice]
+                following = chords[next_index, voice]
+                current_left = np.sin(2 * np.pi * current * t + phases[voice])
+                next_left = np.sin(2 * np.pi * following * t + phases[voice + 3])
+                current_right = np.sin(2 * np.pi * (current * 1.0012) * t + phases[voice + 3])
+                next_right = np.sin(2 * np.pi * (following * 0.9988) * t + phases[voice])
+                weight = (0.30, 0.22, 0.15)[voice]
+                left += weight * ((1.0 - crossfade) * current_left + crossfade * next_left)
+                right += weight * ((1.0 - crossfade) * current_right + crossfade * next_right)
+
+            melody_notes = np.array([196.00, 164.81, 146.83, 130.81, 110.00, 130.81, 98.00, 82.41])
+            melody_position = t / 24.0
+            melody_index = np.floor(melody_position).astype(int) % len(melody_notes)
+            melody_fraction = np.mod(melody_position, 1.0)
+            melody_envelope = np.sin(np.pi * melody_fraction) ** 2 * novelty
+            melody = 0.055 * melody_envelope * np.sin(
+                2 * np.pi * melody_notes[melody_index] * t + phases[1]
+            )
+            return np.column_stack((left + melody, right + melody * 0.92))
+
+        white = rng.normal(0.0, 1.0, (len(t), 2))
+        filtered = np.empty_like(white)
+        b = np.array([0.018], dtype=np.float64)
+        a = np.array([1.0, -0.982], dtype=np.float64)
+        for channel in range(2):
+            filtered[:, channel], filter_state[channel] = lfilter(
+                b, a, white[:, channel], zi=filter_state[channel]
+            )
+
+        if world == "rain_room":
+            droplets = white * (0.035 + 0.02 * novelty[:, None])
+            return filtered * 0.38 + droplets
+
+        drone_left = 0.34 * np.sin(2 * np.pi * 55.0 * t + 0.10 * np.sin(2 * np.pi * 0.004 * t))
+        drone_right = 0.34 * np.sin(2 * np.pi * 55.12 * t + 0.10 * np.sin(2 * np.pi * 0.0037 * t + 0.6))
+        upper = 0.07 * novelty * np.sin(2 * np.pi * 110.0 * t + 0.4 * np.sin(2 * np.pi * 0.007 * t))
+        return np.column_stack((drone_left + upper, drone_right + upper)) + filtered * 0.12
+
+    def generator(self, duration: float):
+        if self.recipe is None:
+            raise ValueError("SleepJourneySpec requires a sleep recipe")
+        recipe = self.recipe
+        request = recipe.request
+        request.validate()
+        if request.layers is None:
+            raise ValueError("Sleep recipe has no resolved layer selection")
+        requested_duration = recipe.duration_seconds
+        if abs(duration - requested_duration) > 1.0 / self.sample_rate:
+            raise ValueError(
+                f"Sleep journey duration is fixed at {requested_duration:.2f}s by its recipe, got {duration:.2f}s"
+            )
+
+        total_frames = int(self.sample_rate * duration)
+        descent = max(recipe.descent_seconds, 1.0)
+        fade_in_seconds = min(30.0, duration * 0.08)
+        user_audio = None
+        if request.user_audio:
+            user_audio = load_audio(request.user_audio, self.sample_rate)
+            if len(user_audio) == 0:
+                raise ValueError(f"Audio file is empty: {request.user_audio}")
+
+        intensity = {
+            "gentle": {"bed": 0.42, "binaural": 0.035, "monaural": 0.018, "iso": 0.012, "hbox": 0.014},
+            "balanced": {"bed": 0.52, "binaural": 0.055, "monaural": 0.028, "iso": 0.019, "hbox": 0.022},
+            "immersive": {"bed": 0.60, "binaural": 0.075, "monaural": 0.040, "iso": 0.028, "hbox": 0.032},
+        }[request.intensity]
+
+        rng = np.random.default_rng(request.seed)
+        filter_state = [np.zeros(1, dtype=np.float64), np.zeros(1, dtype=np.float64)]
+        phases = rng.uniform(0.0, 2 * np.pi, 6)
+        beat_phase_state = 0.0
+
+        for offset in range(0, total_frames, self.frame):
+            n = min(self.frame, total_frames - offset)
+            t = (offset + np.arange(n)) / self.sample_rate
+            descent_progress = _smoothstep(t / descent)
+            beat = recipe.start_beat_hz + (recipe.end_beat_hz - recipe.start_beat_hz) * descent_progress
+            after_descent = np.clip((t - descent) / max(recipe.support_seconds, 1.0), 0.0, 1.0)
+
+            fade_in = _smoothstep(t / max(fade_in_seconds, 1.0))
+            fade_out = _smoothstep((duration - t) / max(recipe.fade_out_seconds, 1.0))
+            global_envelope = fade_in * fade_out
+            novelty = (1.0 - 0.82 * descent_progress) * (1.0 - 0.45 * after_descent)
+            active_layer_envelope = global_envelope * (1.0 - 0.82 * after_descent)
+            bed_envelope = global_envelope * (1.0 - 0.28 * after_descent)
+
+            generated_world = "deep_night" if request.sound_world == "user_audio" else request.sound_world
+            bed = self._generated_bed(t, generated_world, rng, filter_state, novelty, phases)
+            if user_audio is not None:
+                supplied = _looped_slice(user_audio, offset, n)
+                bed = supplied * 0.92 + bed * 0.08
+            output = bed * (intensity["bed"] * bed_envelope[:, None])
+
+            increments = 2 * np.pi * beat / self.sample_rate
+            beat_phase = beat_phase_state + np.concatenate(([0.0], np.cumsum(increments[:-1])))
+            beat_phase_state = float(beat_phase[-1] + increments[-1])
+            carrier_phase = 2 * np.pi * recipe.carrier_hz * t
+            layers = request.layers
+
+            if layers.binaural:
+                left = np.sin(carrier_phase)
+                right = np.sin(carrier_phase + beat_phase)
+                output += np.column_stack((left, right)) * (intensity["binaural"] * active_layer_envelope[:, None])
+
+            if layers.monaural:
+                mono_phase = 2 * np.pi * (recipe.carrier_hz + 27.0) * t
+                mono = 0.5 * (np.sin(mono_phase) + np.sin(mono_phase + beat_phase))
+                output += np.column_stack((mono, mono)) * (intensity["monaural"] * active_layer_envelope[:, None])
+
+            if layers.isochronic:
+                pulse = (0.5 - 0.5 * np.cos(beat_phase)) ** 2
+                iso = np.sin(2 * np.pi * (recipe.carrier_hz * 0.72) * t) * pulse
+                output += np.column_stack((iso, iso)) * (intensity["iso"] * active_layer_envelope[:, None])
+
+            if layers.harmonic_box:
+                hleft = np.zeros(n)
+                hright = np.zeros(n)
+                for index, phase in enumerate((0.0, np.pi / 2, np.pi, 3 * np.pi / 2)):
+                    gate = 0.5 + 0.5 * np.sin(beat_phase + phase)
+                    hleft += np.sin(carrier_phase + index * 0.5 * beat_phase) * gate
+                    hright += np.sin(carrier_phase + (1.0 + index * 0.5) * beat_phase) * gate
+                output += np.column_stack((hleft, hright)) / 4.0 * (
+                    intensity["hbox"] * active_layer_envelope[:, None]
+                )
+
+            output = np.tanh(output * self._amp_scale()).astype(np.float32)
+            stage = "sleep_descent" if float(t[-1]) < descent else "sleep_support"
+            yield output, {
+                "type": "sleep_journey",
+                "recipe": recipe.name,
+                "stage": stage,
+                "problem": request.problem,
+                "sound_world": request.sound_world,
+                "beat_hz": float(np.mean(beat)),
+                "layers": layers.enabled_names(),
+            }

--- a/pysbagen/mixer.py
+++ b/pysbagen/mixer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Iterable, Iterator, List, Tuple
+from typing import Callable, Iterable, Iterator, List, Tuple
 
 import numpy as np
 
@@ -24,6 +24,7 @@ def _stereo_float32(chunk: np.ndarray) -> np.ndarray:
 
 @dataclass
 class _StreamState:
+    spec: object
     iterator: Iterator
     pending: np.ndarray = field(default_factory=lambda: np.empty((0, 2), dtype=np.float32))
     info: dict | None = None
@@ -65,33 +66,44 @@ class _StreamState:
         return output, self.info if produced_audio else None, produced_audio
 
 
-def mix_generators(
-    gens: Iterable, duration: float
+def _new_state(spec, duration: float) -> _StreamState:
+    sample_rate = getattr(spec, "sample_rate", SR)
+    if sample_rate != SR:
+        raise ValueError(f"Generator sample rate {sample_rate} does not match mixer rate {SR}")
+    return _StreamState(spec=spec, iterator=iter(spec.generator(max(duration, 0.0))))
+
+
+def _read_states(states: list[_StreamState], frame_count: int) -> tuple[np.ndarray, list[dict]]:
+    accumulator = np.zeros((frame_count, 2), dtype=np.float32)
+    infos: list[dict] = []
+    for state in states:
+        chunk, info, produced_audio = state.read(frame_count)
+        if produced_audio:
+            accumulator += chunk
+            if info is not None:
+                infos.append(info)
+    return accumulator, infos
+
+
+def _mix_state_groups_frames(
+    groups: list[tuple[list[_StreamState], Callable[[np.ndarray], np.ndarray]]],
+    total_frames: int,
 ) -> Iterator[Tuple[np.ndarray, list[dict]]]:
-    """Mix generators for exactly ``duration`` seconds, padding exhausted streams with silence."""
-    if duration <= 0:
+    if total_frames <= 0:
         return
-
-    specs = list(gens)
-    for spec in specs:
-        sample_rate = getattr(spec, "sample_rate", SR)
-        if sample_rate != SR:
-            raise ValueError(f"Generator sample rate {sample_rate} does not match mixer rate {SR}")
-
-    states = [_StreamState(iter(spec.generator(duration))) for spec in specs]
-    total_frames = int(SR * duration)
 
     for offset in range(0, total_frames, FRAME):
         frame_count = min(FRAME, total_frames - offset)
+        progress = (offset + np.arange(frame_count, dtype=np.float64)) / max(total_frames - 1, 1)
         accumulator = np.zeros((frame_count, 2), dtype=np.float32)
-        infos: List[dict] = []
-
-        for state in states:
-            chunk, info, produced_audio = state.read(frame_count)
-            if produced_audio:
-                accumulator += chunk
-                if info is not None:
-                    infos.append(info)
+        infos: list[dict] = []
+        for states, gain_fn in groups:
+            chunk, group_infos = _read_states(states, frame_count)
+            gain = np.asarray(gain_fn(progress), dtype=np.float32)
+            if gain.ndim == 0:
+                gain = np.full(frame_count, float(gain), dtype=np.float32)
+            accumulator += chunk * gain[:, None]
+            infos.extend(group_infos)
 
         peak = float(np.max(np.abs(accumulator))) if len(accumulator) else 0.0
         if peak > 1.0:
@@ -99,17 +111,44 @@ def mix_generators(
         yield accumulator, infos
 
 
+def _mix_state_groups(
+    groups: list[tuple[list[_StreamState], Callable[[np.ndarray], np.ndarray]]],
+    duration: float,
+) -> Iterator[Tuple[np.ndarray, list[dict]]]:
+    yield from _mix_state_groups_frames(groups, int(SR * duration))
+
+
+def _constant_gain(value: float) -> Callable[[np.ndarray], np.ndarray]:
+    return lambda progress: np.full_like(progress, value, dtype=np.float64)
+
+
+def mix_generators(
+    gens: Iterable, duration: float
+) -> Iterator[Tuple[np.ndarray, list[dict]]]:
+    """Mix generators for exactly ``duration`` seconds, padding exhausted streams with silence."""
+    states = [_new_state(spec, duration) for spec in list(gens)]
+    yield from _mix_state_groups([(states, _constant_gain(1.0))], duration)
+
+
+def _schedule_tokens(names: list[str]) -> tuple[list[str], bool]:
+    transition = bool(names and names[-1] == "->")
+    tokens = names[:-1] if transition else names
+    return tokens, transition
+
+
 def _apply_schedule_event(active: list, tone_sets: dict, names: list[str]) -> list:
+    names, _ = _schedule_tokens(names)
     if not names:
         return active
 
-    if not names[0].startswith(("+", "-")):
+    first_lower = names[0].lower()
+    if first_lower in {"-", "off", "alloff"} or not names[0].startswith(("+", "-")):
         active = []
 
     for token in names:
         lowered = token.lower()
         if lowered in {"-", "off", "alloff"}:
-            if lowered == "alloff":
+            if lowered in {"-", "alloff"}:
                 active = []
             continue
 
@@ -126,33 +165,109 @@ def _apply_schedule_event(active: list, tone_sets: dict, names: list[str]) -> li
     return active
 
 
+def _reconcile_states(
+    existing: list[_StreamState],
+    specs: list,
+    remaining_duration: float,
+) -> list[_StreamState]:
+    by_identity = {id(state.spec): state for state in existing}
+    return [
+        by_identity.get(id(spec)) or _new_state(spec, remaining_duration)
+        for spec in specs
+    ]
+
+
+def _transition_groups(
+    source_states: list[_StreamState],
+    target_specs: list,
+    remaining_duration: float,
+) -> tuple[list[tuple[list[_StreamState], Callable[[np.ndarray], np.ndarray]]], list[_StreamState]]:
+    source_by_id = {id(state.spec): state for state in source_states}
+    target_ids = {id(spec) for spec in target_specs}
+    common = [state for state in source_states if id(state.spec) in target_ids]
+    source_only = [state for state in source_states if id(state.spec) not in target_ids]
+    target_only = [
+        _new_state(spec, remaining_duration)
+        for spec in target_specs
+        if id(spec) not in source_by_id
+    ]
+    target_by_id = {id(state.spec): state for state in common + target_only}
+    final_states = [target_by_id[id(spec)] for spec in target_specs]
+
+    groups: list[tuple[list[_StreamState], Callable[[np.ndarray], np.ndarray]]] = []
+    if common:
+        groups.append((common, _constant_gain(1.0)))
+    if source_only:
+        groups.append((source_only, lambda progress: 1.0 - progress))
+    if target_only:
+        groups.append((target_only, lambda progress: progress))
+    if not groups:
+        groups.append(([], _constant_gain(1.0)))
+    return groups, final_states
+
+
 def build_session_generator(tone_sets, schedule, duration=None):
-    """Render a schedule without collapsing silent gaps or overrunning an explicit duration."""
+    """Render schedules with persistent streams, real silence, and full-interval ``->`` crossfades."""
     if not schedule:
         return
 
     ordered = sorted(schedule, key=lambda item: item[0])
     if duration is None:
         duration = float(ordered[-1][0])
+    duration = float(duration)
     if duration < 0:
         raise ValueError("duration must be non-negative")
+    duration_frames = int(SR * duration)
 
-    active: list = []
-    cursor = 0.0
+    event_frames = [(int(SR * float(time_value)), names) for time_value, names in ordered]
+    first_frame = event_frames[0][0]
+    if first_frame < 0:
+        raise ValueError("Schedule times must be non-negative")
+    if first_frame > 0:
+        yield from _mix_state_groups_frames(
+            [([], _constant_gain(1.0))], min(first_frame, duration_frames)
+        )
+    if first_frame >= duration_frames:
+        return
 
-    for start, names in ordered:
-        start = float(start)
-        if start < cursor:
+    active_specs = _apply_schedule_event([], tone_sets, event_frames[0][1])
+    active_states = _reconcile_states(
+        [], active_specs, (duration_frames - first_frame) / SR
+    )
+
+    for index, (start_frame, names) in enumerate(event_frames):
+        if index and start_frame < event_frames[index - 1][0]:
             raise ValueError("Schedule times must be non-decreasing")
-        if start > duration:
+        if start_frame >= duration_frames:
             break
+        next_frame = duration_frames
+        if index + 1 < len(event_frames):
+            next_frame = min(event_frames[index + 1][0], duration_frames)
+        segment_frames = max(0, next_frame - start_frame)
+        _, transition = _schedule_tokens(names)
 
-        segment_duration = start - cursor
-        if segment_duration > 0:
-            yield from mix_generators(active, segment_duration)
-
-        active = _apply_schedule_event(active, tone_sets, names)
-        cursor = start
-
-    if cursor < duration:
-        yield from mix_generators(active, duration - cursor)
+        if transition and index + 1 < len(event_frames) and segment_frames > 0:
+            target_specs = _apply_schedule_event(
+                list(active_specs), tone_sets, event_frames[index + 1][1]
+            )
+            groups, final_states = _transition_groups(
+                active_states,
+                target_specs,
+                (duration_frames - start_frame) / SR,
+            )
+            yield from _mix_state_groups_frames(groups, segment_frames)
+            active_specs = target_specs
+            active_states = final_states
+        else:
+            yield from _mix_state_groups_frames(
+                [(active_states, _constant_gain(1.0))], segment_frames
+            )
+            if index + 1 < len(event_frames) and next_frame < duration_frames:
+                active_specs = _apply_schedule_event(
+                    list(active_specs), tone_sets, event_frames[index + 1][1]
+                )
+                active_states = _reconcile_states(
+                    active_states,
+                    active_specs,
+                    (duration_frames - next_frame) / SR,
+                )

--- a/pysbagen/mixer.py
+++ b/pysbagen/mixer.py
@@ -119,7 +119,8 @@ def _apply_schedule_event(active: list, tone_sets: dict, names: list[str]) -> li
             raise ValueError(f"Schedule references unknown tone set: {name}")
         selected = tone_sets[name]
         if operation == "-":
-            active = [generator for generator in active if generator not in selected]
+            selected_ids = {id(generator) for generator in selected}
+            active = [generator for generator in active if id(generator) not in selected_ids]
         else:
             active.extend(selected)
     return active

--- a/pysbagen/mixer.py
+++ b/pysbagen/mixer.py
@@ -1,76 +1,157 @@
-from typing import Generator, Iterable, List, Tuple
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Iterator, List, Tuple
+
 import numpy as np
 
 FRAME = 1024
 SR = 44100
 
-def _pad_chunk(chunk: np.ndarray, frame_len: int) -> np.ndarray:
-    """Pad a chunk to ``frame_len`` without modifying the input."""
-    if chunk.shape[0] == frame_len:
-        return chunk
-    padded = np.zeros((frame_len, chunk.shape[1]), dtype=chunk.dtype)
-    padded[: chunk.shape[0]] = chunk
-    return padded
+
+def _stereo_float32(chunk: np.ndarray) -> np.ndarray:
+    array = np.asarray(chunk, dtype=np.float32)
+    if array.ndim == 1:
+        array = array[:, None]
+    if array.ndim != 2:
+        raise ValueError(f"Audio chunks must be one- or two-dimensional, got {array.shape}")
+    if array.shape[1] == 1:
+        array = np.repeat(array, 2, axis=1)
+    elif array.shape[1] > 2:
+        array = array[:, :2]
+    return array
 
 
-def mix_generators(gens: Iterable, duration: float) -> Generator[Tuple[np.ndarray, list], None, None]:
-    if not gens or duration <= 0:
+@dataclass
+class _StreamState:
+    iterator: Iterator
+    pending: np.ndarray = field(default_factory=lambda: np.empty((0, 2), dtype=np.float32))
+    info: dict | None = None
+    exhausted: bool = False
+
+    def read(self, frame_count: int) -> tuple[np.ndarray, dict | None, bool]:
+        pieces: list[np.ndarray] = []
+        collected = 0
+        produced_audio = False
+
+        while collected < frame_count:
+            if len(self.pending):
+                take = min(frame_count - collected, len(self.pending))
+                pieces.append(self.pending[:take])
+                self.pending = self.pending[take:]
+                collected += take
+                produced_audio = True
+                continue
+
+            if self.exhausted:
+                break
+
+            try:
+                chunk, info = next(self.iterator)
+            except StopIteration:
+                self.exhausted = True
+                continue
+
+            normalized = _stereo_float32(chunk)
+            if len(normalized) == 0:
+                continue
+            self.pending = normalized
+            self.info = info
+
+        output = np.zeros((frame_count, 2), dtype=np.float32)
+        if pieces:
+            combined = np.vstack(pieces)
+            output[: len(combined)] = combined
+        return output, self.info if produced_audio else None, produced_audio
+
+
+def mix_generators(
+    gens: Iterable, duration: float
+) -> Iterator[Tuple[np.ndarray, list[dict]]]:
+    """Mix generators for exactly ``duration`` seconds, padding exhausted streams with silence."""
+    if duration <= 0:
         return
 
-    streams = [g.generator(duration) for g in gens]
-    while True:
-        try:
-            chunks: List[np.ndarray] = []
-            infos: List[dict] = []
-            for stream in streams:
-                chunk, info = next(stream)
-                chunks.append(chunk)
-                infos.append(info)
+    specs = list(gens)
+    for spec in specs:
+        sample_rate = getattr(spec, "sample_rate", SR)
+        if sample_rate != SR:
+            raise ValueError(f"Generator sample rate {sample_rate} does not match mixer rate {SR}")
 
-            frame_len = max(chunk.shape[0] for chunk in chunks)
-            acc = np.zeros((frame_len, 2), dtype=np.float32)
-            for chunk in chunks:
-                acc += _pad_chunk(chunk.astype(np.float32), frame_len)
+    states = [_StreamState(iter(spec.generator(duration))) for spec in specs]
+    total_frames = int(SR * duration)
 
-            peak = float(np.max(np.abs(acc)))
-            if peak > 1.0:
-                acc /= peak
+    for offset in range(0, total_frames, FRAME):
+        frame_count = min(FRAME, total_frames - offset)
+        accumulator = np.zeros((frame_count, 2), dtype=np.float32)
+        infos: List[dict] = []
 
-            yield acc, infos
-        except StopIteration:
-            break
+        for state in states:
+            chunk, info, produced_audio = state.read(frame_count)
+            if produced_audio:
+                accumulator += chunk
+                if info is not None:
+                    infos.append(info)
+
+        peak = float(np.max(np.abs(accumulator))) if len(accumulator) else 0.0
+        if peak > 1.0:
+            accumulator /= peak
+        yield accumulator, infos
+
+
+def _apply_schedule_event(active: list, tone_sets: dict, names: list[str]) -> list:
+    if not names:
+        return active
+
+    if not names[0].startswith(("+", "-")):
+        active = []
+
+    for token in names:
+        lowered = token.lower()
+        if lowered in {"-", "off", "alloff"}:
+            if lowered == "alloff":
+                active = []
+            continue
+
+        operation = token[0] if token[0] in "+-" else "+"
+        name = token.lstrip("+-")
+        if name not in tone_sets:
+            raise ValueError(f"Schedule references unknown tone set: {name}")
+        selected = tone_sets[name]
+        if operation == "-":
+            active = [generator for generator in active if generator not in selected]
+        else:
+            active.extend(selected)
+    return active
+
 
 def build_session_generator(tone_sets, schedule, duration=None):
+    """Render a schedule without collapsing silent gaps or overrunning an explicit duration."""
     if not schedule:
         return
-    times = [t for t, _ in schedule]
+
+    ordered = sorted(schedule, key=lambda item: item[0])
     if duration is None:
-        duration = times[-1]
-    schedule = schedule + [(duration, ["off"])]
+        duration = float(ordered[-1][0])
+    if duration < 0:
+        raise ValueError("duration must be non-negative")
 
-    active = []
-    last = 0.0
-    for start, names in schedule:
-        seg = start - last
-        if seg > 0:
-            yield from mix_generators(active, seg)
+    active: list = []
+    cursor = 0.0
 
-        absolute = not names[0].startswith(('+', '-'))
-        if absolute:
-            active.clear()
+    for start, names in ordered:
+        start = float(start)
+        if start < cursor:
+            raise ValueError("Schedule times must be non-decreasing")
+        if start > duration:
+            break
 
-        tokens = {n.lower() for n in names}
-        if "alloff" in tokens:
-            active.clear()
+        segment_duration = start - cursor
+        if segment_duration > 0:
+            yield from mix_generators(active, segment_duration)
 
-        for n in names:
-            if n.lower() in {"-", "off", "alloff"}:
-                continue
-            clean = n.lstrip("+-")
-            if n.startswith('-'):
-                # remove by identity
-                to_remove = tone_sets.get(clean, [])
-                active = [g for g in active if g not in to_remove]
-            else:
-                active.extend(tone_sets.get(clean, []))
-        last = start
+        active = _apply_schedule_event(active, tone_sets, names)
+        cursor = start
+
+    if cursor < duration:
+        yield from mix_generators(active, duration - cursor)

--- a/pysbagen/parser.py
+++ b/pysbagen/parser.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional, Tuple
 from .generators import FileSpec, HarmonicBoxSpec, IsochronicSpec, NoiseSpec, ToneSpec
 from .types import AnySpec
 
-_AUDIO_EXTENSIONS = {".wav", ".ogg", ".flac", ".aif", ".aiff", ".mp3"}
+_AUDIO_EXTENSIONS = {".wav", ".ogg", ".flac", ".aif", ".aiff", ".mp3", ".m4a", ".aac", ".opus", ".wma", ".caf"}
 _NUMBER = re.compile(r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$")
 
 
@@ -17,7 +17,6 @@ def _parse_hms(value: str) -> int:
     parts = value.split(":")
     if not 1 <= len(parts) <= 3 or any(not part.isdigit() for part in parts):
         raise ValueError(f"Invalid schedule time: {value!r}")
-
     numbers = [int(part) for part in parts]
     if len(numbers) == 1:
         return numbers[0]
@@ -53,7 +52,6 @@ def _parse_file_component(spec: str, base_dir: Path | None) -> Optional[FileSpec
             candidate = _resolve_audio_path(path_text, base_dir)
             if candidate.suffix.lower() in _AUDIO_EXTENSIONS or candidate.is_file():
                 return FileSpec(path=str(candidate), amp=float(amp_text))
-
     candidate = _resolve_audio_path(spec, base_dir)
     if candidate.suffix.lower() in _AUDIO_EXTENSIONS or candidate.is_file():
         return FileSpec(path=str(candidate))
@@ -61,50 +59,39 @@ def _parse_file_component(spec: str, base_dir: Path | None) -> Optional[FileSpec
 
 
 def parse_tone_component(spec: str, base_dir: str | Path | None = None) -> Optional[AnySpec]:
-    """Parse one SBG component into a generator specification."""
     spec = spec.strip()
     if not spec:
         raise ValueError("Tone component cannot be empty")
     if spec.lower() in {"-", "off"}:
         return None
-
     resolved_base = Path(base_dir) if base_dir is not None else None
     prefix, separator, rest = spec.partition(":")
     recognized_prefix = prefix.lower() if separator else ""
-
     if recognized_prefix == "iso":
         params_text, amp = _split_params_and_amp(rest)
         params = [float(value) for value in params_text.split(",")]
         if len(params) != 2:
             raise ValueError("iso requires frequency and beat: iso:FREQ,BEAT[/AMP]")
         return IsochronicSpec(freq=params[0], beat=params[1], amp=amp)
-
     if recognized_prefix == "hbox":
         params_text, amp = _split_params_and_amp(rest)
         params = [float(value) for value in params_text.split(",")]
         if len(params) != 3:
             raise ValueError("hbox requires base, difference, and modulation")
         return HarmonicBoxSpec(base=params[0], diff=params[1], mod=params[2], amp=amp)
-
     if recognized_prefix == "file":
         parsed_file = _parse_file_component(rest, resolved_base)
         if parsed_file is None:
             raise ValueError(f"Unsupported audio file component: {rest!r}")
         return parsed_file
-
     if recognized_prefix in {"spin", "slide"}:
         spec = rest
-
-    noise_match = re.fullmatch(
-        r"(?i)(pink|white)(?:/([+-]?(?:\d+(?:\.\d*)?|\.\d+)))?", spec
-    )
+    noise_match = re.fullmatch(r"(?i)(pink|white)(?:/([+-]?(?:\d+(?:\.\d*)?|\.\d+)))?", spec)
     if noise_match:
         return NoiseSpec(kind=noise_match.group(1).lower(), amp=float(noise_match.group(2) or 100.0))
-
     parsed_file = _parse_file_component(spec, resolved_base)
     if parsed_file is not None:
         return parsed_file
-
     core_spec, amp = _split_params_and_amp(spec)
     beat = 0.0
     if "+" in core_spec:
@@ -115,22 +102,17 @@ def parse_tone_component(spec: str, base_dir: str | Path | None = None) -> Optio
         beat = -float(beat_text)
     else:
         base_text = core_spec
-
     return ToneSpec(base=float(base_text), beat=beat, amp=amp)
 
 
-def parse_sbg_from_string(
-    source: str, base_dir: str | Path | None = None
-) -> tuple[Dict[str, List[AnySpec]], List[Tuple[float, List[str]]]]:
+def parse_sbg_from_string(source: str, base_dir: str | Path | None = None) -> tuple[Dict[str, List[AnySpec]], List[Tuple[float, List[str]]]]:
     tone_sets: Dict[str, List[AnySpec]] = {}
     schedule: List[Tuple[float, List[str]]] = []
     resolved_base = Path(base_dir) if base_dir is not None else None
-
     for line_number, raw in enumerate(source.splitlines(), start=1):
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
-
         try:
             is_schedule = line.upper().startswith("NOW") or line[0].isdigit() or line.startswith("+")
             if not is_schedule and ":" in line:
@@ -139,27 +121,29 @@ def parse_sbg_from_string(
                 if not label:
                     raise ValueError("Tone-set label cannot be empty")
                 parts = shlex.split(rest, comments=True, posix=True)
-                tone_sets[label] = [
-                    component
-                    for part in parts
-                    if (component := parse_tone_component(part, resolved_base)) is not None
-                ]
+                tone_sets[label] = [component for part in parts if (component := parse_tone_component(part, resolved_base)) is not None]
                 continue
-
             if line.upper().startswith("NOW"):
                 time_value = 0
                 rest = line[3:].strip()
             else:
                 time_text, rest = line.split(maxsplit=1)
                 time_value = _parse_hms(time_text.lstrip("+"))
-
-            items = [item for item in shlex.split(rest.replace("->", " ")) if item]
-            if not items:
+            raw_items = [item for item in shlex.split(rest) if item]
+            transition_positions = [index for index, item in enumerate(raw_items) if item == "->"]
+            if transition_positions and transition_positions != [len(raw_items) - 1]:
+                raise ValueError("'->' must end a schedule line and transitions to the next timed event")
+            transition = bool(transition_positions)
+            if transition:
+                raw_items.pop()
+            if raw_items and raw_items[0] in {"==", "--", "<>", "<-", "->", "=-", "-="}:
+                raw_items.pop(0)
+            items = raw_items + (["->"] if transition else [])
+            if not raw_items:
                 raise ValueError("Schedule event must name at least one tone set or off")
             schedule.append((float(time_value), items))
         except (TypeError, ValueError) as exc:
             raise ValueError(f"Invalid SBG line {line_number}: {raw.strip()} ({exc})") from exc
-
     schedule.sort(key=lambda item: item[0])
     return tone_sets, schedule
 

--- a/pysbagen/parser.py
+++ b/pysbagen/parser.py
@@ -1,96 +1,170 @@
-from typing import Dict, List, Tuple, Optional, Union
+from __future__ import annotations
+
 import os
+import re
+import shlex
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from .generators import FileSpec, HarmonicBoxSpec, IsochronicSpec, NoiseSpec, ToneSpec
 from .types import AnySpec
-from .generators import *
 
-def _parse_hms(s: str) -> int:
-    # supports "NOW", "M:S", "H:M:S"
-    ts = [int(x) for x in s.split(":")]
-    if len(ts) == 1:  # seconds
-        h, m, s = 0, 0, ts[0]
-    elif len(ts) == 2:
-        h, m, s = 0, ts[0], ts[1]
-    else:
-        h, m, s = ts
-    return h*3600 + m*60 + s
+_AUDIO_EXTENSIONS = {".wav", ".ogg", ".flac", ".aif", ".aiff", ".mp3"}
+_NUMBER = re.compile(r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$")
 
-def parse_tone_component(spec: str) -> Optional[AnySpec]:
-    """Parses a single component string from an SBG file into a generator spec."""
+
+def _parse_hms(value: str) -> int:
+    parts = value.split(":")
+    if not 1 <= len(parts) <= 3 or any(not part.isdigit() for part in parts):
+        raise ValueError(f"Invalid schedule time: {value!r}")
+
+    numbers = [int(part) for part in parts]
+    if len(numbers) == 1:
+        return numbers[0]
+    if numbers[-1] >= 60:
+        raise ValueError(f"Schedule seconds must be below 60: {value!r}")
+    if len(numbers) == 2:
+        return numbers[0] * 60 + numbers[1]
+    if numbers[1] >= 60:
+        raise ValueError(f"Schedule minutes must be below 60: {value!r}")
+    return numbers[0] * 3600 + numbers[1] * 60 + numbers[2]
+
+
+def _split_params_and_amp(value: str, default_amp: float = 100.0) -> tuple[str, float]:
+    if "/" not in value:
+        return value, default_amp
+    params, amp_text = value.rsplit("/", 1)
+    if not _NUMBER.match(amp_text.strip()):
+        return value, default_amp
+    return params, float(amp_text)
+
+
+def _resolve_audio_path(path_text: str, base_dir: Path | None) -> Path:
+    path = Path(os.path.expandvars(path_text)).expanduser()
+    if base_dir is not None and not path.is_absolute():
+        path = base_dir / path
+    return path.resolve(strict=False)
+
+
+def _parse_file_component(spec: str, base_dir: Path | None) -> Optional[FileSpec]:
+    if "/" in spec:
+        path_text, amp_text = spec.rsplit("/", 1)
+        if _NUMBER.match(amp_text.strip()):
+            candidate = _resolve_audio_path(path_text, base_dir)
+            if candidate.suffix.lower() in _AUDIO_EXTENSIONS or candidate.is_file():
+                return FileSpec(path=str(candidate), amp=float(amp_text))
+
+    candidate = _resolve_audio_path(spec, base_dir)
+    if candidate.suffix.lower() in _AUDIO_EXTENSIONS or candidate.is_file():
+        return FileSpec(path=str(candidate))
+    return None
+
+
+def parse_tone_component(spec: str, base_dir: str | Path | None = None) -> Optional[AnySpec]:
+    """Parse one SBG component into a generator specification."""
     spec = spec.strip()
+    if not spec:
+        raise ValueError("Tone component cannot be empty")
     if spec.lower() in {"-", "off"}:
         return None
 
-    if ':' in spec and not spec[0].isdigit():
-        # Handle special prefixes like 'iso:', 'hbox:', 'spin:', etc.
-        prefix, rest = spec.split(':', 1)
-        prefix = prefix.lower()
+    resolved_base = Path(base_dir) if base_dir is not None else None
+    prefix, separator, rest = spec.partition(":")
+    recognized_prefix = prefix.lower() if separator else ""
 
-        if prefix == "iso":
-            params_str, amp_str = rest.split('/') if '/' in rest else (rest, '100')
-            freq, beat = [float(x) for x in params_str.split(',')]
-            return IsochronicSpec(freq=freq, beat=beat, amp=float(amp_str))
+    if recognized_prefix == "iso":
+        params_text, amp = _split_params_and_amp(rest)
+        params = [float(value) for value in params_text.split(",")]
+        if len(params) != 2:
+            raise ValueError("iso requires frequency and beat: iso:FREQ,BEAT[/AMP]")
+        return IsochronicSpec(freq=params[0], beat=params[1], amp=amp)
 
-        if prefix == "hbox":
-            params_str, amp_str = rest.split('/') if '/' in rest else (rest, '100')
-            base, diff, mod = [float(x) for x in params_str.split(',')]
-            return HarmonicBoxSpec(base=base, diff=diff, mod=mod, amp=float(amp_str))
+    if recognized_prefix == "hbox":
+        params_text, amp = _split_params_and_amp(rest)
+        params = [float(value) for value in params_text.split(",")]
+        if len(params) != 3:
+            raise ValueError("hbox requires base, difference, and modulation")
+        return HarmonicBoxSpec(base=params[0], diff=params[1], mod=params[2], amp=amp)
 
-        # For other unsupported prefixes (spin, slide), just use the core spec.
+    if recognized_prefix == "file":
+        parsed_file = _parse_file_component(rest, resolved_base)
+        if parsed_file is None:
+            raise ValueError(f"Unsupported audio file component: {rest!r}")
+        return parsed_file
+
+    if recognized_prefix in {"spin", "slide"}:
         spec = rest
 
-    if spec.lower().startswith("pink") or spec.lower().startswith("white"):
-        kind, amp_str = spec.split("/")
-        return NoiseSpec(kind=kind, amp=float(amp_str))
+    noise_match = re.fullmatch(
+        r"(?i)(pink|white)(?:/([+-]?(?:\d+(?:\.\d*)?|\.\d+)))?", spec
+    )
+    if noise_match:
+        return NoiseSpec(kind=noise_match.group(1).lower(), amp=float(noise_match.group(2) or 100.0))
 
-    if "/" in spec and os.path.isfile(spec.split("/")[0]):
-        path, amp_str = spec.split("/")
-        return FileSpec(path=path, amp=float(amp_str))
+    parsed_file = _parse_file_component(spec, resolved_base)
+    if parsed_file is not None:
+        return parsed_file
 
-    # Default case: standard binaural tone (e.g., "200+10/50")
-    amp = 100.0
-    core_spec = spec
-    if '/' in spec:
-        core_spec, amp_str = spec.rsplit('/', 1)
-        amp = float(amp_str)
-
+    core_spec, amp = _split_params_and_amp(spec)
     beat = 0.0
-    if '+' in core_spec:
-        base_str, beat_str = core_spec.split('+', 1)
-        beat = float(beat_str)
-    elif '-' in core_spec and core_spec.count('-') == 1 and not core_spec.startswith('-'):
-        # Handle subtraction for beat frequency, but avoid negative base frequencies
-        base_str, beat_str = core_spec.split('-', 1)
-        beat = -float(beat_str)
+    if "+" in core_spec:
+        base_text, beat_text = core_spec.split("+", 1)
+        beat = float(beat_text)
+    elif "-" in core_spec and core_spec.count("-") == 1 and not core_spec.startswith("-"):
+        base_text, beat_text = core_spec.split("-", 1)
+        beat = -float(beat_text)
     else:
-        base_str = core_spec
+        base_text = core_spec
 
-    return ToneSpec(base=float(base_str), beat=beat, amp=amp)
+    return ToneSpec(base=float(base_text), beat=beat, amp=amp)
 
-def parse_sbg_from_string(s: str):
+
+def parse_sbg_from_string(
+    source: str, base_dir: str | Path | None = None
+) -> tuple[Dict[str, List[AnySpec]], List[Tuple[float, List[str]]]]:
     tone_sets: Dict[str, List[AnySpec]] = {}
     schedule: List[Tuple[float, List[str]]] = []
-    for raw in s.splitlines():
+    resolved_base = Path(base_dir) if base_dir is not None else None
+
+    for line_number, raw in enumerate(source.splitlines(), start=1):
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
 
-        if ":" in line and not line[0].isdigit() and not line.startswith("+"):
-            label, rest = line.split(":", 1)
-            parts = [p for p in rest.split() if p]
-            comps = [c for p in parts if (c := parse_tone_component(p)) is not None]
-            tone_sets[label.strip()] = comps
-        else:
+        try:
+            is_schedule = line.upper().startswith("NOW") or line[0].isdigit() or line.startswith("+")
+            if not is_schedule and ":" in line:
+                label, rest = line.split(":", 1)
+                label = label.strip()
+                if not label:
+                    raise ValueError("Tone-set label cannot be empty")
+                parts = shlex.split(rest, comments=True, posix=True)
+                tone_sets[label] = [
+                    component
+                    for part in parts
+                    if (component := parse_tone_component(part, resolved_base)) is not None
+                ]
+                continue
+
             if line.upper().startswith("NOW"):
-                t = 0
+                time_value = 0
                 rest = line[3:].strip()
             else:
-                time_str, rest = line.split(maxsplit=1)
-                t = _parse_hms(time_str.lstrip("+"))
-            items = [x for x in rest.replace("->", " ").split() if x]
-            schedule.append((t, items))
-    schedule.sort(key=lambda x: x[0])
+                time_text, rest = line.split(maxsplit=1)
+                time_value = _parse_hms(time_text.lstrip("+"))
+
+            items = [item for item in shlex.split(rest.replace("->", " ")) if item]
+            if not items:
+                raise ValueError("Schedule event must name at least one tone set or off")
+            schedule.append((float(time_value), items))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid SBG line {line_number}: {raw.strip()} ({exc})") from exc
+
+    schedule.sort(key=lambda item: item[0])
     return tone_sets, schedule
 
-def parse_sbg(path: str):
-    with open(path, "r", encoding="latin-1") as f:
-        return parse_sbg_from_string(f.read())
+
+def parse_sbg(path: str | Path):
+    schedule_path = Path(path).expanduser().resolve()
+    with schedule_path.open("r", encoding="latin-1") as handle:
+        return parse_sbg_from_string(handle.read(), base_dir=schedule_path.parent)

--- a/pysbagen/playback.py
+++ b/pysbagen/playback.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from threading import Event
+from typing import Callable, Iterable
+
+import numpy as np
+
+
+def play_chunks(
+    chunks: Iterable[tuple[np.ndarray, list[dict]]],
+    *,
+    stop_event: Event | None = None,
+    on_chunk: Callable[[list[dict]], None] | None = None,
+) -> int:
+    """Play a generated stream immediately through PyAudio and return frames played."""
+    try:
+        import pyaudio
+    except ImportError as exc:
+        raise RuntimeError(
+            "Live playback requires the GUI extra and a working PyAudio installation: pip install 'pysbagen[gui]'"
+        ) from exc
+
+    audio = pyaudio.PyAudio()
+    stream = audio.open(format=pyaudio.paFloat32, channels=2, rate=44100, output=True)
+    frames = 0
+    try:
+        for chunk, info in chunks:
+            if stop_event is not None and stop_event.is_set():
+                break
+            normalized = np.asarray(chunk, dtype=np.float32)
+            if normalized.ndim != 2 or normalized.shape[1] != 2:
+                raise ValueError(f"Playback expected stereo chunks, got {normalized.shape}")
+            stream.write(normalized.tobytes())
+            frames += len(normalized)
+            if on_chunk is not None:
+                on_chunk(info)
+    finally:
+        stream.stop_stream()
+        stream.close()
+        audio.terminate()
+    return frames

--- a/pysbagen/playback.py
+++ b/pysbagen/playback.py
@@ -17,7 +17,7 @@ def play_chunks(
         import pyaudio
     except ImportError as exc:
         raise RuntimeError(
-            "Live playback requires the GUI extra and a working PyAudio installation: pip install 'pysbagen[gui]'"
+            "Live playback requires the GUI extra and a working PyAudio installation: pip install 'pysbagen[playback]'"
         ) from exc
 
     audio = pyaudio.PyAudio()

--- a/pysbagen/sleep.py
+++ b/pysbagen/sleep.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
+from typing import Literal
+
+from .generators.sleep import SleepJourneySpec
+
+SleepProblem = Literal["racing_mind", "cannot_cross", "waking_back_up"]
+SleepSoundWorld = Literal["warm_ambient", "slow_night_music", "rain_room", "deep_night", "user_audio"]
+SleepIntensity = Literal["gentle", "balanced", "immersive"]
+
+PROBLEM_LABELS = {
+    "racing_mind": "My mind will not stop",
+    "cannot_cross": "I feel relaxed, but cannot cross into sleep",
+    "waking_back_up": "I fall asleep, then keep waking back up",
+}
+SOUND_WORLD_LABELS = {
+    "warm_ambient": "Warm, slowly changing ambient chords",
+    "slow_night_music": "Slow, gentle night music",
+    "rain_room": "Soft rain-like room",
+    "deep_night": "Deep, dark, low-stimulation night sound",
+    "user_audio": "Use my own music or audio",
+}
+INTENSITY_LABELS = {
+    "gentle": "Very gentle — barely noticeable underlying layers",
+    "balanced": "Balanced — present, but not demanding attention",
+    "immersive": "Immersive — deeper and more enveloping",
+}
+DURATION_CHOICES = (30, 45, 60, 90)
+
+
+@dataclass(frozen=True)
+class SleepLayers:
+    binaural: bool = True
+    monaural: bool = True
+    isochronic: bool = False
+    harmonic_box: bool = True
+
+    def enabled_names(self) -> tuple[str, ...]:
+        return tuple(
+            name
+            for name, enabled in (
+                ("binaural", self.binaural),
+                ("monaural", self.monaural),
+                ("isochronic", self.isochronic),
+                ("harmonic_box", self.harmonic_box),
+            )
+            if enabled
+        )
+
+
+def recommended_layers(problem: SleepProblem, intensity: SleepIntensity) -> SleepLayers:
+    """Choose a tolerable starting blend without treating one technique as universally superior."""
+    if problem == "waking_back_up":
+        return SleepLayers(binaural=True, monaural=True, isochronic=False, harmonic_box=False)
+    if problem == "cannot_cross":
+        return SleepLayers(
+            binaural=True,
+            monaural=True,
+            isochronic=False,
+            harmonic_box=intensity != "gentle",
+        )
+    return SleepLayers(
+        binaural=True,
+        monaural=True,
+        isochronic=intensity == "immersive",
+        harmonic_box=True,
+    )
+
+
+@dataclass(frozen=True)
+class SleepRequest:
+    problem: SleepProblem
+    sound_world: SleepSoundWorld
+    intensity: SleepIntensity = "balanced"
+    duration_minutes: float = 45.0
+    user_audio: str | None = None
+    layers: SleepLayers | None = None
+    seed: int = 0
+
+    def validate(self) -> None:
+        if self.problem not in PROBLEM_LABELS:
+            raise ValueError(f"Unknown sleep problem: {self.problem}")
+        if self.sound_world not in SOUND_WORLD_LABELS:
+            raise ValueError(f"Unknown sleep sound world: {self.sound_world}")
+        if self.intensity not in INTENSITY_LABELS:
+            raise ValueError(f"Unknown sleep intensity: {self.intensity}")
+        if not 10 <= float(self.duration_minutes) <= 180:
+            raise ValueError("Sleep journeys must be between 10 and 180 minutes")
+        if self.sound_world == "user_audio" and not self.user_audio:
+            raise ValueError("Choose an audio file when using your own audio")
+        if self.user_audio and not Path(self.user_audio).expanduser().is_file():
+            raise FileNotFoundError(f"Audio file not found: {Path(self.user_audio).expanduser()}")
+        if self.layers is not None and not self.layers.enabled_names():
+            raise ValueError("Enable at least one underlying audio layer")
+
+    @property
+    def duration_seconds(self) -> float:
+        return float(self.duration_minutes) * 60.0
+
+
+@dataclass(frozen=True)
+class SleepRecipe:
+    name: str
+    request: SleepRequest
+    descent_seconds: float
+    support_seconds: float
+    start_beat_hz: float
+    end_beat_hz: float
+    carrier_hz: float
+    fade_out_seconds: float
+    description: str
+
+    @property
+    def duration_seconds(self) -> float:
+        return self.descent_seconds + self.support_seconds
+
+
+def build_sleep_recipe(request: SleepRequest) -> SleepRecipe:
+    request.validate()
+    resolved = replace(
+        request,
+        layers=request.layers or recommended_layers(request.problem, request.intensity),
+    )
+    resolved.validate()
+    duration = resolved.duration_seconds
+    profiles = {
+        "racing_mind": {
+            "name": "Racing Mind Descent",
+            "descent_ratio": 0.68,
+            "start": 10.0,
+            "end": 4.8,
+            "carrier": 190.0,
+            "description": "Begins with enough gentle movement to occupy a busy mind, then steadily removes novelty and intensity.",
+        },
+        "cannot_cross": {
+            "name": "Crossing the Threshold",
+            "descent_ratio": 0.52,
+            "start": 7.5,
+            "end": 4.5,
+            "carrier": 175.0,
+            "description": "Uses a quieter, shorter descent and a longer uneventful tail for a listener who is already relaxed.",
+        },
+        "waking_back_up": {
+            "name": "Stay-Asleep Support",
+            "descent_ratio": 0.30,
+            "start": 7.0,
+            "end": 5.0,
+            "carrier": 160.0,
+            "description": "Settles quickly, then keeps a long stable low-novelty bed before slowly disappearing.",
+        },
+    }
+    profile = profiles[resolved.problem]
+    descent = duration * profile["descent_ratio"]
+    support = duration - descent
+    fade_out = min(max(duration * 0.12, 90.0), 360.0)
+    return SleepRecipe(
+        name=profile["name"],
+        request=resolved,
+        descent_seconds=descent,
+        support_seconds=support,
+        start_beat_hz=profile["start"],
+        end_beat_hz=profile["end"],
+        carrier_hz=profile["carrier"],
+        fade_out_seconds=fade_out,
+        description=profile["description"],
+    )
+
+
+def build_sleep_spec(request: SleepRequest) -> SleepJourneySpec:
+    return SleepJourneySpec(recipe=build_sleep_recipe(request))
+
+
+def recipe_manifest(recipe: SleepRecipe) -> dict:
+    request = recipe.request
+    manifest = {
+        "format": "pysbagen-sleep-recipe-v1",
+        "recipe": {
+            "name": recipe.name,
+            "description": recipe.description,
+            "descent_seconds": recipe.descent_seconds,
+            "support_seconds": recipe.support_seconds,
+            "start_beat_hz": recipe.start_beat_hz,
+            "end_beat_hz": recipe.end_beat_hz,
+            "carrier_hz": recipe.carrier_hz,
+            "fade_out_seconds": recipe.fade_out_seconds,
+        },
+        "request": asdict(request),
+    }
+    if request.user_audio:
+        source = Path(request.user_audio).expanduser()
+        manifest["source_audio"] = {
+            "path": str(source.resolve()),
+            "sha256": _sha256(source),
+        }
+    return manifest
+
+
+def write_recipe_manifest(recipe: SleepRecipe, audio_path: str | Path) -> Path:
+    path = Path(audio_path).expanduser()
+    manifest_path = path.with_suffix(path.suffix + ".sleep.json")
+    manifest_path.write_text(
+        json.dumps(recipe_manifest(recipe), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()

--- a/pysbagen/sleep_cli.py
+++ b/pysbagen/sleep_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 from .api import render_sleep, write_audio
 from .playback import play_chunks
@@ -35,25 +36,13 @@ def collect_sleep_request(input_fn=input, print_fn=print) -> SleepRequest:
     print_fn("PySbagen Sleep Guide")
     print_fn("Answer four brief questions. You do not need to know anything about frequencies.")
     problem = _choose("What is keeping you awake tonight?", PROBLEM_LABELS, input_fn, print_fn)
-    sound_world = _choose(
-        "What kind of sound feels tolerable or pleasant tonight?",
-        SOUND_WORLD_LABELS,
-        input_fn,
-        print_fn,
-    )
+    sound_world = _choose("What kind of sound feels tolerable or pleasant tonight?", SOUND_WORLD_LABELS, input_fn, print_fn)
     user_audio = None
     if sound_world == "user_audio":
         user_audio = input_fn("Path to your music or audio file: ").strip()
-    intensity = _choose(
-        "How present should the underlying layers feel?",
-        INTENSITY_LABELS,
-        input_fn,
-        print_fn,
-    )
+    intensity = _choose("How present should the underlying layers feel?", INTENSITY_LABELS, input_fn, print_fn)
     durations = {str(value): f"{value} minutes" for value in DURATION_CHOICES}
-    duration = float(
-        _choose("How long should the journey stay with you?", durations, input_fn, print_fn)
-    )
+    duration = float(_choose("How long should the journey stay with you?", durations, input_fn, print_fn))
     return SleepRequest(
         problem=problem,
         sound_world=sound_world,
@@ -66,11 +55,7 @@ def collect_sleep_request(input_fn=input, print_fn=print) -> SleepRequest:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Conversational PySbagen sleep guide")
     parser.add_argument("-o", "--outfile", default="sleep-journey.wav")
-    parser.add_argument(
-        "--play",
-        action="store_true",
-        help="Play immediately instead of only writing a file",
-    )
+    parser.add_argument("--play", action="store_true", help="Play immediately instead of only writing a file")
     return parser
 
 
@@ -81,7 +66,8 @@ def main(argv: list[str] | None = None) -> int:
         recipe = build_sleep_recipe(request)
         print(f"\nMatched journey: {recipe.name}")
         print(recipe.description)
-        print("This is a sleep-support audio experience, not a guaranteed medical treatment.")
+        print("This is a sleep-preparation audio experience, not medical, addiction, or emergency treatment.")
+        print("Use normal professional or emergency support for dangerous withdrawal, severe or unusual symptoms, or an urgent crisis.")
         if args.play:
             print("Starting playback. Press Ctrl+C to stop.")
             play_chunks(render_sleep(request))

--- a/pysbagen/sleep_cli.py
+++ b/pysbagen/sleep_cli.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import argparse
+
+from .api import render_sleep, write_audio
+from .playback import play_chunks
+from .sleep import (
+    DURATION_CHOICES,
+    INTENSITY_LABELS,
+    PROBLEM_LABELS,
+    SOUND_WORLD_LABELS,
+    SleepRequest,
+    build_sleep_recipe,
+    write_recipe_manifest,
+)
+
+
+def _choose(question: str, choices: dict[str, str], input_fn=input, print_fn=print) -> str:
+    print_fn(f"\n{question}")
+    items = list(choices.items())
+    for index, (_, label) in enumerate(items, start=1):
+        print_fn(f"  {index}. {label}")
+    while True:
+        answer = input_fn("Choose a number: ").strip()
+        try:
+            selected = int(answer) - 1
+        except ValueError:
+            selected = -1
+        if 0 <= selected < len(items):
+            return items[selected][0]
+        print_fn("Please choose one of the listed numbers.")
+
+
+def collect_sleep_request(input_fn=input, print_fn=print) -> SleepRequest:
+    print_fn("PySbagen Sleep Guide")
+    print_fn("Answer four brief questions. You do not need to know anything about frequencies.")
+    problem = _choose("What is keeping you awake tonight?", PROBLEM_LABELS, input_fn, print_fn)
+    sound_world = _choose(
+        "What kind of sound feels tolerable or pleasant tonight?",
+        SOUND_WORLD_LABELS,
+        input_fn,
+        print_fn,
+    )
+    user_audio = None
+    if sound_world == "user_audio":
+        user_audio = input_fn("Path to your music or audio file: ").strip()
+    intensity = _choose(
+        "How present should the underlying layers feel?",
+        INTENSITY_LABELS,
+        input_fn,
+        print_fn,
+    )
+    durations = {str(value): f"{value} minutes" for value in DURATION_CHOICES}
+    duration = float(
+        _choose("How long should the journey stay with you?", durations, input_fn, print_fn)
+    )
+    return SleepRequest(
+        problem=problem,
+        sound_world=sound_world,
+        intensity=intensity,
+        duration_minutes=duration,
+        user_audio=user_audio,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Conversational PySbagen sleep guide")
+    parser.add_argument("-o", "--outfile", default="sleep-journey.wav")
+    parser.add_argument(
+        "--play",
+        action="store_true",
+        help="Play immediately instead of only writing a file",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        request = collect_sleep_request()
+        recipe = build_sleep_recipe(request)
+        print(f"\nMatched journey: {recipe.name}")
+        print(recipe.description)
+        print("This is a sleep-support audio experience, not a guaranteed medical treatment.")
+        if args.play:
+            print("Starting playback. Press Ctrl+C to stop.")
+            play_chunks(render_sleep(request))
+        else:
+            result = write_audio(render_sleep(request), args.outfile)
+            manifest = write_recipe_manifest(recipe, result.outfile)
+            print(f"Wrote {result.duration:.2f}s to {result.outfile}")
+            print(f"Saved the exact recipe to {manifest}")
+    except KeyboardInterrupt:
+        print("\nStopped.")
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise SystemExit(f"pysbagen sleep guide: {exc}") from exc
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pysbagen/tests/test_api_cli.py
+++ b/pysbagen/tests/test_api_cli.py
@@ -1,26 +1,15 @@
 from pathlib import Path
-
 import soundfile as sf
-
 from pysbagen.cli import main
 from pysbagen.mixer import SR
 
-
 def test_cli_writes_streamed_quick_session(tmp_path: Path):
     output = tmp_path / "quick.wav"
-
-    result = main([
-        "--base", "200",
-        "--beat", "10",
-        "--duration", "0.1",
-        "--outfile", str(output),
-    ])
-
+    result = main(["--base", "200", "--beat", "10", "--duration", "0.1", "--outfile", str(output)])
     audio, rate = sf.read(output, always_2d=True)
     assert result == 0
     assert rate == SR
     assert audio.shape == (SR // 10, 2)
-
 
 def test_cli_schedule_uses_schedule_directory_for_audio(tmp_path: Path):
     background = tmp_path / "background.wav"
@@ -28,10 +17,35 @@ def test_cli_schedule_uses_schedule_directory_for_audio(tmp_path: Path):
     schedule = tmp_path / "session.sbg"
     schedule.write_text("bed: background.wav/50\nNOW bed\n0:01 off\n", encoding="latin-1")
     output = tmp_path / "scheduled.wav"
-
     result = main([str(schedule), "--outfile", str(output)])
-
     audio, rate = sf.read(output, always_2d=True)
     assert result == 0
     assert rate == SR
     assert audio.shape == (SR, 2)
+
+
+def test_failed_render_preserves_existing_destination(tmp_path: Path):
+    from pysbagen.api import write_audio
+    import numpy as np
+    import pytest
+
+    output = tmp_path / "existing.wav"
+    output.write_bytes(b"original")
+
+    def invalid_stream():
+        yield np.zeros((10, 3), dtype=np.float32), []
+
+    with pytest.raises(ValueError, match="stereo"):
+        write_audio(invalid_stream(), output)
+    assert output.read_bytes() == b"original"
+
+
+def test_empty_render_preserves_existing_destination(tmp_path: Path):
+    from pysbagen.api import write_audio
+    import pytest
+
+    output = tmp_path / "existing.wav"
+    output.write_bytes(b"original")
+    with pytest.raises(ValueError, match="No audio"):
+        write_audio(iter(()), output)
+    assert output.read_bytes() == b"original"

--- a/pysbagen/tests/test_api_cli.py
+++ b/pysbagen/tests/test_api_cli.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import soundfile as sf
+
+from pysbagen.cli import main
+from pysbagen.mixer import SR
+
+
+def test_cli_writes_streamed_quick_session(tmp_path: Path):
+    output = tmp_path / "quick.wav"
+
+    result = main([
+        "--base", "200",
+        "--beat", "10",
+        "--duration", "0.1",
+        "--outfile", str(output),
+    ])
+
+    audio, rate = sf.read(output, always_2d=True)
+    assert result == 0
+    assert rate == SR
+    assert audio.shape == (SR // 10, 2)
+
+
+def test_cli_schedule_uses_schedule_directory_for_audio(tmp_path: Path):
+    background = tmp_path / "background.wav"
+    sf.write(background, [[0.25, 0.25]] * 100, SR)
+    schedule = tmp_path / "session.sbg"
+    schedule.write_text("bed: background.wav/50\nNOW bed\n0:01 off\n", encoding="latin-1")
+    output = tmp_path / "scheduled.wav"
+
+    result = main([str(schedule), "--outfile", str(output)])
+
+    audio, rate = sf.read(output, always_2d=True)
+    assert result == 0
+    assert rate == SR
+    assert audio.shape == (SR, 2)

--- a/pysbagen/tests/test_file_generator.py
+++ b/pysbagen/tests/test_file_generator.py
@@ -1,11 +1,9 @@
 from pathlib import Path
-
 import numpy as np
 import pytest
 import soundfile as sf
-
 import pysbagen.generators.file as file_generator
-from pysbagen.generators import FileSpec
+from pysbagen.generators import FileSpec, load_audio
 from pysbagen.mixer import SR, mix_generators
 
 
@@ -17,9 +15,7 @@ def test_file_generator_resamples_and_expands_mono(tmp_path: Path):
     path = tmp_path / "mono.wav"
     source_rate = 22050
     sf.write(path, np.linspace(-0.5, 0.5, source_rate // 10, dtype=np.float32), source_rate)
-
     audio = stack(mix_generators([FileSpec(path=str(path))], 0.1))
-
     assert audio.shape == (SR // 10, 2)
     np.testing.assert_allclose(audio[:, 0], audio[:, 1], atol=1e-5)
 
@@ -27,10 +23,8 @@ def test_file_generator_resamples_and_expands_mono(tmp_path: Path):
 def test_short_file_is_padded_and_loop_option_repeats(tmp_path: Path):
     path = tmp_path / "short.wav"
     sf.write(path, np.ones((100, 2), dtype=np.float32) * 0.25, SR)
-
     padded = stack(mix_generators([FileSpec(path=str(path))], 0.01))
     looped = stack(mix_generators([FileSpec(path=str(path), loop=True)], 0.01))
-
     assert np.allclose(padded[100:], 0)
     assert np.any(looped[100:] != 0)
 
@@ -39,7 +33,6 @@ def test_mp3_requires_ffmpeg_without_importing_legacy_audioop(tmp_path: Path, mo
     path = tmp_path / "session.mp3"
     path.write_bytes(b"not-real-mp3")
     monkeypatch.setattr(file_generator.shutil, "which", lambda executable: None)
-
     with pytest.raises(RuntimeError, match="FFmpeg"):
         FileSpec(path=str(path))._load()
 
@@ -63,9 +56,23 @@ def test_mp3_decoder_reads_ffmpeg_float_output(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(file_generator.shutil, "which", lambda executable: "/usr/bin/ffmpeg")
     monkeypatch.setattr(file_generator.subprocess, "run", fake_run)
-
     decoded = FileSpec(path=str(path))._load()
-
     np.testing.assert_array_equal(decoded, expected)
     assert captured["command"][-1] == "pipe:1"
     assert captured["command"][captured["command"].index("-ar") + 1] == str(SR)
+
+
+def test_unknown_format_falls_back_to_ffmpeg(tmp_path: Path, monkeypatch):
+    path = tmp_path / "session.weird"
+    path.write_bytes(b"not-real-audio")
+    expected = np.array([[0.1, -0.1]], dtype="<f4")
+
+    class Result:
+        returncode = 0
+        stdout = expected.tobytes()
+        stderr = b""
+
+    monkeypatch.setattr(file_generator.sf, "read", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("unsupported")))
+    monkeypatch.setattr(file_generator.shutil, "which", lambda executable: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(file_generator.subprocess, "run", lambda *args, **kwargs: Result())
+    np.testing.assert_array_equal(load_audio(path), expected)

--- a/pysbagen/tests/test_file_generator.py
+++ b/pysbagen/tests/test_file_generator.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 import soundfile as sf
 
+import pysbagen.generators.file as file_generator
 from pysbagen.generators import FileSpec
 from pysbagen.mixer import SR, mix_generators
 
@@ -31,3 +33,39 @@ def test_short_file_is_padded_and_loop_option_repeats(tmp_path: Path):
 
     assert np.allclose(padded[100:], 0)
     assert np.any(looped[100:] != 0)
+
+
+def test_mp3_requires_ffmpeg_without_importing_legacy_audioop(tmp_path: Path, monkeypatch):
+    path = tmp_path / "session.mp3"
+    path.write_bytes(b"not-real-mp3")
+    monkeypatch.setattr(file_generator.shutil, "which", lambda executable: None)
+
+    with pytest.raises(RuntimeError, match="FFmpeg"):
+        FileSpec(path=str(path))._load()
+
+
+def test_mp3_decoder_reads_ffmpeg_float_output(tmp_path: Path, monkeypatch):
+    path = tmp_path / "session.mp3"
+    path.write_bytes(b"not-real-mp3")
+    expected = np.array([[0.25, -0.25], [0.5, -0.5]], dtype="<f4")
+    captured = {}
+
+    class Result:
+        returncode = 0
+        stdout = expected.tobytes()
+        stderr = b""
+
+    def fake_run(command, capture_output, check):
+        captured["command"] = command
+        assert capture_output is True
+        assert check is False
+        return Result()
+
+    monkeypatch.setattr(file_generator.shutil, "which", lambda executable: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(file_generator.subprocess, "run", fake_run)
+
+    decoded = FileSpec(path=str(path))._load()
+
+    np.testing.assert_array_equal(decoded, expected)
+    assert captured["command"][-1] == "pipe:1"
+    assert captured["command"][captured["command"].index("-ar") + 1] == str(SR)

--- a/pysbagen/tests/test_file_generator.py
+++ b/pysbagen/tests/test_file_generator.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+from pysbagen.generators import FileSpec
+from pysbagen.mixer import SR, mix_generators
+
+
+def stack(generator):
+    return np.vstack([chunk for chunk, _ in generator])
+
+
+def test_file_generator_resamples_and_expands_mono(tmp_path: Path):
+    path = tmp_path / "mono.wav"
+    source_rate = 22050
+    sf.write(path, np.linspace(-0.5, 0.5, source_rate // 10, dtype=np.float32), source_rate)
+
+    audio = stack(mix_generators([FileSpec(path=str(path))], 0.1))
+
+    assert audio.shape == (SR // 10, 2)
+    np.testing.assert_allclose(audio[:, 0], audio[:, 1], atol=1e-5)
+
+
+def test_short_file_is_padded_and_loop_option_repeats(tmp_path: Path):
+    path = tmp_path / "short.wav"
+    sf.write(path, np.ones((100, 2), dtype=np.float32) * 0.25, SR)
+
+    padded = stack(mix_generators([FileSpec(path=str(path))], 0.01))
+    looped = stack(mix_generators([FileSpec(path=str(path), loop=True)], 0.01))
+
+    assert np.allclose(padded[100:], 0)
+    assert np.any(looped[100:] != 0)

--- a/pysbagen/tests/test_mixer.py
+++ b/pysbagen/tests/test_mixer.py
@@ -1,24 +1,49 @@
 import numpy as np
-from pysbagen.mixer import mix_generators
-from pysbagen.generators.binaural import ToneSpec
+import pytest
 
-def test_mix_generators():
-    # Create a couple of tone specs
-    spec1 = ToneSpec(base=200, beat=10, amp=50)
-    spec2 = ToneSpec(base=300, beat=20, amp=50)
+from pysbagen.generators import ToneSpec
+from pysbagen.mixer import SR, build_session_generator, mix_generators
 
-    # Mix them for 1 second
-    duration = 1.0
-    mixed_generator = mix_generators([spec1, spec2], duration)
 
-    # Get all the chunks and stack them
-    chunks = [chunk for chunk, info in mixed_generator]
-    audio = np.vstack(chunks)
+class ShortGenerator:
+    sample_rate = SR
 
-    # Check the shape of the output
-    assert audio.shape[0] == int(44100 * duration)
-    assert audio.shape[1] == 2
+    def generator(self, duration):
+        yield np.ones((100, 1), dtype=np.float32), {"type": "short"}
 
-    # Check the peak level
-    peak = np.max(np.abs(audio))
-    assert peak <= 1.0
+
+def stack(generator):
+    return np.vstack([chunk for chunk, _ in generator])
+
+
+def test_mix_generators_has_exact_duration():
+    audio = stack(mix_generators([ToneSpec(base=200, beat=10, amp=50)], 1.125))
+    assert audio.shape == (int(SR * 1.125), 2)
+    assert np.max(np.abs(audio)) <= 1.0
+
+
+def test_exhausted_stream_does_not_truncate_other_generators():
+    audio = stack(mix_generators([ShortGenerator(), ToneSpec()], 0.1))
+    assert audio.shape == (int(SR * 0.1), 2)
+    assert np.any(audio[100:] != 0)
+
+
+def test_empty_mix_preserves_silent_timeline():
+    audio = stack(mix_generators([], 0.25))
+    assert audio.shape == (int(SR * 0.25), 2)
+    assert np.all(audio == 0)
+
+
+def test_schedule_preserves_leading_silence_and_honors_duration():
+    tone = ToneSpec(base=200, beat=10)
+    schedule = [(1.0, ["alpha"]), (3.0, ["off"])]
+    audio = stack(build_session_generator({"alpha": [tone]}, schedule, duration=2.0))
+
+    assert audio.shape == (int(SR * 2.0), 2)
+    assert np.all(audio[:SR] == 0)
+    assert np.any(audio[SR:] != 0)
+
+
+def test_unknown_schedule_name_fails_loudly():
+    with pytest.raises(ValueError, match="unknown tone set"):
+        list(build_session_generator({}, [(0, ["missing"]), (1, ["off"])], duration=1))

--- a/pysbagen/tests/test_mixer.py
+++ b/pysbagen/tests/test_mixer.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pysbagen.generators import ToneSpec
-from pysbagen.mixer import SR, build_session_generator, mix_generators
+from pysbagen.mixer import SR, _apply_schedule_event, build_session_generator, mix_generators
 
 
 class ShortGenerator:
@@ -47,3 +47,15 @@ def test_schedule_preserves_leading_silence_and_honors_duration():
 def test_unknown_schedule_name_fails_loudly():
     with pytest.raises(ValueError, match="unknown tone set"):
         list(build_session_generator({}, [(0, ["missing"]), (1, ["off"])], duration=1))
+
+
+def test_relative_removal_uses_identity_not_dataclass_equality():
+    first = ToneSpec(base=200, beat=10)
+    equal_but_distinct = ToneSpec(base=200, beat=10)
+    tone_sets = {"first": [first], "second": [equal_but_distinct]}
+
+    active = _apply_schedule_event([], tone_sets, ["first", "+second"])
+    active = _apply_schedule_event(active, tone_sets, ["-first"])
+
+    assert active == [equal_but_distinct]
+    assert active[0] is equal_but_distinct

--- a/pysbagen/tests/test_mixer.py
+++ b/pysbagen/tests/test_mixer.py
@@ -1,61 +1,93 @@
 import numpy as np
 import pytest
-
 from pysbagen.generators import ToneSpec
 from pysbagen.mixer import SR, _apply_schedule_event, build_session_generator, mix_generators
 
-
 class ShortGenerator:
     sample_rate = SR
-
     def generator(self, duration):
         yield np.ones((100, 1), dtype=np.float32), {"type": "short"}
 
-
 def stack(generator):
     return np.vstack([chunk for chunk, _ in generator])
-
 
 def test_mix_generators_has_exact_duration():
     audio = stack(mix_generators([ToneSpec(base=200, beat=10, amp=50)], 1.125))
     assert audio.shape == (int(SR * 1.125), 2)
     assert np.max(np.abs(audio)) <= 1.0
 
-
 def test_exhausted_stream_does_not_truncate_other_generators():
     audio = stack(mix_generators([ShortGenerator(), ToneSpec()], 0.1))
     assert audio.shape == (int(SR * 0.1), 2)
     assert np.any(audio[100:] != 0)
-
 
 def test_empty_mix_preserves_silent_timeline():
     audio = stack(mix_generators([], 0.25))
     assert audio.shape == (int(SR * 0.25), 2)
     assert np.all(audio == 0)
 
-
 def test_schedule_preserves_leading_silence_and_honors_duration():
     tone = ToneSpec(base=200, beat=10)
     schedule = [(1.0, ["alpha"]), (3.0, ["off"])]
     audio = stack(build_session_generator({"alpha": [tone]}, schedule, duration=2.0))
-
     assert audio.shape == (int(SR * 2.0), 2)
     assert np.all(audio[:SR] == 0)
     assert np.any(audio[SR:] != 0)
-
 
 def test_unknown_schedule_name_fails_loudly():
     with pytest.raises(ValueError, match="unknown tone set"):
         list(build_session_generator({}, [(0, ["missing"]), (1, ["off"])], duration=1))
 
-
 def test_relative_removal_uses_identity_not_dataclass_equality():
     first = ToneSpec(base=200, beat=10)
     equal_but_distinct = ToneSpec(base=200, beat=10)
     tone_sets = {"first": [first], "second": [equal_but_distinct]}
-
     active = _apply_schedule_event([], tone_sets, ["first", "+second"])
     active = _apply_schedule_event(active, tone_sets, ["-first"])
-
     assert active == [equal_but_distinct]
     assert active[0] is equal_but_distinct
+
+
+class CountingGenerator:
+    sample_rate = SR
+
+    def __init__(self, value=0.1):
+        self.value = value
+        self.calls = 0
+
+    def generator(self, duration):
+        self.calls += 1
+        total = int(SR * duration)
+        for start in range(0, total, 128):
+            count = min(128, total - start)
+            yield np.full((count, 2), self.value, dtype=np.float32), {"type": "counting"}
+
+
+def test_schedule_reuses_still_active_streams_across_events():
+    bed = CountingGenerator(0.1)
+    overlay = CountingGenerator(0.05)
+    schedule = [
+        (0.0, ["bed"]),
+        (0.01, ["+overlay"]),
+        (0.02, ["-overlay"]),
+        (0.03, ["off"]),
+    ]
+    audio = stack(build_session_generator({"bed": [bed], "overlay": [overlay]}, schedule, duration=0.03))
+    assert audio.shape == (int(SR * 0.03), 2)
+    assert bed.calls == 1
+    assert overlay.calls == 1
+
+
+def test_bare_dash_clears_every_active_generator():
+    tone = ToneSpec(base=200, beat=10)
+    active = _apply_schedule_event([], {"alpha": [tone]}, ["alpha"])
+    assert _apply_schedule_event(active, {"alpha": [tone]}, ["-"]) == []
+
+
+def test_arrow_crossfades_to_next_event_over_full_interval():
+    low = CountingGenerator(0.2)
+    high = CountingGenerator(0.8)
+    schedule = [(0.0, ["low", "->"]), (0.02, ["high"])]
+    audio = stack(build_session_generator({"low": [low], "high": [high]}, schedule, duration=0.02))
+    assert float(np.mean(audio[0])) == pytest.approx(0.2, abs=0.01)
+    assert float(np.mean(audio[-1])) == pytest.approx(0.8, abs=0.01)

--- a/pysbagen/tests/test_parser.py
+++ b/pysbagen/tests/test_parser.py
@@ -1,26 +1,52 @@
-import os
-from pysbagen.parser import parse_sbg
+from pathlib import Path
 
-def test_parse_sbg():
-    # Create a dummy .sbg file for testing
-    sbg_content = """
-    # This is a test
-    alpha: 200+10/50
-    beta: 300+20/60
+import pytest
 
+from pysbagen.generators import FileSpec, HarmonicBoxSpec, IsochronicSpec, NoiseSpec, ToneSpec
+from pysbagen.parser import parse_sbg_from_string, parse_tone_component
+
+
+def test_parse_complete_schedule():
+    source = """
+    # Full component coverage
+    alpha: 200+10/50 pink/10 iso:220,8/40 hbox:180,5,8/30
     NOW alpha
-    0:10 beta
+    0:10 off
     """
-    sbg_path = "test.sbg"
-    with open(sbg_path, "w") as f:
-        f.write(sbg_content)
+    tone_sets, schedule = parse_sbg_from_string(source)
 
-    tone_sets, schedule = parse_sbg(sbg_path)
+    assert [type(item) for item in tone_sets["alpha"]] == [
+        ToneSpec,
+        NoiseSpec,
+        IsochronicSpec,
+        HarmonicBoxSpec,
+    ]
+    assert schedule == [(0.0, ["alpha"]), (10.0, ["off"])]
 
-    assert "alpha" in tone_sets
-    assert "beta" in tone_sets
-    assert len(schedule) == 2
-    assert schedule[0][0] == 0
-    assert schedule[1][0] == 10
 
-    os.remove(sbg_path)
+def test_file_component_resolves_paths_with_slashes(tmp_path: Path):
+    audio = tmp_path / "soundscapes" / "rain.wav"
+    audio.parent.mkdir()
+    audio.touch()
+
+    parsed = parse_tone_component("soundscapes/rain.wav/45", base_dir=tmp_path)
+
+    assert isinstance(parsed, FileSpec)
+    assert parsed.path == str(audio.resolve())
+    assert parsed.amp == 45
+
+
+def test_quoted_file_path_is_one_component(tmp_path: Path):
+    audio = tmp_path / "soft rain.wav"
+    audio.touch()
+    source = 'rain: "soft rain.wav/35"\nNOW rain\n0:01 off\n'
+
+    tone_sets, _ = parse_sbg_from_string(source, base_dir=tmp_path)
+
+    assert isinstance(tone_sets["rain"][0], FileSpec)
+    assert tone_sets["rain"][0].path == str(audio.resolve())
+
+
+def test_invalid_line_reports_line_number():
+    with pytest.raises(ValueError, match="line 2"):
+        parse_sbg_from_string("alpha: 200+10\n0:99 alpha")

--- a/pysbagen/tests/test_parser.py
+++ b/pysbagen/tests/test_parser.py
@@ -1,10 +1,7 @@
 from pathlib import Path
-
 import pytest
-
 from pysbagen.generators import FileSpec, HarmonicBoxSpec, IsochronicSpec, NoiseSpec, ToneSpec
 from pysbagen.parser import parse_sbg_from_string, parse_tone_component
-
 
 def test_parse_complete_schedule():
     source = """
@@ -14,39 +11,38 @@ def test_parse_complete_schedule():
     0:10 off
     """
     tone_sets, schedule = parse_sbg_from_string(source)
-
-    assert [type(item) for item in tone_sets["alpha"]] == [
-        ToneSpec,
-        NoiseSpec,
-        IsochronicSpec,
-        HarmonicBoxSpec,
-    ]
+    assert [type(item) for item in tone_sets["alpha"]] == [ToneSpec, NoiseSpec, IsochronicSpec, HarmonicBoxSpec]
     assert schedule == [(0.0, ["alpha"]), (10.0, ["off"])]
-
 
 def test_file_component_resolves_paths_with_slashes(tmp_path: Path):
     audio = tmp_path / "soundscapes" / "rain.wav"
     audio.parent.mkdir()
     audio.touch()
-
     parsed = parse_tone_component("soundscapes/rain.wav/45", base_dir=tmp_path)
-
     assert isinstance(parsed, FileSpec)
     assert parsed.path == str(audio.resolve())
     assert parsed.amp == 45
-
 
 def test_quoted_file_path_is_one_component(tmp_path: Path):
     audio = tmp_path / "soft rain.wav"
     audio.touch()
     source = 'rain: "soft rain.wav/35"\nNOW rain\n0:01 off\n'
-
     tone_sets, _ = parse_sbg_from_string(source, base_dir=tmp_path)
-
     assert isinstance(tone_sets["rain"][0], FileSpec)
     assert tone_sets["rain"][0].path == str(audio.resolve())
-
 
 def test_invalid_line_reports_line_number():
     with pytest.raises(ValueError, match="line 2"):
         parse_sbg_from_string("alpha: 200+10\n0:99 alpha")
+
+
+def test_transition_arrow_is_preserved_for_the_next_timed_event():
+    source = "alpha: 200+10/20\nbeta: 200+5/20\nNOW == alpha ->\n0:10 == beta\n"
+    _, schedule = parse_sbg_from_string(source)
+    assert schedule == [(0.0, ["alpha", "->"]), (10.0, ["beta"])]
+
+
+def test_transition_arrow_must_end_the_schedule_line():
+    source = "alpha: 200+10/20\nbeta: 200+5/20\nNOW alpha -> beta\n0:10 off\n"
+    with pytest.raises(ValueError, match="must end"):
+        parse_sbg_from_string(source)

--- a/pysbagen/tests/test_sleep.py
+++ b/pysbagen/tests/test_sleep.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+import json
+import numpy as np
+import pytest
+import soundfile as sf
+
+from pysbagen.generators.sleep import SleepJourneySpec
+from pysbagen.sleep import (
+    SleepLayers,
+    SleepRequest,
+    build_sleep_recipe,
+    recommended_layers,
+    recipe_manifest,
+    write_recipe_manifest,
+)
+
+
+def request(**overrides):
+    values = dict(problem="racing_mind", sound_world="warm_ambient", intensity="balanced", duration_minutes=10, seed=4)
+    values.update(overrides)
+    return SleepRequest(**values)
+
+
+def test_problem_profiles_are_materially_different():
+    racing = build_sleep_recipe(request(problem="racing_mind"))
+    crossing = build_sleep_recipe(request(problem="cannot_cross"))
+    waking = build_sleep_recipe(request(problem="waking_back_up"))
+    assert racing.descent_seconds > crossing.descent_seconds > waking.descent_seconds
+    assert racing.start_beat_hz > crossing.start_beat_hz >= waking.start_beat_hz
+    assert waking.support_seconds > crossing.support_seconds > racing.support_seconds
+
+
+def test_recommended_layers_change_by_problem_and_intensity():
+    assert recommended_layers("racing_mind", "immersive").isochronic is True
+    assert recommended_layers("waking_back_up", "immersive").harmonic_box is False
+    assert recommended_layers("cannot_cross", "gentle").harmonic_box is False
+
+
+def test_request_requires_user_audio_when_selected():
+    with pytest.raises(ValueError, match="Choose an audio file"):
+        build_sleep_recipe(request(sound_world="user_audio"))
+
+
+def test_request_requires_at_least_one_custom_layer():
+    with pytest.raises(ValueError, match="Enable at least one"):
+        build_sleep_recipe(request(layers=SleepLayers(False, False, False, False)))
+
+
+def test_low_rate_generator_is_stereo_bounded_and_reports_both_stages():
+    recipe = build_sleep_recipe(request())
+    spec = SleepJourneySpec(recipe=recipe, sample_rate=200, frame=64)
+    frames = 0
+    stages = set()
+    for chunk, info in spec.generator(recipe.duration_seconds):
+        assert chunk.ndim == 2 and chunk.shape[1] == 2
+        assert np.max(np.abs(chunk)) <= 1.0
+        frames += len(chunk)
+        stages.add(info["stage"])
+    assert frames == int(200 * recipe.duration_seconds)
+    assert stages == {"sleep_descent", "sleep_support"}
+
+
+def test_user_audio_can_be_layered_and_looped(tmp_path: Path):
+    path = tmp_path / "short.flac"
+    data = np.column_stack((np.linspace(-0.2, 0.2, 200), np.linspace(0.2, -0.2, 200))).astype(np.float32)
+    sf.write(path, data, 200)
+    recipe = build_sleep_recipe(request(sound_world="user_audio", user_audio=str(path)))
+    first, info = next(SleepJourneySpec(recipe=recipe, sample_rate=200, frame=64).generator(recipe.duration_seconds))
+    assert first.shape == (64, 2)
+    assert info["sound_world"] == "user_audio"
+
+
+def test_seed_makes_generated_bed_reproducible():
+    first_recipe = build_sleep_recipe(request(seed=99))
+    other_recipe = build_sleep_recipe(request(seed=100))
+    first, _ = next(SleepJourneySpec(recipe=first_recipe, sample_rate=200, frame=64).generator(first_recipe.duration_seconds))
+    second, _ = next(SleepJourneySpec(recipe=first_recipe, sample_rate=200, frame=64).generator(first_recipe.duration_seconds))
+    other, _ = next(SleepJourneySpec(recipe=other_recipe, sample_rate=200, frame=64).generator(other_recipe.duration_seconds))
+    assert np.array_equal(first, second)
+    assert not np.array_equal(first, other)
+
+
+def test_recipe_manifest_records_exact_layers_and_source_hash(tmp_path: Path):
+    source = tmp_path / "source.wav"
+    sf.write(source, np.zeros((20, 2), dtype=np.float32), 200)
+    recipe = build_sleep_recipe(request(sound_world="user_audio", user_audio=str(source)))
+    manifest = recipe_manifest(recipe)
+    assert manifest["format"] == "pysbagen-sleep-recipe-v1"
+    assert manifest["request"]["layers"]["binaural"] is True
+    assert len(manifest["source_audio"]["sha256"]) == 64
+    output = tmp_path / "journey.wav"
+    path = write_recipe_manifest(recipe, output)
+    assert json.loads(path.read_text())["recipe"]["name"] == recipe.name

--- a/pysbagen/tests/test_sleep_cli.py
+++ b/pysbagen/tests/test_sleep_cli.py
@@ -1,0 +1,12 @@
+from pysbagen.sleep_cli import collect_sleep_request
+
+
+def test_conversation_collects_human_sleep_request():
+    answers = iter(["1", "2", "3", "2"])
+    output = []
+    request = collect_sleep_request(input_fn=lambda prompt: next(answers), print_fn=output.append)
+    assert request.problem == "racing_mind"
+    assert request.sound_world == "slow_night_music"
+    assert request.intensity == "immersive"
+    assert request.duration_minutes == 45
+    assert any("do not need to know anything about frequencies" in line for line in output)

--- a/sleep_gui.py
+++ b/sleep_gui.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+import threading
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+
+from pysbagen.api import render_sleep, write_audio
+from pysbagen.playback import play_chunks
+from pysbagen.sleep import (
+    DURATION_CHOICES,
+    INTENSITY_LABELS,
+    PROBLEM_LABELS,
+    SOUND_WORLD_LABELS,
+    SleepLayers,
+    SleepRequest,
+    build_sleep_recipe,
+    write_recipe_manifest,
+)
+
+
+class SleepGuideGui:
+    def __init__(self, root: tk.Tk):
+        self.root = root
+        self.page_index = 0
+        self.pages: list[ttk.Frame] = []
+        self.stop_event = threading.Event()
+        self.worker: threading.Thread | None = None
+
+        root.title("PySbagen Sleep Guide")
+        root.geometry("760x650")
+        root.minsize(680, 560)
+
+        ttk.Label(
+            root,
+            text="PySbagen Sleep Guide",
+            font=("Helvetica", 20, "bold"),
+        ).pack(pady=(16, 4))
+        ttk.Label(
+            root,
+            text="Tell me what is happening tonight. PySbagen will build a matched, gradually fading audio journey.",
+            wraplength=680,
+            justify="center",
+        ).pack(pady=(0, 12))
+
+        self.page_host = ttk.Frame(root, padding=14)
+        self.page_host.pack(fill="both", expand=True, padx=16)
+
+        self.problem = tk.StringVar(value="racing_mind")
+        self.sound_world = tk.StringVar(value="warm_ambient")
+        self.intensity = tk.StringVar(value="balanced")
+        self.duration = tk.StringVar(value="45")
+        self.user_audio = tk.StringVar()
+        self.outfile = tk.StringVar(value="sleep-journey.wav")
+        self.use_recommended = tk.BooleanVar(value=True)
+        self.layer_binaural = tk.BooleanVar(value=True)
+        self.layer_monaural = tk.BooleanVar(value=True)
+        self.layer_isochronic = tk.BooleanVar(value=False)
+        self.layer_hbox = tk.BooleanVar(value=True)
+        self.summary = tk.StringVar()
+        self.status = tk.StringVar(value="Ready")
+
+        self._build_problem_page()
+        self._build_sound_page()
+        self._build_intensity_page()
+        self._build_ready_page()
+        self._show_page(0)
+
+        controls = ttk.Frame(root, padding=(16, 8))
+        controls.pack(fill="x")
+        self.back_button = ttk.Button(controls, text="Back", command=self.back)
+        self.back_button.pack(side="left")
+        self.next_button = ttk.Button(controls, text="Next", command=self.next)
+        self.next_button.pack(side="right")
+        ttk.Label(root, textvariable=self.status, relief=tk.SUNKEN, anchor="w").pack(
+            fill="x", side="bottom"
+        )
+        self._update_navigation()
+
+    def _new_page(self, heading: str, prompt: str) -> ttk.Frame:
+        page = ttk.Frame(self.page_host)
+        ttk.Label(page, text=heading, font=("Helvetica", 16, "bold")).pack(
+            anchor="w", pady=(4, 8)
+        )
+        ttk.Label(page, text=prompt, wraplength=650, justify="left").pack(
+            anchor="w", pady=(0, 14)
+        )
+        self.pages.append(page)
+        return page
+
+    def _radio_choices(
+        self,
+        parent: ttk.Frame,
+        variable: tk.StringVar,
+        choices: dict[str, str],
+    ) -> None:
+        for value, label in choices.items():
+            ttk.Radiobutton(parent, text=label, variable=variable, value=value).pack(
+                anchor="w", pady=6
+            )
+
+    def _build_problem_page(self):
+        page = self._new_page(
+            "1. What is keeping you awake?",
+            "Choose the description closest to what is happening tonight.",
+        )
+        self._radio_choices(page, self.problem, PROBLEM_LABELS)
+
+    def _build_sound_page(self):
+        page = self._new_page(
+            "2. What would feel pleasant?",
+            "The pleasant layer is part of the journey, not filler hiding a tone.",
+        )
+        self._radio_choices(page, self.sound_world, SOUND_WORLD_LABELS)
+        row = ttk.Frame(page)
+        row.pack(fill="x", pady=(12, 0))
+        ttk.Entry(row, textvariable=self.user_audio).pack(
+            side="left", fill="x", expand=True
+        )
+        ttk.Button(row, text="Choose my audio…", command=self.choose_audio).pack(
+            side="left", padx=(8, 0)
+        )
+        ttk.Label(
+            page,
+            text="Used only when ‘Use my own music or audio’ is selected.",
+        ).pack(anchor="w", pady=4)
+
+    def _build_intensity_page(self):
+        page = self._new_page(
+            "3. How present should the hidden layers feel?",
+            "Choose by feel. You do not need to choose frequencies.",
+        )
+        self._radio_choices(page, self.intensity, INTENSITY_LABELS)
+        ttk.Checkbutton(
+            page,
+            text="Use the recommended layer blend for this sleep problem",
+            variable=self.use_recommended,
+            command=self._toggle_custom_layers,
+        ).pack(anchor="w", pady=(16, 6))
+        self.layer_frame = ttk.LabelFrame(
+            page,
+            text="Optional layer choices",
+            padding=10,
+        )
+        self.layer_frame.pack(fill="x")
+        for text, variable in (
+            ("Binaural", self.layer_binaural),
+            ("Monaural", self.layer_monaural),
+            ("Soft isochronic modulation", self.layer_isochronic),
+            ("Harmonic Box X-style layer", self.layer_hbox),
+        ):
+            ttk.Checkbutton(self.layer_frame, text=text, variable=variable).pack(
+                anchor="w", pady=2
+            )
+        self._toggle_custom_layers()
+
+    def _build_ready_page(self):
+        page = self._new_page(
+            "4. How long should it stay with you?",
+            "The journey descends, enters a quieter support period, and slowly fades away.",
+        )
+        duration_row = ttk.Frame(page)
+        duration_row.pack(fill="x", pady=6)
+        ttk.Label(duration_row, text="Journey length").pack(side="left")
+        ttk.Combobox(
+            duration_row,
+            textvariable=self.duration,
+            values=tuple(str(value) for value in DURATION_CHOICES),
+            state="readonly",
+            width=8,
+        ).pack(side="left", padx=8)
+        ttk.Label(duration_row, text="minutes").pack(side="left")
+
+        ttk.Separator(page).pack(fill="x", pady=14)
+        ttk.Label(
+            page,
+            textvariable=self.summary,
+            wraplength=650,
+            justify="left",
+        ).pack(anchor="w", pady=6)
+        ttk.Label(
+            page,
+            text="Keep the volume comfortable. Stop if the audio causes pain, dizziness, agitation, or other unwanted effects.",
+            wraplength=650,
+        ).pack(anchor="w", pady=(6, 14))
+
+        actions = ttk.Frame(page)
+        actions.pack(fill="x", pady=4)
+        self.play_button = ttk.Button(
+            actions,
+            text="Put on headphones and start",
+            command=self.start_playback,
+        )
+        self.play_button.pack(side="left")
+        self.stop_button = ttk.Button(
+            actions,
+            text="Stop",
+            command=self.stop_playback,
+            state="disabled",
+        )
+        self.stop_button.pack(side="left", padx=8)
+
+        save = ttk.LabelFrame(page, text="Or save the journey", padding=8)
+        save.pack(fill="x", pady=(14, 0))
+        row = ttk.Frame(save)
+        row.pack(fill="x")
+        ttk.Entry(row, textvariable=self.outfile).pack(
+            side="left", fill="x", expand=True
+        )
+        ttk.Button(row, text="Choose output…", command=self.choose_output).pack(
+            side="left", padx=8
+        )
+        ttk.Button(
+            save,
+            text="Generate audio file",
+            command=self.save_audio,
+        ).pack(anchor="e", pady=(8, 0))
+
+    def _toggle_custom_layers(self):
+        state = "disabled" if self.use_recommended.get() else "normal"
+        for child in self.layer_frame.winfo_children():
+            child.configure(state=state)
+
+    def choose_audio(self):
+        path = filedialog.askopenfilename(
+            title="Choose music or audio",
+            filetypes=(("Audio files", "*.*"),),
+        )
+        if path:
+            self.user_audio.set(path)
+            self.sound_world.set("user_audio")
+
+    def choose_output(self):
+        path = filedialog.asksaveasfilename(
+            title="Save sleep journey",
+            defaultextension=".wav",
+            filetypes=(("WAV audio", "*.wav"), ("All files", "*.*")),
+        )
+        if path:
+            self.outfile.set(path)
+
+    def _request(self) -> SleepRequest:
+        layers = None
+        if not self.use_recommended.get():
+            layers = SleepLayers(
+                binaural=self.layer_binaural.get(),
+                monaural=self.layer_monaural.get(),
+                isochronic=self.layer_isochronic.get(),
+                harmonic_box=self.layer_hbox.get(),
+            )
+        request = SleepRequest(
+            problem=self.problem.get(),
+            sound_world=self.sound_world.get(),
+            intensity=self.intensity.get(),
+            duration_minutes=float(self.duration.get()),
+            user_audio=(self.user_audio.get().strip() or None)
+            if self.sound_world.get() == "user_audio"
+            else None,
+            layers=layers,
+        )
+        request.validate()
+        return request
+
+    def _refresh_summary(self):
+        try:
+            recipe = build_sleep_recipe(self._request())
+        except (OSError, ValueError) as exc:
+            self.summary.set(str(exc))
+            return
+        layer_text = (
+            ", ".join(recipe.request.layers.enabled_names())
+            if recipe.request.layers
+            else "none"
+        )
+        self.summary.set(
+            f"Matched journey: {recipe.name}\n{recipe.description}\n"
+            f"Descent: {recipe.descent_seconds / 60:.0f} min · Quiet support: {recipe.support_seconds / 60:.0f} min\n"
+            f"Underlying blend: {layer_text}"
+        )
+
+    def _show_page(self, index: int):
+        for page in self.pages:
+            page.pack_forget()
+        self.page_index = index
+        self.pages[index].pack(fill="both", expand=True)
+        if index == len(self.pages) - 1:
+            self._refresh_summary()
+        self._update_navigation()
+
+    def _update_navigation(self):
+        if not hasattr(self, "back_button"):
+            return
+        self.back_button.configure(
+            state="disabled" if self.page_index == 0 else "normal"
+        )
+        if self.page_index == len(self.pages) - 1:
+            self.next_button.configure(text="Start over", command=self.start_over)
+        else:
+            self.next_button.configure(text="Next", command=self.next)
+
+    def next(self):
+        if (
+            self.page_index == 1
+            and self.sound_world.get() == "user_audio"
+            and not self.user_audio.get().strip()
+        ):
+            messagebox.showerror(
+                "PySbagen Sleep Guide",
+                "Choose the music or audio you want to use.",
+            )
+            return
+        self._show_page(min(self.page_index + 1, len(self.pages) - 1))
+
+    def back(self):
+        self._show_page(max(self.page_index - 1, 0))
+
+    def start_over(self):
+        self.stop_playback()
+        self._show_page(0)
+
+    def _set_running(self, running: bool, status: str):
+        self.status.set(status)
+        self.play_button.configure(state="disabled" if running else "normal")
+        self.stop_button.configure(state="normal" if running else "disabled")
+
+    def start_playback(self):
+        try:
+            request = self._request()
+        except (OSError, ValueError) as exc:
+            messagebox.showerror("PySbagen Sleep Guide", str(exc))
+            return
+        self.stop_event.clear()
+        self._set_running(True, "Playing your matched sleep journey…")
+
+        def worker():
+            try:
+                play_chunks(render_sleep(request), stop_event=self.stop_event)
+            except Exception as exc:
+                self.root.after(0, self._playback_failed, str(exc))
+            else:
+                self.root.after(0, self._playback_finished)
+
+        self.worker = threading.Thread(target=worker, daemon=True)
+        self.worker.start()
+
+    def stop_playback(self):
+        self.stop_event.set()
+        if hasattr(self, "stop_button"):
+            self.status.set("Stopping…")
+            self.stop_button.configure(state="disabled")
+
+    def _playback_finished(self):
+        status = "Stopped" if self.stop_event.is_set() else "Journey complete"
+        self._set_running(False, status)
+
+    def _playback_failed(self, message: str):
+        self._set_running(False, f"Playback error: {message}")
+        messagebox.showerror("PySbagen Sleep Guide", message)
+
+    def save_audio(self):
+        try:
+            request = self._request()
+            recipe = build_sleep_recipe(request)
+            outfile = self.outfile.get().strip()
+            if not outfile:
+                raise ValueError("Choose an output file")
+        except (OSError, ValueError) as exc:
+            messagebox.showerror("PySbagen Sleep Guide", str(exc))
+            return
+        self.status.set("Generating sleep journey…")
+
+        def worker():
+            try:
+                result = write_audio(render_sleep(request), outfile)
+                manifest = write_recipe_manifest(recipe, result.outfile)
+            except Exception as exc:
+                self.root.after(0, self._save_failed, str(exc))
+            else:
+                self.root.after(0, self._save_finished, result.outfile, manifest)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _save_finished(self, outfile: Path, manifest: Path):
+        self.status.set(f"Saved {outfile}")
+        messagebox.showinfo(
+            "Sleep journey saved",
+            f"Audio: {outfile}\nRecipe: {manifest}",
+        )
+
+    def _save_failed(self, message: str):
+        self.status.set(f"Generation error: {message}")
+        messagebox.showerror("PySbagen Sleep Guide", message)
+
+
+def main():
+    root = tk.Tk()
+    SleepGuideGui(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

This PR contains two complete implementation trains and the next researched product direction:

1. repair and unify the existing Python SBaGen-compatible engine, CLI, advanced studio, schedules, file handling, mixing, packaging, and qualification;
2. build PySbagen’s first human-facing product: a conversational layered-audio Sleep Guide;
3. preserve the InvisiSynth/scout creativity findings and the resulting product-gap check before implementation begins.

## Sleep Guide

Normal listeners answer four ordinary questions:

- what is keeping them awake;
- what sound feels pleasant or tolerable tonight;
- how present the underlying layers should feel;
- how long the journey should remain.

The answers select one of three materially different routes:

- **Racing Mind Descent** — more initial movement, then a long reduction in novelty;
- **Crossing the Threshold** — a quieter descent for someone already relaxed;
- **Stay-Asleep Support** — a shorter descent and longer stable support period.

Every route contains a planned **Sleep Descent** and quieter **Sleep Support** phase with changing signal relationships and a gradual fade rather than one static tone.

## Pleasant and layered audio

Generated sound worlds include warm ambient chords, slow night music, a rain-like room, and a deep-night environment. Listeners can instead provide their own audio in broadly decodable formats.

Independently selectable underlying layers include binaural, monaural, smooth isochronic, and Harmonic Box X-style structures. Saved sessions receive a reproducible `.sleep.json` recipe with exact timing, layer blend, carrier/beat movement, seed, and source-audio SHA-256 when applicable.

## Review-driven reliability repairs

- atomic output replacement preserves existing files on failed or empty renders;
- long looping files and FFmpeg-decoded audio stream in bounded chunks;
- still-active schedule generators retain phase and file position across events;
- bare `-` silences a schedule;
- trailing SBaGen `->` performs a full-interval crossfade;
- the guarded advanced studio prevents overlapping jobs, reads Tk values on the UI thread, and closes replaced Matplotlib figures;
- GUI and playback dependencies are separate, with a combined `desktop` extra;
- research limitations and user-facing safety boundaries are explicit.

## Creativity research and product gap

The scout pass found that creativity is a changing cycle rather than one frequency or soundtrack. Divergence, incubation, lateral association, capture, convergence, and improvisation require different audio conditions.

Recorded in:

- `docs/research/CREATIVITY_AUDIO_RESEARCH_FOUNDATIONS.md`
- `docs/planning/CREATIVITY_PRODUCT_GAP_CHECK.md`

The identified product opening is a **Creative Cycle engine** that asks what the person is creating, detects whether they are blank, stuck, overflowing, improvising, or deciding, changes audio by phase, creates incubation and capture windows, and preserves exact recipes for later controlled research.

No creativity implementation or unsupported sensor plumbing was added in this pass.

## Deliberate boundaries

- Sensor-driven closed-loop support remains documented future work; no dead adapters or unsupported device endpoints were added.
- Blinding, sham conditions, consent, protocol assignment, and study measures remain reserved for a separately launched **Research Dose Environment**.
- Ordinary experiences do not claim guaranteed sleep, medical treatment, dopamine delivery, pain or migraine relief, sobriety, or guaranteed creativity.

## Entry points

- `sbgpy-sleep-gui` — conversational desktop Sleep Guide
- `sbgpy-sleep` — conversational terminal Sleep Guide
- `sbgpy-sleep --play` — answer the questions and play immediately
- `sbgpy-gui` — guarded advanced studio
- `sbgpy` — advanced CLI and SBG schedules

## Qualification

Implementation qualification before the final documentation commits:

- `PYTHONPATH=. pytest -q` — **33 passed**
- `python -m compileall -q pysbagen gui.py gui_safe.py sleep_gui.py visualization.py drg_decoder.py` — **passed**
- `python -m pip wheel . --no-deps --no-build-isolation` — built `pysbagen-0.3.0-py3-none-any.whl`
- Python 3.10–3.13 GitHub Actions matrix passed
- all review threads resolved

The final two commits add documentation only.

## Documentation and beadtrains

- `README.md`
- `docs/SLEEP_GUIDE.md`
- `docs/research/SLEEP_AUDIO_RESEARCH_FOUNDATIONS.md`
- `docs/research/CREATIVITY_AUDIO_RESEARCH_FOUNDATIONS.md`
- `docs/planning/CREATIVITY_PRODUCT_GAP_CHECK.md`
- `.beads/pysbagen_sleep_experience_train_2026_07_29.md`
- `.beads/mindmanipulation_full_product_train_2026_07_29.md`