### PR TITLE
Correct SBaGen handoff scope and queue workstation train

### DIFF
--- a/.beads/pysbagen_compatibility_preservation_train_2026_07_31_COMPLETION.md
+++ b/.beads/pysbagen_compatibility_preservation_train_2026_07_31_COMPLETION.md
@@ -7,6 +7,17 @@
 **Status:** Complete and merged to `main`  
 **Source plan:** `.beads/pysbagen_compatibility_preservation_train_2026_07_31.md`
 
+## Scope clarification
+
+This receipt closes the **13-bead compatibility, preservation, inspection, qualification, and provenance train only**.
+
+It does not claim that the separate workstation/product features listed by the original SBaGen website and bundled `TODO.txt` were implemented. Those missing and partial capabilities are now reconciled in:
+
+- `docs/planning/SBAGEN_ORIGINAL_TODO_GAP_MATRIX.md`
+- `.beads/pysbagen_experimenter_workstation_train_2026_07_31.md`
+
+The compatibility train remains valid and complete inside its declared scope. The wider pain-point handoff remains open until the workstation matrix is delivered or explicitly dispositioned.
+
 ## Train result
 
 The 13-bead compatibility train was implemented and merged as one coherent product path. SBG and DRG artifacts now enter through a canonical import contract before rendering, playback, extraction, or library storage.

--- a/.beads/pysbagen_experimenter_workstation_train_2026_07_31.md
+++ b/.beads/pysbagen_experimenter_workstation_train_2026_07_31.md
@@ -1,0 +1,294 @@
+# PySbagen Experimenter Workstation and Original-TODO Completion Beadtrain
+
+**Date:** July 31, 2026  
+**Status:** Queued — active next product train  
+**Base:** `main` after the compatibility/preservation merge and scope correction  
+**Planned implementation branch:** `agent/experimenter-workstation-train-20260731`  
+**Source matrix:** `docs/planning/SBAGEN_ORIGINAL_TODO_GAP_MATRIX.md`
+
+## Train goal
+
+Complete the product layer that the original SBaGen website and bundled TODO described but never delivered: a reusable, editable, live-controllable experimenter workstation around the audio engine.
+
+This train is not another compatibility audit. Its fixtures and matrices exist only to make real authoring, playback, live control, capture, conversion, and rendering dependable.
+
+At completion, a user must be able to:
+
+- open an SBG/DRG/project document in one workstation;
+- understand and edit the sequence as text or visually without losing source provenance;
+- run independent channels and parameter slides concurrently;
+- schedule one-shot samples or voice cues;
+- use reproducible random ranges, sweeps, fades, modulation, and colored noise;
+- control master volume and crossfade among scenes while playing;
+- mark interesting moments and export session-event timing records;
+- convert supported semantics to and from Gnaural XML and explicit audio formats;
+- use a backend-neutral transport that supports export, ordinary playback, and optional JACK;
+- see exact receipts for every live or rendered alteration.
+
+Creativity implementation remains deferred. The workstation must become dependable before adding a Creativity Cycle or other outcome-specific product.
+
+## Boundaries
+
+- Do not copy or redistribute proprietary I-Doser content.
+- Do not silently reinterpret unsupported legacy constructs.
+- Do not build fake hardware adapters or endpoints.
+- Flashing/light-glasses features remain isolated experimental lanes with explicit safety gates.
+- LPT1 control is intentionally excluded from core.
+- Existing compatibility, sleep, streaming, atomic-write, and provenance behavior must remain intact.
+- No stubs, dead controls, or menu items that claim unavailable functionality.
+- No recursive audit train: every bead must deliver a user-visible capability or a necessary shared engine component.
+
+---
+
+# Beads
+
+## WST-001 — Canonical editable project document
+
+**Status:** queued  
+**Depends on:** existing import/timeline models
+
+Create a versioned project schema that can contain:
+
+- immutable imported SBG/DRG source identity;
+- editable tone sets, channels, events, automation curves, samples, scenes, and metadata;
+- raw-source preservation plus semantic edits;
+- source-to-project and project-to-render provenance;
+- deterministic JSON serialization;
+- migration hooks for future schema versions.
+
+**Acceptance:** Opening and saving an untouched supported SBG preserves semantic identity; edits produce a new project identity without overwriting the original source.
+
+## WST-002 — Full schedule editor workstation shell
+
+**Status:** queued  
+**Depends on:** WST-001
+
+Turn the advanced GUI into one coherent workstation with:
+
+- Open, Save, Save As, Import, Export, and recent-local-file actions;
+- raw SBG editor with syntax highlighting and source-located diagnostics;
+- visual timeline/channel editor generated from the same project model;
+- inspector, validation, transport, and render panels;
+- reversible text/visual edits where semantics are representable;
+- explicit conflict handling when raw text and visual edits diverge.
+
+**Acceptance:** A user can open, edit, validate, preview, save, reopen, and render a project without switching among disconnected applications.
+
+## WST-003 — Backend-neutral transport and master bus
+
+**Status:** queued  
+**Depends on:** WST-001
+
+Build one callback-oriented transport used by GUI and API for:
+
+- play, pause, resume, stop, seek, loop-region, and current position;
+- master gain independent of source recipes;
+- clipping/headroom forecast and live meter data;
+- clean cancellation and device cleanup;
+- offline render using the same event clock;
+- optional backend adapters, beginning with existing playback and then JACK where available.
+
+**Acceptance:** Live playback and offline rendering share event timing and receipt semantics; master gain is captured in manifests and never requires editing the source schedule.
+
+## WST-004 — Independent channels and concurrent automation
+
+**Status:** queued  
+**Depends on:** WST-001, WST-003
+
+Add explicit channel buses with:
+
+- independent sources and tone sets;
+- gain, mute, solo, pan/motion, and routing;
+- automation that continues while unrelated channel events occur;
+- independent slides and overlapping transitions;
+- stable generator state across event boundaries.
+
+Implement original `slide:` and `spin:` semantics from fixtures where understood; retain visible approximation states where exact historical behavior remains uncertain.
+
+**Acceptance:** At least three channels can run concurrent, independently changing parameters without one channel resetting another.
+
+## WST-005 — General automation curves and organic variation
+
+**Status:** queued  
+**Depends on:** WST-004
+
+Add serializable automation for:
+
+- linear, equal-power, logarithmic, sinusoidal, Gaussian, and user-defined curves;
+- carrier, beat, amplitude, pan/motion, filter, and supported generator parameters;
+- bounded low-frequency drift/LFO;
+- seeded random ranges with exact replay;
+- preview of min/max and rate before playback.
+
+**Acceptance:** Random and organic variation is reproducible from the saved seed and cannot exceed declared bounds.
+
+## WST-006 — One-shot sample and voice-cue triggers
+
+**Status:** queued  
+**Depends on:** WST-003, WST-004
+
+Add timeline-triggered WAV/AIFF/FLAC/OGG/MP3 cues with:
+
+- exact trigger time or event-relative placement;
+- gain, pan, optional ducking, overlap, and retrigger policy;
+- missing-source and decode diagnostics;
+- one-shot behavior distinct from looping background beds;
+- source hashes and licensing/provenance fields.
+
+**Acceptance:** A voice cue can fire once at a declared sequence point without truncating or resetting continuous tone channels.
+
+## WST-007 — Live scenes and keyboard crossfades
+
+**Status:** queued  
+**Depends on:** WST-003, WST-005
+
+Add scene banks and user-configurable keyboard controls for:
+
+- selecting or launching scenes;
+- real-time crossfading between complete sequences or scene groups;
+- configurable fade curve and duration;
+- panic/stop and master mute;
+- visible current and target scene;
+- deterministic event logging.
+
+**Acceptance:** Scene changes do not block the UI, click, leak generators, or lose the event record.
+
+## WST-008 — Session markers and user-event ledger
+
+**Status:** queued  
+**Depends on:** WST-003
+
+Add live marker capture from GUI buttons and keyboard shortcuts:
+
+- named and quick unnamed markers;
+- transport-relative and wall-clock timestamps;
+- active scene/channel/parameter snapshot;
+- optional note entered after the session rather than interrupting playback;
+- append-only local event ledger tied to exact recipe and output identities;
+- privacy-safe JSON/CSV export.
+
+**Acceptance:** A user can mark an interesting moment without stopping playback and later recover the exact active configuration.
+
+## WST-009 — Colored noise and generalized modulation
+
+**Status:** queued  
+**Depends on:** WST-005
+
+Expand noise and modulation support:
+
+- white, pink, brown/red, blue, violet, gray, and configurable spectral slope;
+- deterministic seed and continuous filter state;
+- amplitude and supported filter/pitch modulation;
+- spectrum/headroom qualification tests;
+- no chunk-boundary discontinuities.
+
+**Acceptance:** Noise color and modulation survive streaming, seeking where supported, and deterministic rendering.
+
+## WST-010 — Mix-stream processors: `mixspin` and `mixbeat`
+
+**Status:** queued  
+**Depends on:** WST-004, WST-005
+
+Implement advanced source-bus processors:
+
+- `mixspin` spatial/motion processing applied to an imported or mixed stream;
+- `mixbeat` analytic-signal/Hilbert-based frequency shifting only after signal-level verification;
+- bypass and wet/dry controls;
+- latency and edge-effect reporting;
+- headphone/speaker suitability guidance;
+- explicit experimental status until reference fixtures demonstrate intended behavior.
+
+**Acceptance:** Processor tests verify channel separation, target shift/motion, bounded amplitude, and deterministic output; unsupported source conditions fail visibly.
+
+## WST-011 — Loss-aware interchange and audio formats
+
+**Status:** queued  
+**Depends on:** WST-001, WST-005, WST-006
+
+Add:
+
+- Gnaural XML import and export;
+- field-by-field reversible/equivalent/approximated/lost conversion reports;
+- explicit WAV and AIFF output selection with runtime capability detection;
+- project-manifest export independent of rendered audio;
+- no claim of round-trip losslessness unless fixture-proven.
+
+**Acceptance:** A supported Gnaural fixture round-trips semantically; unsupported fields remain disclosed rather than dropped.
+
+## WST-012 — Desktop launch and file association
+
+**Status:** queued  
+**Depends on:** WST-002
+
+Provide platform launch behavior for supported packaging paths:
+
+- open `.sbg`, `.drg`, and project documents in the workstation;
+- safe argument handling and import inspection before playback;
+- Windows and macOS launcher/file-association documentation and build metadata;
+- no playback merely from double-click without inspection/explicit action.
+
+**Acceptance:** Packaged launchers open the document in a stable editor state and never silently render or play it.
+
+## WST-013 — Experimental visual/hardware synchronization boundary
+
+**Status:** queued  
+**Depends on:** WST-003
+
+Create the boundary—not fake hardware implementations—for synchronized outputs:
+
+- plugin interface receiving bounded session clock/beat events;
+- disabled-by-default screen-pulse experiment with photosensitive-seizure warning, conservative rate/contrast limits, and immediate stop;
+- documented future AudioStrobe/light-glasses adapter contract;
+- explicit exclusion of direct LPT1 control from core.
+
+**Acceptance:** Ordinary installations expose no flashing default; experimental activation is explicit and independently stoppable.
+
+## WST-014 — Workstation journey tests and performance qualification
+
+**Status:** queued  
+**Depends on:** WST-001 through WST-013
+
+Prove complete journeys:
+
+1. import SBG → edit text → validate → visual timeline → save project → reopen → render;
+2. three independent channels with overlapping slides and one-shot voice cue;
+3. seeded random automation → repeat render → identical hash;
+4. live scene crossfade → marker capture → event-ledger export;
+5. colored-noise modulation without chunk discontinuities;
+6. Gnaural import/export report;
+7. master gain and AIFF/WAV receipts;
+8. safe cancellation and device cleanup;
+9. existing sleep and compatibility journeys remain green.
+
+Measure bounded memory and UI responsiveness on long sessions rather than buffering full output.
+
+## WST-015 — Documentation, migration, and completion receipt
+
+**Status:** queued  
+**Depends on:** WST-014
+
+Update README, workstation guide, CLI help, project schema, compatibility matrix, and original-TODO gap matrix. Record every row as delivered, partial with reason, experimental-lane, or intentionally excluded.
+
+The completion receipt must not say "original TODO complete" while any unrecorded missing row remains.
+
+---
+
+# Required execution order
+
+1. WST-001 → WST-003 establish project and transport foundations.
+2. WST-004 → WST-009 deliver authoring, channel, trigger, live-control, capture, and modulation capabilities.
+3. WST-010 is advanced signal processing and must remain visibly experimental until qualified.
+4. WST-011 → WST-013 complete interchange, desktop integration, and explicit experimental boundaries.
+5. WST-014 → WST-015 qualify and close the train.
+
+## Definition of done
+
+This train is complete only when:
+
+- the workstation performs open/edit/validate/play/control/mark/save/render journeys;
+- original TODO rows are reconciled one by one;
+- missing features are delivered or explicitly dispositioned with a defensible reason;
+- compatibility reports and provenance remain intact;
+- no menu item, CLI flag, or document claims functionality that is absent;
+- local tests and package builds pass before merge;
+- creativity remains deferred unless separately authorized.

--- a/docs/planning/CURRENT_PRODUCT_PRIORITY.md
+++ b/docs/planning/CURRENT_PRODUCT_PRIORITY.md
@@ -1,41 +1,60 @@
 # PySbagen Current Product Priority
 
 **Date:** July 31, 2026  
-**Status:** Compatibility priority delivered; creativity remains deferred
+**Status:** Compatibility phase delivered; original-SBaGen workstation completion is the active next priority
 
-## Completed priority
+## Scope correction
 
-The I-Doser/SBaGen compatibility, preservation, inspection, and ordinary-user reliability train defined in:
+The I-Doser/SBaGen compatibility, preservation, inspection, and local-library train was successfully implemented and merged through:
 
 - `.beads/pysbagen_compatibility_preservation_train_2026_07_31.md`
-
-was implemented on:
-
-- `agent/compatibility-preservation-train-20260731`
-
-and merged through:
-
 - PR `#9` — **Build the SBaGen and DRG compatibility product**
 - merge commit `0c95a67ca65db22d6441b123a5709bcaf929a064`
+- completion receipt `.beads/pysbagen_compatibility_preservation_train_2026_07_31_COMPLETION.md`
 
-The final implementation and qualification receipt is:
+That train completed the six priorities explicitly listed under the pain-point scout's **next compatibility train** section.
 
-- `.beads/pysbagen_compatibility_preservation_train_2026_07_31_COMPLETION.md`
+It did **not** complete the separate workstation/product features recorded by the original SBaGen website and bundled TODO. The previous wording "compatibility priority delivered" was accurate only for that bounded phase, but it could be read as though the entire pain-point handoff had been delivered. This document corrects that interpretation.
 
-## Delivered product priorities
+## Delivered compatibility foundation
 
-1. **Honest SBG/DRG import reports** with immutable source identity, explicit compatibility states, missing-source visibility, timing/end behavior, and render dispositions.
-2. **Complete DRG package preservation** retaining original bytes, metadata, every decoded element, nested schedule, image, opaque elements, hashes, and provenance.
-3. **Original-SBaGen semantic compatibility matrix** in machine-readable and human-readable forms with fixture-backed state classifications.
-4. **Timeline/source inspection before playback** through `sbgpy-inspect` and `sbgpy-inspect-gui`.
-5. **Audio-source and listening-path qualification** covering channels, sample rate, resampling, clipping, near-mono, anti-phase, route suitability, Bluetooth, normalization, and spatial processing.
-6. **Local-first provenance library** with content identity, immutable source copies, explicit lifecycle states, duplicate provenance, offline verification, and exportable manifests.
+1. Honest SBG/DRG import reports and render dispositions.
+2. Complete DRG package preservation.
+3. Original-SBaGen semantic compatibility matrix.
+4. Timeline/source inspection before playback.
+5. Audio-source and listening-path qualification.
+6. Local-first provenance library.
 
-The enforcement rule across the product is now implemented: unsupported, unknown, partial, approximated, missing-source, rendered-only, intentionally-excluded, and unsafe-to-render states remain visible and never collapse into an optimistic success flag.
+These remain delivered and are the foundation for the next train.
 
-## Qualification
+## Active next priority: experimenter workstation
 
-PR #9 passed the full product-path matrix on Python 3.10, 3.11, 3.12, and 3.13. The Python 3.12 lane also built the distributable wheel. The final repository suite reported **43 passing tests** before merge.
+The original SBaGen TODO gap is now mapped in:
+
+- `docs/planning/SBAGEN_ORIGINAL_TODO_GAP_MATRIX.md`
+
+The implementation plan is:
+
+- `.beads/pysbagen_experimenter_workstation_train_2026_07_31.md`
+
+Planned implementation branch:
+
+- `agent/experimenter-workstation-train-20260731`
+
+The active train covers the missing or partial product layer, including:
+
+- a full editable schedule/project workstation;
+- independent channels and concurrent slides;
+- one-shot WAV/MP3/voice triggers;
+- reproducible random ranges and organic variation;
+- master volume and backend-neutral live transport;
+- keyboard scene crossfades;
+- session markers and user-event timing records;
+- generalized modulation, sweep curves, logarithmic fades, and broader colored noise;
+- `mixspin` and qualified experimental `mixbeat` processing;
+- Gnaural XML interchange and explicit WAV/AIFF output;
+- desktop file association and launch behavior;
+- explicit safety/hardware disposition for flashing, AudioStrobe, light-glasses, and obsolete LPT1 control.
 
 ## Creativity status
 
@@ -44,6 +63,12 @@ The creativity research and product gap remain valid and preserved in:
 - `docs/research/CREATIVITY_AUDIO_RESEARCH_FOUNDATIONS.md`
 - `docs/planning/CREATIVITY_PRODUCT_GAP_CHECK.md`
 
-However, **creativity implementation remains deferred**. Completing the compatibility train does not silently authorize the Creative Cycle train.
+However, **creativity implementation remains deferred**. The experimenter workstation train takes precedence and does not silently authorize the Creative Cycle train.
 
-The next product priority must be chosen explicitly rather than inferred from parked research.
+## Completion rule
+
+The full pain-point handoff must not be described as complete until every row in `SBAGEN_ORIGINAL_TODO_GAP_MATRIX.md` is either:
+
+- delivered through a supported, tested product path;
+- retained as an explicit experimental lane with appropriate safeguards; or
+- intentionally excluded with a documented rationale.

--- a/docs/planning/SBAGEN_ORIGINAL_TODO_GAP_MATRIX.md
+++ b/docs/planning/SBAGEN_ORIGINAL_TODO_GAP_MATRIX.md
@@ -1,0 +1,67 @@
+# Original SBaGen TODO — PySbagen Product Gap Matrix
+
+**Date:** July 31, 2026  
+**Status:** Active source-to-product reconciliation  
+**Primary sources:**
+
+- `sbagen-1.4.5/sbagen-1.4.5/TODO.txt`
+- `https://uazu.net/sbagen/` — official SBaGen TODO and unmaintained-project notice
+- `docs/research/IDOSER_SBAGEN_PAIN_POINT_SCOUT.md`
+
+## Why this matrix exists
+
+The compatibility, preservation, and inspection train completed the six priorities under the scout's **"Priority pain points for the next compatibility train"** section. It did **not** complete the separate workstation/product features listed in the original SBaGen TODO.
+
+Those TODO items were not incidental research notes. Together they describe the missing experimenter's workstation around the synthesis engine: editable authoring, reusable sequencing, independent channels, live control, event capture, richer modulation, sample cues, conversion, and desktop integration.
+
+The previous product-priority record incorrectly allowed "compatibility delivered" to read as though the entire pain-point handoff had been delivered. This matrix corrects that scope.
+
+## State vocabulary
+
+- **delivered** — available through a supported product path and covered by current tests/docs;
+- **partial** — some foundation exists, but the original user capability is not complete;
+- **missing** — no supported product path currently provides the capability;
+- **experimental-lane** — valid idea, but requires explicit safety, hardware, or platform qualification;
+- **intentionally-excluded** — understood and explicitly rejected from the modern product, with rationale.
+
+## Reconciliation matrix
+
+| Original SBaGen TODO / website request | Current PySbagen state | Evidence and gap | Product disposition |
+|---|---|---|---|
+| Easy clickable GUI separate from the command line | **partial** | `sbgpy-gui`, the Sleep Guide, and Compatibility Inspector exist, but the advanced studio is not yet a complete open/edit/validate/play/transport/write workstation for SBG documents. | Build the full experimenter workstation rather than another disconnected GUI. |
+| Minimal GUI with open/save, editor, test, play, and write-WAV views | **partial** | Schedule selection and export exist. Raw schedule editing, syntax diagnostics tied to source locations, save/save-as, transport position, and reversible visual editing are incomplete. | Deliver as the workstation document/editor shell. |
+| Reusable `sbagenlib` sequencing/audio engine | **delivered** | `pysbagen.api`, parser, mixer, generators, importer, and plugin entry-point foundations provide a reusable Python engine used by multiple front ends. | Preserve and harden; do not rebuild. |
+| Several independent channels with independent slides | **missing** | The compatibility matrix classifies `spin:` and `slide:` as approximated; the underlying tone may render, but motion semantics and concurrently sliding channels do not. | Build channel buses, per-channel envelopes, and fixture-proven independent motion. |
+| Trigger WAV/MP3 samples or voice cues at sequence points | **missing** | Background files can be layered, but there is no event-triggered one-shot sample/cue model. | Add scheduled one-shot cues, overlap policy, gain, pan, and provenance. |
+| Mark interesting combinations during a session without leaving the experience | **missing** | No live marker command or transport-bound session marker exists. | Add keyboard/button markers captured against the exact session clock and recipe identity. |
+| Record timing of user events from clicks or keypresses | **missing** | No local event ledger accompanies playback. | Add append-only session event records and privacy-safe export. |
+| Random variation within declared frequency ranges | **missing** | `SBG-RANDOM-001` is currently unsupported. Generated sleep worlds may use deterministic variation, but ordinary SBG range semantics do not exist. | Add seeded, bounded, inspectable random/range modulation with exact replay manifests. |
+| Global volume control without editing the sequence | **missing** | Individual amplitudes exist, but there is no canonical master gain shared by CLI, GUI, live playback, and render receipts. | Add master gain with clipping forecast and receipt capture. |
+| Keyboard control to fade between sequences in real time | **missing** | No scene bank, live crossfade transport, or keyboard mapping exists. | Add safe live scene crossfades using the shared callback/transport engine. |
+| General volume modulation in addition to beating | **partial** | Isochronic and sleep envelopes modulate amplitude in specialized generators. There is no general schedule-level modulation/envelope object applicable to arbitrary channels and sources. | Add reusable amplitude modulation/envelope semantics. |
+| Sinusoidal, Gaussian, or user-defined sweeps | **missing** | Linear interval crossfades exist, but sweep-shape selection and reusable curves do not. | Add curve-defined parameter automation with serializable shapes. |
+| Logarithmic fades | **missing** | Current crossfades are documented as linear. | Add explicit linear, equal-power, logarithmic, and custom-curve fades. |
+| Colored noise beyond the original basics | **partial** | White and pink noise are supported. Brown/red, blue, violet, gray, and configurable spectral slopes are not. | Add qualified colored-noise generators with deterministic seeds and spectra tests. |
+| Noise amplitude and pitch/filter modulation | **missing** | Noise is not exposed through the same automation system as tones and source buses. | Add bounded modulation through the general automation engine. |
+| More organic low-frequency variation in carriers/beats | **partial** | Some guided generators evolve over time, but ordinary studio recipes cannot apply reproducible drift to arbitrary parameters. | Add seeded drift/LFO controls as an authoring feature. |
+| Isochronic tones | **delivered** | `IsochronicSpec`, CLI, GUI, and sleep routes already provide isochronic layers. | Keep; extend through the common automation/channel model. |
+| `mixspin:` on imported/mixed audio | **missing** | No mix-stream spin implementation exists. | Add a fixture-proven spatial/motion processor with clear headphone/speaker behavior. |
+| `mixbeat:` to create binaural shifting from recordings | **missing** | No Hilbert/analytic-signal mixbeat processor exists. | Research, implement, and verify as an advanced processor; never label it equivalent before signal tests pass. |
+| Convert to and from Gnaural XML | **missing** | Import reports and manifests exist, but Gnaural XML interchange does not. | Add loss-aware import/export with explicit reversible/approximated fields. |
+| Automatic conversion of old SBG into a new visual format | **partial** | SBG parsing and a serializable timeline exist, but there is no editable canonical project document with round-trip visual editing. | Add a project schema that preserves raw source and records every semantic edit. |
+| AIFF output in addition to WAV | **partial** | SoundFile may support AIFF depending on runtime, but the public CLI/GUI, tests, estimates, and docs are WAV-centered. | Add explicit capability detection, AIFF output selection, and qualification tests. |
+| Mac desktop access / double-click SBG files | **missing** | No packaged desktop file association or launcher integration is recorded. | Add platform launchers/file associations after the workstation command is stable. |
+| Callback-model backend and JACK support | **partial** | Modern Python playback exists through PyAudio, but there is no canonical callback transport/backend abstraction or JACK path. | Build backend-neutral transport first; provide JACK where available without coupling core logic to it. |
+| Screen flashing synchronized to beats | **experimental-lane** | Not implemented or dispositioned. Flashing visuals carry photosensitive-seizure risk. | Only as disabled-by-default, strongly warned, rate/contrast-limited experimental output with no ordinary-user default. |
+| AudioStrobe / light-glasses output | **experimental-lane** | Not implemented; hardware and safety qualification are absent. | Document and isolate behind an explicit hardware research interface before any implementation. |
+| LPT1 light-glasses control | **intentionally-excluded** | Obsolete, platform-specific direct hardware control conflicts with a modern cross-platform product and lacks available test hardware. | Do not implement in core; allow future third-party hardware plugins through a documented interface. |
+
+## Correct product conclusion
+
+The compatibility train was valuable and remains complete **within its declared scope**. The full pain-point handoff is not complete until the workstation train addresses the missing and partial product rows above, or explicitly records a justified exclusion.
+
+The active implementation plan is:
+
+- `.beads/pysbagen_experimenter_workstation_train_2026_07_31.md`
+
+Creativity remains parked. This train completes the SBaGen experimenter/workstation foundation before outcome-specific creativity product work begins.


### PR DESCRIPTION
## What changed

- records that PR #9 completed the compatibility/preservation phase, not the full original-SBaGen pain-point handoff;
- adds a source-to-product matrix for every relevant item from the official SBaGen TODO and bundled TODO file;
- defines a 15-bead experimenter workstation train covering the missing authoring, channel, trigger, live-control, event-capture, modulation, interchange, desktop, and safety-boundary work;
- updates the current product priority so creativity remains parked behind workstation completion.

## Why

The previous priority record could be read as though the original SBaGen website's missing workstation features had landed. They had not. This PR corrects the repository truth without undoing the valid compatibility work.

## Validation

Documentation-only scope. Compared against `main`: four intended files, no unrelated changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a roadmap for a reusable experimenter workstation with editable projects, concurrent channels, automation, triggers, live controls, markers, format conversion, and reproducible rendering.
  * Added a gap matrix documenting planned workstation capabilities and their current status.

* **Documentation**
  * Clarified that compatibility work is complete within its defined scope.
  * Updated product priorities and completion criteria for the upcoming workstation train.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->