### PR TITLE
Differentiate PySbagen and begin SBaGenX interoperability

### DIFF
--- a/.beads/pysbagen_experimenter_workstation_train_2026_07_31.md
+++ b/.beads/pysbagen_experimenter_workstation_train_2026_07_31.md
@@ -1,294 +1,53 @@
 # PySbagen Experimenter Workstation and Original-TODO Completion Beadtrain
 
 **Date:** July 31, 2026  
-**Status:** Queued — active next product train  
-**Base:** `main` after the compatibility/preservation merge and scope correction  
-**Planned implementation branch:** `agent/experimenter-workstation-train-20260731`  
-**Source matrix:** `docs/planning/SBAGEN_ORIGINAL_TODO_GAP_MATRIX.md`
+**Status:** Superseded before implementation  
+**Original branch:** `agent/experimenter-workstation-train-20260731` — not created or authorized  
+**Replacement:** `.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md`
 
-## Train goal
+## Why this train was superseded
 
-Complete the product layer that the original SBaGen website and bundled TODO described but never delivered: a reusable, editable, live-controllable experimenter workstation around the audio engine.
+This plan was created after comparing the original SBaGen TODO only against PySbagen. It correctly identified capabilities absent from PySbagen, but it did not first compare them against the active modern SBaGen continuation.
 
-This train is not another compatibility audit. Its fixtures and matrices exist only to make real authoring, playback, live control, capture, conversion, and rendering dependable.
+A source-level review of `lm7137/SBaGenX` showed that the proposed train would duplicate substantial existing work:
 
-At completion, a user must be able to:
+- the reusable native engine and sequence runtime;
+- `.sbg`/`.sbgf` editing and validation;
+- curves and built-in programs;
+- native mix effects including `mixspin` and `mixbeat`;
+- live parameter controls;
+- multiple voices and auxiliary tones;
+- expanded noise/tone families;
+- native export, plotting, packaging, and frontends.
 
-- open an SBG/DRG/project document in one workstation;
-- understand and edit the sequence as text or visually without losing source provenance;
-- run independent channels and parameter slides concurrently;
-- schedule one-shot samples or voice cues;
-- use reproducible random ranges, sweeps, fades, modulation, and colored noise;
-- control master volume and crossfade among scenes while playing;
-- mark interesting moments and export session-event timing records;
-- convert supported semantics to and from Gnaural XML and explicit audio formats;
-- use a backend-neutral transport that supports export, ordinary playback, and optional JACK;
-- see exact receipts for every live or rendered alteration.
+Running WST-001 through WST-015 as written would turn PySbagen into a competing, less mature Python reimplementation of SBaGenX rather than a differentiated product.
 
-Creativity implementation remains deferred. The workstation must become dependable before adding a Creativity Cycle or other outcome-specific product.
+## Preserved ideas
 
-## Boundaries
+The following ideas remain valid but move into the interoperability train as PySbagen-owned session/product layers:
 
-- Do not copy or redistribute proprietary I-Doser content.
-- Do not silently reinterpret unsupported legacy constructs.
-- Do not build fake hardware adapters or endpoints.
-- Flashing/light-glasses features remain isolated experimental lanes with explicit safety gates.
-- LPT1 control is intentionally excluded from core.
-- Existing compatibility, sleep, streaming, atomic-write, and provenance behavior must remain intact.
-- No stubs, dead controls, or menu items that claim unavailable functionality.
-- No recursive audit train: every bead must deliver a user-visible capability or a necessary shared engine component.
+- backend-independent session markers and event ledger;
+- outcome history and local preference learning;
+- one-shot cue orchestration if still absent upstream;
+- exact backend/version/protocol/output receipts;
+- guided-product capability selection;
+- DRG and SBGF preservation;
+- loss-aware interchange and compatibility reporting;
+- research consent and protocol-assignment workflows.
 
----
+## Removed duplication
 
-# Beads
+The replacement train does not independently recreate:
 
-## WST-001 — Canonical editable project document
+- a competing `.sbg`/`.sbgf` editor;
+- a new curve/project language before `.sbgf` support;
+- `mixspin`, `mixbeat`, `mixpulse`, or `mixam` DSP;
+- native live carrier/beat/amplitude/mix ramps;
+- the SBaGenX export stack, plot system, desktop packaging, or mobile frontend.
 
-**Status:** queued  
-**Depends on:** existing import/timeline models
+## Authoritative product boundary
 
-Create a versioned project schema that can contain:
+- `docs/planning/SBAGENX_DIFFERENTIATION_AND_INTEROP_MATRIX.md`
+- `.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md`
 
-- immutable imported SBG/DRG source identity;
-- editable tone sets, channels, events, automation curves, samples, scenes, and metadata;
-- raw-source preservation plus semantic edits;
-- source-to-project and project-to-render provenance;
-- deterministic JSON serialization;
-- migration hooks for future schema versions.
-
-**Acceptance:** Opening and saving an untouched supported SBG preserves semantic identity; edits produce a new project identity without overwriting the original source.
-
-## WST-002 — Full schedule editor workstation shell
-
-**Status:** queued  
-**Depends on:** WST-001
-
-Turn the advanced GUI into one coherent workstation with:
-
-- Open, Save, Save As, Import, Export, and recent-local-file actions;
-- raw SBG editor with syntax highlighting and source-located diagnostics;
-- visual timeline/channel editor generated from the same project model;
-- inspector, validation, transport, and render panels;
-- reversible text/visual edits where semantics are representable;
-- explicit conflict handling when raw text and visual edits diverge.
-
-**Acceptance:** A user can open, edit, validate, preview, save, reopen, and render a project without switching among disconnected applications.
-
-## WST-003 — Backend-neutral transport and master bus
-
-**Status:** queued  
-**Depends on:** WST-001
-
-Build one callback-oriented transport used by GUI and API for:
-
-- play, pause, resume, stop, seek, loop-region, and current position;
-- master gain independent of source recipes;
-- clipping/headroom forecast and live meter data;
-- clean cancellation and device cleanup;
-- offline render using the same event clock;
-- optional backend adapters, beginning with existing playback and then JACK where available.
-
-**Acceptance:** Live playback and offline rendering share event timing and receipt semantics; master gain is captured in manifests and never requires editing the source schedule.
-
-## WST-004 — Independent channels and concurrent automation
-
-**Status:** queued  
-**Depends on:** WST-001, WST-003
-
-Add explicit channel buses with:
-
-- independent sources and tone sets;
-- gain, mute, solo, pan/motion, and routing;
-- automation that continues while unrelated channel events occur;
-- independent slides and overlapping transitions;
-- stable generator state across event boundaries.
-
-Implement original `slide:` and `spin:` semantics from fixtures where understood; retain visible approximation states where exact historical behavior remains uncertain.
-
-**Acceptance:** At least three channels can run concurrent, independently changing parameters without one channel resetting another.
-
-## WST-005 — General automation curves and organic variation
-
-**Status:** queued  
-**Depends on:** WST-004
-
-Add serializable automation for:
-
-- linear, equal-power, logarithmic, sinusoidal, Gaussian, and user-defined curves;
-- carrier, beat, amplitude, pan/motion, filter, and supported generator parameters;
-- bounded low-frequency drift/LFO;
-- seeded random ranges with exact replay;
-- preview of min/max and rate before playback.
-
-**Acceptance:** Random and organic variation is reproducible from the saved seed and cannot exceed declared bounds.
-
-## WST-006 — One-shot sample and voice-cue triggers
-
-**Status:** queued  
-**Depends on:** WST-003, WST-004
-
-Add timeline-triggered WAV/AIFF/FLAC/OGG/MP3 cues with:
-
-- exact trigger time or event-relative placement;
-- gain, pan, optional ducking, overlap, and retrigger policy;
-- missing-source and decode diagnostics;
-- one-shot behavior distinct from looping background beds;
-- source hashes and licensing/provenance fields.
-
-**Acceptance:** A voice cue can fire once at a declared sequence point without truncating or resetting continuous tone channels.
-
-## WST-007 — Live scenes and keyboard crossfades
-
-**Status:** queued  
-**Depends on:** WST-003, WST-005
-
-Add scene banks and user-configurable keyboard controls for:
-
-- selecting or launching scenes;
-- real-time crossfading between complete sequences or scene groups;
-- configurable fade curve and duration;
-- panic/stop and master mute;
-- visible current and target scene;
-- deterministic event logging.
-
-**Acceptance:** Scene changes do not block the UI, click, leak generators, or lose the event record.
-
-## WST-008 — Session markers and user-event ledger
-
-**Status:** queued  
-**Depends on:** WST-003
-
-Add live marker capture from GUI buttons and keyboard shortcuts:
-
-- named and quick unnamed markers;
-- transport-relative and wall-clock timestamps;
-- active scene/channel/parameter snapshot;
-- optional note entered after the session rather than interrupting playback;
-- append-only local event ledger tied to exact recipe and output identities;
-- privacy-safe JSON/CSV export.
-
-**Acceptance:** A user can mark an interesting moment without stopping playback and later recover the exact active configuration.
-
-## WST-009 — Colored noise and generalized modulation
-
-**Status:** queued  
-**Depends on:** WST-005
-
-Expand noise and modulation support:
-
-- white, pink, brown/red, blue, violet, gray, and configurable spectral slope;
-- deterministic seed and continuous filter state;
-- amplitude and supported filter/pitch modulation;
-- spectrum/headroom qualification tests;
-- no chunk-boundary discontinuities.
-
-**Acceptance:** Noise color and modulation survive streaming, seeking where supported, and deterministic rendering.
-
-## WST-010 — Mix-stream processors: `mixspin` and `mixbeat`
-
-**Status:** queued  
-**Depends on:** WST-004, WST-005
-
-Implement advanced source-bus processors:
-
-- `mixspin` spatial/motion processing applied to an imported or mixed stream;
-- `mixbeat` analytic-signal/Hilbert-based frequency shifting only after signal-level verification;
-- bypass and wet/dry controls;
-- latency and edge-effect reporting;
-- headphone/speaker suitability guidance;
-- explicit experimental status until reference fixtures demonstrate intended behavior.
-
-**Acceptance:** Processor tests verify channel separation, target shift/motion, bounded amplitude, and deterministic output; unsupported source conditions fail visibly.
-
-## WST-011 — Loss-aware interchange and audio formats
-
-**Status:** queued  
-**Depends on:** WST-001, WST-005, WST-006
-
-Add:
-
-- Gnaural XML import and export;
-- field-by-field reversible/equivalent/approximated/lost conversion reports;
-- explicit WAV and AIFF output selection with runtime capability detection;
-- project-manifest export independent of rendered audio;
-- no claim of round-trip losslessness unless fixture-proven.
-
-**Acceptance:** A supported Gnaural fixture round-trips semantically; unsupported fields remain disclosed rather than dropped.
-
-## WST-012 — Desktop launch and file association
-
-**Status:** queued  
-**Depends on:** WST-002
-
-Provide platform launch behavior for supported packaging paths:
-
-- open `.sbg`, `.drg`, and project documents in the workstation;
-- safe argument handling and import inspection before playback;
-- Windows and macOS launcher/file-association documentation and build metadata;
-- no playback merely from double-click without inspection/explicit action.
-
-**Acceptance:** Packaged launchers open the document in a stable editor state and never silently render or play it.
-
-## WST-013 — Experimental visual/hardware synchronization boundary
-
-**Status:** queued  
-**Depends on:** WST-003
-
-Create the boundary—not fake hardware implementations—for synchronized outputs:
-
-- plugin interface receiving bounded session clock/beat events;
-- disabled-by-default screen-pulse experiment with photosensitive-seizure warning, conservative rate/contrast limits, and immediate stop;
-- documented future AudioStrobe/light-glasses adapter contract;
-- explicit exclusion of direct LPT1 control from core.
-
-**Acceptance:** Ordinary installations expose no flashing default; experimental activation is explicit and independently stoppable.
-
-## WST-014 — Workstation journey tests and performance qualification
-
-**Status:** queued  
-**Depends on:** WST-001 through WST-013
-
-Prove complete journeys:
-
-1. import SBG → edit text → validate → visual timeline → save project → reopen → render;
-2. three independent channels with overlapping slides and one-shot voice cue;
-3. seeded random automation → repeat render → identical hash;
-4. live scene crossfade → marker capture → event-ledger export;
-5. colored-noise modulation without chunk discontinuities;
-6. Gnaural import/export report;
-7. master gain and AIFF/WAV receipts;
-8. safe cancellation and device cleanup;
-9. existing sleep and compatibility journeys remain green.
-
-Measure bounded memory and UI responsiveness on long sessions rather than buffering full output.
-
-## WST-015 — Documentation, migration, and completion receipt
-
-**Status:** queued  
-**Depends on:** WST-014
-
-Update README, workstation guide, CLI help, project schema, compatibility matrix, and original-TODO gap matrix. Record every row as delivered, partial with reason, experimental-lane, or intentionally excluded.
-
-The completion receipt must not say "original TODO complete" while any unrecorded missing row remains.
-
----
-
-# Required execution order
-
-1. WST-001 → WST-003 establish project and transport foundations.
-2. WST-004 → WST-009 deliver authoring, channel, trigger, live-control, capture, and modulation capabilities.
-3. WST-010 is advanced signal processing and must remain visibly experimental until qualified.
-4. WST-011 → WST-013 complete interchange, desktop integration, and explicit experimental boundaries.
-5. WST-014 → WST-015 qualify and close the train.
-
-## Definition of done
-
-This train is complete only when:
-
-- the workstation performs open/edit/validate/play/control/mark/save/render journeys;
-- original TODO rows are reconciled one by one;
-- missing features are delivered or explicitly dispositioned with a defensible reason;
-- compatibility reports and provenance remain intact;
-- no menu item, CLI flag, or document claims functionality that is absent;
-- local tests and package builds pass before merge;
-- creativity remains deferred unless separately authorized.
+This archived file is retained so the scope correction remains traceable. No bead in this superseded train should be executed unless it is explicitly reintroduced after a fresh SBaGenX capability check.

--- a/.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md
+++ b/.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md
@@ -1,0 +1,285 @@
+# PySbagen × SBaGenX Differentiation and Interoperability Beadtrain
+
+**Date:** July 31, 2026  
+**Status:** Active — implementation started  
+**Branch:** `agent/sbagenx-interoperability-train-20260731`  
+**Source matrix:** `docs/planning/SBAGENX_DIFFERENTIATION_AND_INTEROP_MATRIX.md`  
+**SBaGenX reference:** `lm7137/SBaGenX@be7c74d378774a759f1e4149dc9df3617b4d0d3b`
+
+## Train goal
+
+Make PySbagen the provenance-first, human-facing protocol and session operating layer for the SBaGen ecosystem while treating SBaGenX as the optional advanced native SBaGen engine.
+
+This train deliberately avoids rebuilding SBaGenX's `.sbg`/`.sbgf` editor, curve engine, mix effects, live parameter controls, native export stack, plotting system, packaging, or mobile frontend.
+
+At completion, PySbagen must be able to:
+
+- detect and qualify an installed SBaGenX executable or native library;
+- preserve exact SBaGenX version/API/capability identity;
+- validate and inspect SBG/SBGF through a version-gated native adapter;
+- optionally render through SBaGenX with complete provenance and discrepancy receipts;
+- retain the Python renderer as a portable fallback;
+- record session markers, user events, outcomes, and local preferences independently of the rendering backend;
+- run existing guided experiences through an explicit backend-selection policy;
+- preserve DRG and SBGF artifacts without pretending conversion is lossless;
+- never silently route work through an unqualified native backend.
+
+Creativity implementation remains deferred.
+
+## Boundaries
+
+- Do not copy SBaGenX source wholesale into PySbagen.
+- Do not vendor or redistribute SBaGenX binaries without a separate license/dependency review.
+- Do not make SBaGenX mandatory for DRG preservation, inspection, the local library, or existing Sleep Guide use.
+- Do not claim bit-identical cross-engine output unless fixture-proven.
+- Do not invent another curve language before supporting `.sbgf` preservation and native validation.
+- Do not independently recreate `mixspin`, `mixbeat`, `mixpulse`, `mixam`, native live ramps, or the SBaGenX editor.
+- Every native operation must record backend version, API version, capabilities, source identity, invocation policy, and output identity.
+- Unknown API revisions or missing symbols fail closed to inspection/fallback rather than guessing.
+
+---
+
+# Beads
+
+## SBX-001 — Source-pinned differentiation matrix
+
+**Status:** complete
+
+Inspect the actual SBaGenX repository and classify proposed work as delegate, interoperate, shared/fallback, PySbagen-owned, or verify-later.
+
+**Delivered:** `docs/planning/SBAGENX_DIFFERENTIATION_AND_INTEROP_MATRIX.md`.
+
+## SBX-002 — Optional backend discovery and capability probe
+
+**Status:** complete
+
+Add a standard-library-only discovery surface for:
+
+- `SBAGENX_BIN` and PATH executable lookup;
+- `SBAGENXLIB_PATH` and system shared-library lookup;
+- executable version probing;
+- `sbx_version()` and `sbx_api_version()`;
+- symbol-backed capabilities for native rendering, SBG/SBGF validation, container writing, live controls, and mix-stream processing;
+- text and deterministic JSON reports;
+- explicit fallback when SBaGenX is absent.
+
+**Delivered:**
+
+- `pysbagen/sbagenx_backend.py`
+- `sbgpy-inspect backend`
+- unit tests using a fake native library
+
+Discovery does not yet authorize native rendering.
+
+## SBX-003 — Version-gated native binding contract
+
+**Status:** queued  
+**Depends on:** SBX-002
+
+Build a narrow ctypes binding around only the symbols PySbagen actually uses.
+
+Requirements:
+
+- exact argument/restype declarations;
+- API-version policy table;
+- symbol requirements per operation;
+- owned-memory cleanup for diagnostics/contexts/writers;
+- platform-safe loading and actionable errors;
+- no broad, untyped dynamic calls;
+- backend identity object reusable by manifests.
+
+**Acceptance:** Unknown or incomplete libraries produce a structured unavailable/unsupported result without crashing or changing fallback behavior.
+
+## SBX-004 — Native SBG and SBGF validation adapter
+
+**Status:** queued  
+**Depends on:** SBX-003
+
+Expose native validation while preserving PySbagen's own compatibility report.
+
+Requirements:
+
+- validate source text without mutating it;
+- map native diagnostics to source line/column/severity/code;
+- record native engine/API identity;
+- retain both PySbagen and SBaGenX findings when they disagree;
+- never let native success erase PySbagen loss/provenance warnings.
+
+**Acceptance:** One report can show Python-parser findings, native findings, and discrepancies side by side.
+
+## SBX-005 — SBGF preservation and inspectable protocol identity
+
+**Status:** queued  
+**Depends on:** SBX-004
+
+Treat `.sbgf` as a first-class preserved artifact:
+
+- immutable source bytes and hash;
+- encoding and syntax diagnostics;
+- declared parameters, solve directive, expression families, and source locations where available;
+- referenced media and source dependencies;
+- native version/API used for validation;
+- explicit rendered-only/equivalent/partial states for conversions.
+
+Do not attempt to replace `.sbgf` with a new PySbagen project language.
+
+## SBX-006 — Optional native render backend with receipts
+
+**Status:** queued  
+**Depends on:** SBX-003 through SBX-005
+
+Add explicit backend selection:
+
+- `python` — current PySbagen renderer;
+- `sbagenx` — qualified native library;
+- `auto` — select native only for fixture-qualified semantics, otherwise Python or blocked according to policy.
+
+Every render receipt must include:
+
+- selected backend and reason;
+- SBaGenX version/API and capability set when native;
+- source hash and import report;
+- sample rate, format, duration, and output hash;
+- unsupported/approximated fields;
+- cross-engine comparison status when available.
+
+No silent subprocess rendering. Prefer the native library; CLI invocation is a separately disclosed fallback only if required.
+
+## SBX-007 — Cross-engine parity and discrepancy laboratory
+
+**Status:** queued  
+**Depends on:** SBX-006
+
+Build representative legal/synthetic fixtures for shared semantics:
+
+- binaural, monaural, isochronic;
+- finite and open-ended sequences;
+- transitions and silence;
+- white/pink noise;
+- background mix where both engines support it.
+
+Measure:
+
+- duration/frame count;
+- RMS/peak and channel relationships;
+- dominant frequencies and beat relationships;
+- transition boundaries;
+- deterministic repeat behavior;
+- documented expected differences.
+
+The output is a product discrepancy report, not a demand for bit identity.
+
+## SBX-008 — Guided-product backend policy
+
+**Status:** queued  
+**Depends on:** SBX-006, SBX-007
+
+Allow guided products to request capabilities rather than hard-code engines.
+
+Examples:
+
+- Sleep Guide can remain on the Python journey engine by default;
+- an advanced imported SBGF session may require SBaGenX;
+- a recipe may be portable, native-preferred, or native-required;
+- backend choice must be visible before playback and saved in the exact recipe/session manifest.
+
+Existing guided journeys must remain usable without SBaGenX installed.
+
+## SBX-009 — Backend-independent session markers and event ledger
+
+**Status:** queued  
+**Depends on:** SBX-006
+
+Build a PySbagen-owned append-only session ledger:
+
+- named and quick markers;
+- transport-relative and wall-clock time;
+- backend identity and position;
+- active recipe/protocol hash;
+- native telemetry snapshot when available;
+- optional post-session notes;
+- privacy-safe JSON/CSV export.
+
+This feature belongs above either renderer and must not be buried in one GUI.
+
+## SBX-010 — Outcome history and local preference learning
+
+**Status:** queued  
+**Depends on:** SBX-009
+
+Add local records for:
+
+- what was played and through which backend/path;
+- exact parameters and source identities;
+- intended purpose;
+- immediate and delayed subjective response;
+- comfort/adverse effects;
+- preference signals;
+- repeatability and protocol-version differences.
+
+Learning remains local, explainable, reversible, and recipe-specific. Do not infer medical efficacy.
+
+## SBX-011 — One-shot cue and orchestration layer
+
+**Status:** queued after verification  
+**Depends on:** SBX-006, SBX-009
+
+First verify whether current SBaGenX provides a completed timed one-shot cue path.
+
+If absent, implement cues as PySbagen session orchestration above the selected renderer:
+
+- exact or event-relative trigger time;
+- source hash, gain, pan, ducking, overlap, and retrigger policy;
+- no reset of continuous native/Python synthesis;
+- event-ledger entry and output/session receipt.
+
+Do not fork SBaGenX DSP merely to add orchestration.
+
+## SBX-012 — Installation, discovery, and license boundary
+
+**Status:** queued  
+**Depends on:** SBX-003, SBX-006
+
+Document and qualify:
+
+- separate SBaGenX installation;
+- environment overrides and system discovery;
+- supported API ranges;
+- Windows, Linux, and macOS library names/locations;
+- optional-dependency behavior;
+- license and attribution responsibilities;
+- diagnostics for incompatible/missing runtime dependencies.
+
+PySbagen packages must not silently bundle third-party native artifacts.
+
+## SBX-013 — End-to-end qualification and completion receipt
+
+**Status:** queued  
+**Depends on:** SBX-001 through SBX-012
+
+Prove complete journeys:
+
+1. no SBaGenX installed → Python/inspection paths continue normally;
+2. native library installed → version/capability report;
+3. SBG validation → dual-engine findings and discrepancy record;
+4. SBGF preservation → native validation → exact identity;
+5. explicit native render → provenance sidecar;
+6. auto backend selection → visible reason;
+7. guided Sleep journey remains portable;
+8. session marker → outcome record → local preference history;
+9. incompatible API → safe refusal/fallback;
+10. existing DRG, compatibility, library, and sleep tests remain green.
+
+## Definition of done
+
+This train is complete only when:
+
+- PySbagen no longer plans to duplicate confirmed SBaGenX features;
+- optional native integration is version/symbol gated;
+- native validation/rendering cannot bypass compatibility truth or provenance;
+- SBGF and DRG remain preserved first-class artifacts;
+- backend choice is visible and reproducible;
+- session intelligence works above either renderer;
+- the Python fallback remains supported;
+- tests and package builds pass across supported Python versions;
+- the completion receipt lists any remaining verify-later rows honestly.

--- a/.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md
+++ b/.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md
@@ -1,8 +1,9 @@
 # PySbagen × SBaGenX Differentiation and Interoperability Beadtrain
 
 **Date:** July 31, 2026  
-**Status:** Active — implementation started  
+**Status:** Active — first native interoperability foundation implemented  
 **Branch:** `agent/sbagenx-interoperability-train-20260731`  
+**Pull request:** `#11` — Differentiate PySbagen and begin SBaGenX interoperability  
 **Source matrix:** `docs/planning/SBAGENX_DIFFERENTIATION_AND_INTEROP_MATRIX.md`  
 **SBaGenX reference:** `lm7137/SBaGenX@be7c74d378774a759f1e4149dc9df3617b4d0d3b`
 
@@ -10,42 +11,28 @@
 
 Make PySbagen the provenance-first, human-facing protocol and session operating layer for the SBaGen ecosystem while treating SBaGenX as the optional advanced native SBaGen engine.
 
-This train deliberately avoids rebuilding SBaGenX's `.sbg`/`.sbgf` editor, curve engine, mix effects, live parameter controls, native export stack, plotting system, packaging, or mobile frontend.
+PySbagen will not rebuild SBaGenX's `.sbg`/`.sbgf` editor, curve engine, mix effects, live controls, multivoice DSP, native export stack, plotting, packaging, or mobile frontend.
 
-At completion, PySbagen must be able to:
-
-- detect and qualify an installed SBaGenX executable or native library;
-- preserve exact SBaGenX version/API/capability identity;
-- validate and inspect SBG/SBGF through a version-gated native adapter;
-- optionally render through SBaGenX with complete provenance and discrepancy receipts;
-- retain the Python renderer as a portable fallback;
-- record session markers, user events, outcomes, and local preferences independently of the rendering backend;
-- run existing guided experiences through an explicit backend-selection policy;
-- preserve DRG and SBGF artifacts without pretending conversion is lossless;
-- never silently route work through an unqualified native backend.
-
-Creativity implementation remains deferred.
+SBaGenX remains optional. PySbagen's Python renderer remains the portable fallback and current guided-product engine.
 
 ## Boundaries
 
 - Do not copy SBaGenX source wholesale into PySbagen.
-- Do not vendor or redistribute SBaGenX binaries without a separate license/dependency review.
-- Do not make SBaGenX mandatory for DRG preservation, inspection, the local library, or existing Sleep Guide use.
+- Do not vendor or redistribute SBaGenX binaries without license/dependency review.
+- Do not make SBaGenX mandatory for DRG preservation, inspection, the local library, or Sleep Guide use.
 - Do not claim bit-identical cross-engine output unless fixture-proven.
-- Do not invent another curve language before supporting `.sbgf` preservation and native validation.
-- Do not independently recreate `mixspin`, `mixbeat`, `mixpulse`, `mixam`, native live ramps, or the SBaGenX editor.
-- Every native operation must record backend version, API version, capabilities, source identity, invocation policy, and output identity.
-- Unknown API revisions or missing symbols fail closed to inspection/fallback rather than guessing.
+- Do not invent another curve language before first-class `.sbgf` preservation.
+- Do not independently recreate confirmed SBaGenX DSP or editor capabilities.
+- Every native operation must record backend version, API version, source identity, and operation result.
+- Unknown API revisions and missing symbols fail closed.
 
 ---
-
-# Beads
 
 ## SBX-001 — Source-pinned differentiation matrix
 
 **Status:** complete
 
-Inspect the actual SBaGenX repository and classify proposed work as delegate, interoperate, shared/fallback, PySbagen-owned, or verify-later.
+Inspected the actual SBaGenX source and classified work as delegate, interoperate, shared/fallback, PySbagen-owned, or verify-later.
 
 **Delivered:** `docs/planning/SBAGENX_DIFFERENTIATION_AND_INTEROP_MATRIX.md`.
 
@@ -53,233 +40,150 @@ Inspect the actual SBaGenX repository and classify proposed work as delegate, in
 
 **Status:** complete
 
-Add a standard-library-only discovery surface for:
+Delivered:
 
-- `SBAGENX_BIN` and PATH executable lookup;
-- `SBAGENXLIB_PATH` and system shared-library lookup;
-- executable version probing;
+- `pysbagen/sbagenx_backend.py`;
+- `sbgpy-inspect backend`;
+- JSON and human reports;
+- `SBAGENX_BIN`, PATH, `SBAGENXLIB_PATH`, and system-library discovery;
+- executable identity from the real `sbagenx -h` banner;
 - `sbx_version()` and `sbx_api_version()`;
-- symbol-backed capabilities for native rendering, SBG/SBGF validation, container writing, live controls, and mix-stream processing;
-- text and deterministic JSON reports;
-- explicit fallback when SBaGenX is absent.
+- symbol-backed capability reporting;
+- discovery-only mode;
+- truthful distinction between candidate found and usable backend;
+- explicit Python-fallback reporting when absent.
 
-**Delivered:**
-
-- `pysbagen/sbagenx_backend.py`
-- `sbgpy-inspect backend`
-- unit tests using a fake native library
-
-Discovery does not yet authorize native rendering.
+Discovery does not authorize native rendering.
 
 ## SBX-003 — Version-gated native binding contract
 
-**Status:** queued  
-**Depends on:** SBX-002
+**Status:** complete for validation operations
 
-Build a narrow ctypes binding around only the symbols PySbagen actually uses.
+Delivered a narrow API-47 ctypes contract in `pysbagen/sbagenx_native.py`:
 
-Requirements:
+- exact function signatures for version, API, SBG validation, SBGF validation, and diagnostic cleanup;
+- exact API-47 `SbxDiagnostic` layout;
+- fail-closed API revision policy;
+- required-symbol checks;
+- native-memory cleanup;
+- empty-version and malformed/null-diagnostic defenses;
+- structured errors instead of fallback guesses.
 
-- exact argument/restype declarations;
-- API-version policy table;
-- symbol requirements per operation;
-- owned-memory cleanup for diagnostics/contexts/writers;
-- platform-safe loading and actionable errors;
-- no broad, untyped dynamic calls;
-- backend identity object reusable by manifests.
-
-**Acceptance:** Unknown or incomplete libraries produce a structured unavailable/unsupported result without crashing or changing fallback behavior.
+Render/context/writer bindings remain intentionally unimplemented until SBX-006.
 
 ## SBX-004 — Native SBG and SBGF validation adapter
 
-**Status:** queued  
-**Depends on:** SBX-003
+**Status:** foundation complete; dual-engine composition remains
 
-Expose native validation while preserving PySbagen's own compatibility report.
+Delivered:
 
-Requirements:
+- `validate_sbagenx_source()` public API;
+- `sbgpy-inspect backend --validate SOURCE`;
+- `.sbg` and `.sbgf` validation through qualified API 47;
+- immutable source byte count and SHA-256;
+- UTF-8 BOM, UTF-8, and Latin-1 source handling;
+- native severity/code/line/column/range/message diagnostics;
+- native library path, version, and API identity;
+- deterministic JSON and human reports.
 
-- validate source text without mutating it;
-- map native diagnostics to source line/column/severity/code;
-- record native engine/API identity;
-- retain both PySbagen and SBaGenX findings when they disagree;
-- never let native success erase PySbagen loss/provenance warnings.
+Still required before this bead is fully closed:
 
-**Acceptance:** One report can show Python-parser findings, native findings, and discrepancies side by side.
+- compose native findings beside PySbagen's own import/compatibility findings;
+- produce an explicit discrepancy section when the engines disagree;
+- ensure native success never weakens PySbagen blockers or provenance warnings.
 
 ## SBX-005 — SBGF preservation and inspectable protocol identity
 
-**Status:** queued  
-**Depends on:** SBX-004
+**Status:** queued
 
-Treat `.sbgf` as a first-class preserved artifact:
-
-- immutable source bytes and hash;
-- encoding and syntax diagnostics;
-- declared parameters, solve directive, expression families, and source locations where available;
-- referenced media and source dependencies;
-- native version/API used for validation;
-- explicit rendered-only/equivalent/partial states for conversions.
-
-Do not attempt to replace `.sbgf` with a new PySbagen project language.
+Treat `.sbgf` as a first-class preserved artifact with immutable bytes/hash, encoding, parameters, solve directives, expression families, dependencies, native diagnostics, and explicit conversion-loss states. Do not replace it with a competing project language.
 
 ## SBX-006 — Optional native render backend with receipts
 
-**Status:** queued  
-**Depends on:** SBX-003 through SBX-005
+**Status:** queued
 
-Add explicit backend selection:
-
-- `python` — current PySbagen renderer;
-- `sbagenx` — qualified native library;
-- `auto` — select native only for fixture-qualified semantics, otherwise Python or blocked according to policy.
-
-Every render receipt must include:
-
-- selected backend and reason;
-- SBaGenX version/API and capability set when native;
-- source hash and import report;
-- sample rate, format, duration, and output hash;
-- unsupported/approximated fields;
-- cross-engine comparison status when available.
-
-No silent subprocess rendering. Prefer the native library; CLI invocation is a separately disclosed fallback only if required.
+Add explicit `python`, `sbagenx`, and capability-gated `auto` backend selection. Prefer the native library; never silently shell out. Receipts must record backend/version/API, source identity, format, duration, configuration, output hash, and discrepancies.
 
 ## SBX-007 — Cross-engine parity and discrepancy laboratory
 
-**Status:** queued  
-**Depends on:** SBX-006
+**Status:** queued
 
-Build representative legal/synthetic fixtures for shared semantics:
-
-- binaural, monaural, isochronic;
-- finite and open-ended sequences;
-- transitions and silence;
-- white/pink noise;
-- background mix where both engines support it.
-
-Measure:
-
-- duration/frame count;
-- RMS/peak and channel relationships;
-- dominant frequencies and beat relationships;
-- transition boundaries;
-- deterministic repeat behavior;
-- documented expected differences.
-
-The output is a product discrepancy report, not a demand for bit identity.
+Use legal/synthetic fixtures for shared binaural, monaural, isochronic, timing, transition, silence, noise, and mix semantics. Compare duration, frames, RMS/peak, channel/frequency relationships, transitions, and deterministic repeat behavior without demanding bit identity.
 
 ## SBX-008 — Guided-product backend policy
 
-**Status:** queued  
-**Depends on:** SBX-006, SBX-007
+**Status:** queued
 
-Allow guided products to request capabilities rather than hard-code engines.
-
-Examples:
-
-- Sleep Guide can remain on the Python journey engine by default;
-- an advanced imported SBGF session may require SBaGenX;
-- a recipe may be portable, native-preferred, or native-required;
-- backend choice must be visible before playback and saved in the exact recipe/session manifest.
-
-Existing guided journeys must remain usable without SBaGenX installed.
+Allow products to request capabilities rather than hard-code engines. Sleep Guide remains portable by default; SBGF or advanced native recipes may be native-preferred or native-required. Save the visible selection reason in every exact recipe/session record.
 
 ## SBX-009 — Backend-independent session markers and event ledger
 
-**Status:** queued  
-**Depends on:** SBX-006
+**Status:** queued
 
-Build a PySbagen-owned append-only session ledger:
-
-- named and quick markers;
-- transport-relative and wall-clock time;
-- backend identity and position;
-- active recipe/protocol hash;
-- native telemetry snapshot when available;
-- optional post-session notes;
-- privacy-safe JSON/CSV export.
-
-This feature belongs above either renderer and must not be buried in one GUI.
+Build append-only named/quick markers with transport/wall-clock time, backend identity, protocol hash, telemetry snapshot where available, post-session notes, and privacy-safe JSON/CSV export.
 
 ## SBX-010 — Outcome history and local preference learning
 
-**Status:** queued  
-**Depends on:** SBX-009
+**Status:** queued
 
-Add local records for:
-
-- what was played and through which backend/path;
-- exact parameters and source identities;
-- intended purpose;
-- immediate and delayed subjective response;
-- comfort/adverse effects;
-- preference signals;
-- repeatability and protocol-version differences.
-
-Learning remains local, explainable, reversible, and recipe-specific. Do not infer medical efficacy.
+Record exact played protocol/backend/path, intended purpose, immediate and delayed response, comfort/adverse effects, preference signals, and version differences. Learning remains local, explainable, reversible, and non-medical.
 
 ## SBX-011 — One-shot cue and orchestration layer
 
-**Status:** queued after verification  
-**Depends on:** SBX-006, SBX-009
+**Status:** queued after upstream verification
 
-First verify whether current SBaGenX provides a completed timed one-shot cue path.
-
-If absent, implement cues as PySbagen session orchestration above the selected renderer:
-
-- exact or event-relative trigger time;
-- source hash, gain, pan, ducking, overlap, and retrigger policy;
-- no reset of continuous native/Python synthesis;
-- event-ledger entry and output/session receipt.
-
-Do not fork SBaGenX DSP merely to add orchestration.
+First verify whether current SBaGenX already provides timed one-shot cues. If absent, implement cues above the selected renderer with exact trigger policy, source identity, gain/pan/ducking/overlap, continuous-renderer preservation, ledger entry, and receipt.
 
 ## SBX-012 — Installation, discovery, and license boundary
 
-**Status:** queued  
-**Depends on:** SBX-003, SBX-006
+**Status:** partial
 
-Document and qualify:
-
-- separate SBaGenX installation;
-- environment overrides and system discovery;
-- supported API ranges;
-- Windows, Linux, and macOS library names/locations;
-- optional-dependency behavior;
-- license and attribution responsibilities;
-- diagnostics for incompatible/missing runtime dependencies.
-
-PySbagen packages must not silently bundle third-party native artifacts.
+The initial guide documents separate installation, environment overrides, candidate/qualification semantics, API-47 scope, and non-vendoring policy. Still required: platform-specific runtime locations, dependency failures, supported future API table, and complete attribution/license packaging guidance.
 
 ## SBX-013 — End-to-end qualification and completion receipt
 
-**Status:** queued  
-**Depends on:** SBX-001 through SBX-012
+**Status:** queued
 
-Prove complete journeys:
+Required journeys:
 
-1. no SBaGenX installed → Python/inspection paths continue normally;
-2. native library installed → version/capability report;
-3. SBG validation → dual-engine findings and discrepancy record;
-4. SBGF preservation → native validation → exact identity;
-5. explicit native render → provenance sidecar;
-6. auto backend selection → visible reason;
-7. guided Sleep journey remains portable;
-8. session marker → outcome record → local preference history;
-9. incompatible API → safe refusal/fallback;
-10. existing DRG, compatibility, library, and sleep tests remain green.
+1. no SBaGenX installed → existing Python/inspection paths remain usable;
+2. native candidate → truthful identity/capability report;
+3. incompatible API → safe refusal;
+4. SBG validation → dual-engine findings;
+5. SBGF preservation → native validation → exact identity;
+6. explicit native render → provenance sidecar;
+7. visible automatic backend decision;
+8. portable guided Sleep journey;
+9. marker → outcome → preference history;
+10. existing DRG, compatibility, library, and sleep suites remain green.
+
+## Current qualification receipt
+
+Focused tests authored for:
+
+- executable help-banner identity;
+- native library version/API/symbol discovery;
+- discovered-versus-qualified state;
+- missing backend/configured path reporting;
+- exact API-47 diagnostic decoding;
+- rejection of unknown API revisions;
+- rejection of malformed null diagnostic pointers;
+- Latin-1 source preservation and SHA-256 identity.
+
+A previous isolated run passed the initial probe and native-binding tests. After the latest hardening commits, this runtime could not clone the public branch because outbound DNS access was unavailable, and no GitHub Actions run appeared for the current PR head. The full repository suite therefore remains an explicit pre-merge requirement rather than an implied success.
+
+CodeRabbit's full review was rate-limited. Its available static precheck reported low helper-docstring coverage; the new backend module was then fully documented. No actionable inline review thread has been posted.
 
 ## Definition of done
 
 This train is complete only when:
 
-- PySbagen no longer plans to duplicate confirmed SBaGenX features;
+- confirmed SBaGenX features are no longer scheduled for duplicate implementation;
 - optional native integration is version/symbol gated;
 - native validation/rendering cannot bypass compatibility truth or provenance;
-- SBGF and DRG remain preserved first-class artifacts;
+- SBGF and DRG remain first-class preserved artifacts;
 - backend choice is visible and reproducible;
 - session intelligence works above either renderer;
-- the Python fallback remains supported;
-- tests and package builds pass across supported Python versions;
-- the completion receipt lists any remaining verify-later rows honestly.
+- Python fallback remains supported;
+- full tests and package builds pass before merge;
+- remaining verify-later rows are resolved honestly.

--- a/.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md
+++ b/.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md
@@ -1,7 +1,7 @@
 # PySbagen × SBaGenX Differentiation and Interoperability Beadtrain
 
 **Date:** July 31, 2026  
-**Status:** Active — first native interoperability foundation implemented  
+**Status:** Active — first native interoperability foundation implemented and qualified  
 **Branch:** `agent/sbagenx-interoperability-train-20260731`  
 **Pull request:** `#11` — Differentiate PySbagen and begin SBaGenX interoperability  
 **Source matrix:** `docs/planning/SBAGENX_DIFFERENTIATION_AND_INTEROP_MATRIX.md`  
@@ -159,20 +159,34 @@ Required journeys:
 
 ## Current qualification receipt
 
-Focused tests authored for:
+GitHub Actions **Python qualification run #42** passed on the implementation head:
 
-- executable help-banner identity;
+- Python 3.10 product-path tests — passed;
+- Python 3.11 product-path tests — passed;
+- Python 3.12 product-path tests — passed;
+- Python 3.13 product-path tests — passed;
+- complete repository result — **55 tests passed**;
+- Python 3.12 source distribution and wheel build — passed;
+- wheel inspection in the build log includes `pysbagen/sbagenx_backend.py` and `pysbagen/sbagenx_native.py`.
+
+The build emits an existing setuptools deprecation warning for the TOML-table form of `project.license`; it does not fail this train but should be repaired before the announced February 18, 2027 cutoff.
+
+CodeRabbit status is green. Two correctness threads were addressed and resolved:
+
+1. candidate discovery was separated from successful backend qualification, with normal CLI failure for unusable candidates;
+2. unrecognized help banners no longer become fake version strings.
+
+Regression coverage includes:
+
+- executable help-banner identity and unrecognized-banner refusal;
 - native library version/API/symbol discovery;
 - discovered-versus-qualified state;
+- non-executable and unloadable candidates;
 - missing backend/configured path reporting;
 - exact API-47 diagnostic decoding;
 - rejection of unknown API revisions;
 - rejection of malformed null diagnostic pointers;
 - Latin-1 source preservation and SHA-256 identity.
-
-A previous isolated run passed the initial probe and native-binding tests. After the latest hardening commits, this runtime could not clone the public branch because outbound DNS access was unavailable, and no GitHub Actions run appeared for the current PR head. The full repository suite therefore remains an explicit pre-merge requirement rather than an implied success.
-
-CodeRabbit's full review was rate-limited. Its available static precheck reported low helper-docstring coverage; the new backend module was then fully documented. No actionable inline review thread has been posted.
 
 ## Definition of done
 

--- a/.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md
+++ b/.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md
@@ -1,7 +1,7 @@
 # PySbagen × SBaGenX Differentiation and Interoperability Beadtrain
 
 **Date:** July 31, 2026  
-**Status:** Active — first native interoperability foundation implemented and qualified  
+**Status:** Active — discovery, API-47 validation, dual-engine truth, and SBGF preservation implemented and qualified  
 **Branch:** `agent/sbagenx-interoperability-train-20260731`  
 **Pull request:** `#11` — Differentiate PySbagen and begin SBaGenX interoperability  
 **Source matrix:** `docs/planning/SBAGENX_DIFFERENTIATION_AND_INTEROP_MATRIX.md`  
@@ -73,36 +73,53 @@ Render/context/writer bindings remain intentionally unimplemented until SBX-006.
 
 ## SBX-004 — Native SBG and SBGF validation adapter
 
-**Status:** foundation complete; dual-engine composition remains
+**Status:** complete
 
 Delivered:
 
-- `validate_sbagenx_source()` public API;
+- `validate_sbagenx_source()` for exact API-47 native validation;
+- `inspect_with_sbagenx()` for one combined PySbagen/SBaGenX truth report;
 - `sbgpy-inspect backend --validate SOURCE`;
-- `.sbg` and `.sbgf` validation through qualified API 47;
-- immutable source byte count and SHA-256;
+- immutable source byte count and SHA-256 checked by both paths;
 - UTF-8 BOM, UTF-8, and Latin-1 source handling;
 - native severity/code/line/column/range/message diagnostics;
 - native library path, version, and API identity;
-- deterministic JSON and human reports.
+- PySbagen compatibility disposition preserved independently;
+- explicit discrepancy codes when PySbagen accepts and SBaGenX rejects, SBaGenX accepts and PySbagen limits, native errors exist, source identities differ, or native semantics may exceed a PySbagen approximation;
+- exit `0` only for an identity-matched, native-valid, PySbagen-safe source without discrepancies;
+- exit `1` for disclosed cross-engine limitations/discrepancies;
+- exit `2` for identity mismatch, native rejection, or operational failure.
 
-Still required before this bead is fully closed:
-
-- compose native findings beside PySbagen's own import/compatibility findings;
-- produce an explicit discrepancy section when the engines disagree;
-- ensure native success never weakens PySbagen blockers or provenance warnings.
+Native success never erases PySbagen blockers, unsupported states, approximations, missing sources, or provenance warnings.
 
 ## SBX-005 — SBGF preservation and inspectable protocol identity
 
-**Status:** queued
+**Status:** complete
 
-Treat `.sbgf` as a first-class preserved artifact with immutable bytes/hash, encoding, parameters, solve directives, expression families, dependencies, native diagnostics, and explicit conversion-loss states. Do not replace it with a competing project language.
+Delivered `pysbagen/sbgf.py` and first-class `.sbgf` inspection:
+
+- immutable original bytes, byte count, SHA-256, and encoding;
+- parameter declarations and source expressions;
+- solve directives with source lines;
+- output/expression assignments;
+- referenced function names;
+- quoted media dependencies, resolved paths, source lines, and missing-source findings;
+- unknown lines preserved rather than dropped or speculatively interpreted;
+- explicit `inspection-only` disposition and qualified-native-runtime requirement;
+- no invented SBG timeline for a function-driven program;
+- ordinary `sbgpy-inspect inspect SOURCE.sbgf` support;
+- local content-addressed library storage and offline source-hash verification;
+- combined native validation through the interoperability report.
+
+PySbagen does not replace `.sbgf` with a competing project language and does not claim to render its expression semantics independently.
 
 ## SBX-006 — Optional native render backend with receipts
 
-**Status:** queued
+**Status:** queued — next implementation bead
 
 Add explicit `python`, `sbagenx`, and capability-gated `auto` backend selection. Prefer the native library; never silently shell out. Receipts must record backend/version/API, source identity, format, duration, configuration, output hash, and discrepancies.
+
+No native render path may land before typed context/writer cleanup, representative parity fixtures, and output receipts are all present.
 
 ## SBX-007 — Cross-engine parity and discrepancy laboratory
 
@@ -149,8 +166,8 @@ Required journeys:
 1. no SBaGenX installed → existing Python/inspection paths remain usable;
 2. native candidate → truthful identity/capability report;
 3. incompatible API → safe refusal;
-4. SBG validation → dual-engine findings;
-5. SBGF preservation → native validation → exact identity;
+4. SBG validation → combined dual-engine findings;
+5. SBGF preservation → local library → native validation → exact identity;
 6. explicit native render → provenance sidecar;
 7. visible automatic backend decision;
 8. portable guided Sleep journey;
@@ -159,17 +176,21 @@ Required journeys:
 
 ## Current qualification receipt
 
-GitHub Actions **Python qualification run #42** passed on the implementation head:
+GitHub Actions **Python qualification run #49** passed the complete current implementation:
 
 - Python 3.10 product-path tests — passed;
 - Python 3.11 product-path tests — passed;
 - Python 3.12 product-path tests — passed;
 - Python 3.13 product-path tests — passed;
-- complete repository result — **55 tests passed**;
+- complete repository result — **59 tests passed**;
 - Python 3.12 source distribution and wheel build — passed;
-- wheel inspection in the build log includes `pysbagen/sbagenx_backend.py` and `pysbagen/sbagenx_native.py`.
+- wheel inspection includes:
+  - `pysbagen/sbagenx_backend.py`;
+  - `pysbagen/sbagenx_native.py`;
+  - `pysbagen/sbgf.py`;
+  - `pysbagen/interoperability.py`.
 
-The build emits an existing setuptools deprecation warning for the TOML-table form of `project.license`; it does not fail this train but should be repaired before the announced February 18, 2027 cutoff.
+The build emits an existing setuptools deprecation warning for the TOML-table form of `project.license`; it does not fail this train but should be repaired before February 18, 2027. GitHub's runner also warns that Node 20 actions are being forced onto Node 24; the workflow remains green.
 
 CodeRabbit status is green. Two correctness threads were addressed and resolved:
 
@@ -186,7 +207,10 @@ Regression coverage includes:
 - exact API-47 diagnostic decoding;
 - rejection of unknown API revisions;
 - rejection of malformed null diagnostic pointers;
-- Latin-1 source preservation and SHA-256 identity.
+- Latin-1 source preservation and SHA-256 identity;
+- SBGF structure, solve directives, function inventory, missing media, local-library verification, and no invented timeline;
+- native-valid/PySbagen-limited discrepancies;
+- PySbagen-accepted/native-rejected discrepancies.
 
 ## Definition of done
 

--- a/docs/compatibility/SBAGENX_BACKEND_GUIDE.md
+++ b/docs/compatibility/SBAGENX_BACKEND_GUIDE.md
@@ -1,13 +1,13 @@
 # Optional SBaGenX Backend Guide
 
-**Status:** Discovery and API-47 native validation foundation  
+**Status:** Discovery, API-47 validation, combined truth reports, and SBGF preservation  
 **PySbagen behavior:** SBaGenX is optional; native rendering is not enabled yet
 
 ## Product boundary
 
 SBaGenX is the advanced native SBaGen engine. PySbagen remains responsible for compatibility truth, DRG/SBGF preservation, provenance, local library records, listening-path qualification, guided products, session history, and research workflows.
 
-The current adapter can discover and qualify an installed SBaGenX runtime and validate `.sbg`/`.sbgf` source through the reviewed API-47 diagnostic contract. It does not silently change rendering behavior.
+The current adapter can discover and qualify an installed SBaGenX runtime, preserve `.sbgf` as a first-class artifact, and compare PySbagen inspection with API-47 native validation. It does not silently change rendering behavior.
 
 ## Probe an installation
 
@@ -35,7 +35,32 @@ sbgpy-inspect backend \
   --library /path/to/libsbagenx.so
 ```
 
-## Validate SBG or SBGF through SBaGenX
+## Preserve and inspect SBGF without a native runtime
+
+```bash
+sbgpy-inspect inspect curve.sbgf
+```
+
+Store the immutable source in the local content-addressed library:
+
+```bash
+sbgpy-inspect inspect curve.sbgf --add-to-library
+```
+
+PySbagen records:
+
+- original byte count, SHA-256, and encoding;
+- parameter declarations and expressions;
+- solve directives and source lines;
+- output/expression assignments;
+- referenced function names;
+- quoted media dependencies, resolved paths, and missing sources;
+- unclassified lines without dropping them;
+- an explicit `inspection-only` state and native-runtime requirement.
+
+PySbagen does not reinterpret `.sbgf` as ordinary SBG events, does not invent a fake timeline, and does not claim to render the function language independently.
+
+## Compare SBG or SBGF through both truth layers
 
 ```bash
 sbgpy-inspect backend \
@@ -49,16 +74,38 @@ sbgpy-inspect backend \
   --json
 ```
 
-Native validation records:
+The result contains two separate reports:
+
+1. **PySbagen compatibility truth** — preservation, missing sources, unsupported or approximated semantics, provenance, and render disposition.
+2. **SBaGenX native validation** — API-47 diagnostics from the exact same source bytes.
+
+The combined discrepancy section records when:
+
+- the source hashes differ;
+- PySbagen accepts a source that SBaGenX rejects;
+- SBaGenX validates a source that PySbagen keeps limited or inspection-only;
+- native error diagnostics exist;
+- SBaGenX may preserve semantics that PySbagen currently approximates.
+
+Native success never erases a PySbagen blocker, missing source, unsupported state, approximation, or provenance warning.
+
+### Exit status
+
+- `0` — source identity matches, SBaGenX validates it, PySbagen marks it safe, and no discrepancy remains;
+- `1` — validation succeeded but a PySbagen limitation or cross-engine discrepancy must remain visible;
+- `2` — source identity mismatch, native rejection, unsupported native API, missing/unloadable backend, or operational failure.
+
+## Native validation identity
+
+The API-47 binding records:
 
 - immutable source byte count and SHA-256;
 - detected UTF-8 BOM, UTF-8, or Latin-1 decoding;
 - source kind and absolute path;
 - native library path, `sbx_version()`, and `sbx_api_version()`;
-- structured severity, code, line, column, range, and message diagnostics;
-- a truthful validity result that does not erase PySbagen compatibility findings.
+- structured severity, code, line, column, range, and message diagnostics.
 
-The binding is deliberately fail-closed and currently qualifies **SBaGenX API 47 only**, matching the source revision reviewed for this train. New API revisions require an explicit binding review rather than automatic acceptance.
+The binding is deliberately fail-closed and currently qualifies **SBaGenX API 47 only**, matching the source revision reviewed for this train. A new API revision requires an explicit struct/signature review rather than automatic acceptance.
 
 ## Environment overrides
 
@@ -67,7 +114,7 @@ The binding is deliberately fail-closed and currently qualifies **SBaGenX API 47
 
 Without overrides, PySbagen checks PATH for `sbagenx` and asks the platform dynamic-library resolver for `sbagenx`/`sbagenxlib`.
 
-## Reported identity
+## Reported backend identity
 
 The probe records where available:
 
@@ -83,37 +130,35 @@ The probe records where available:
   - live parameter control;
   - mix-stream processing.
 
-SBaGenX uses `-V` for master volume; it does not publish a `--version` contract in the reviewed source. The adapter therefore uses the documented help banner for CLI identity and the native functions for authoritative library identity.
+SBaGenX uses `-V` for master volume; it does not publish a `--version` contract in the reviewed source. The adapter therefore uses the help banner for CLI identity and native functions for authoritative library identity.
 
 A discovered candidate is not automatically a usable backend. Normal probing succeeds only when the executable or library returns a qualified identity. Discovery-only mode reports locations without claiming qualification.
 
 ## Missing backend
 
-When SBaGenX is not installed, the command reports that explicitly. Existing PySbagen behavior remains available:
+When SBaGenX is not installed, existing PySbagen behavior remains available:
 
-- SBG/DRG inspection and preservation;
+- SBG/SBGF/DRG inspection and preservation;
 - local-first library;
 - audio/path qualification;
-- current Python rendering;
+- current Python rendering for supported SBG and generated recipes;
 - Sleep Guide and exact sleep recipes.
 
 ## Safety and trust boundary
 
-Running the normal probe may execute the configured `sbagenx -h` command and load the configured shared library to read its API and symbols. Use `--discover-only` when inspecting an unfamiliar path without executing/loading it.
+Running the normal probe may execute the configured `sbagenx -h` command and load the configured shared library to read its API and symbols. Use `--discover-only` when inspecting an unfamiliar path without executing or loading it.
 
-Native validation loads and calls the selected shared library. It never downloads, installs, vendors, updates, or renders through SBaGenX automatically.
+Native validation loads and calls the selected shared library. PySbagen never downloads, installs, vendors, updates, or renders through SBaGenX automatically.
 
-## Remaining implementation gates
+## Remaining native-render gates
 
 Native rendering remains blocked until:
 
-1. render/context/writer functions have exact typed bindings and cleanup rules;
-2. representative shared semantics pass parity/discrepancy fixtures;
+1. context/render/writer functions have exact typed bindings and cleanup rules;
+2. representative shared semantics pass parity and discrepancy fixtures;
 3. backend selection is explicit and capability-based;
 4. native output receives source, backend, API, configuration, and output-hash receipts;
 5. Python fallback and existing guided products remain green.
-
-Native validation still needs composition into a single dual-engine compatibility/discrepancy report; the standalone API-47 result is the completed foundation for that step.
 
 See:
 

--- a/docs/compatibility/SBAGENX_BACKEND_GUIDE.md
+++ b/docs/compatibility/SBAGENX_BACKEND_GUIDE.md
@@ -1,0 +1,93 @@
+# Optional SBaGenX Backend Guide
+
+**Status:** Initial interoperability foundation  
+**PySbagen behavior:** SBaGenX is optional; native rendering is not enabled yet
+
+## Product boundary
+
+SBaGenX is the advanced native SBaGen engine. PySbagen remains responsible for compatibility truth, DRG/SBGF preservation, provenance, local library records, listening-path qualification, guided products, session history, and research workflows.
+
+The first adapter stage discovers and qualifies an installed SBaGenX runtime. It does not silently change rendering behavior.
+
+## Probe an installation
+
+```bash
+sbgpy-inspect backend
+```
+
+Machine-readable report:
+
+```bash
+sbgpy-inspect backend --json
+```
+
+Locate configured candidates without executing the CLI or loading the shared library:
+
+```bash
+sbgpy-inspect backend --discover-only
+```
+
+Explicit paths:
+
+```bash
+sbgpy-inspect backend \
+  --executable /path/to/sbagenx \
+  --library /path/to/libsbagenx.so
+```
+
+## Environment overrides
+
+- `SBAGENX_BIN` — SBaGenX command-line executable
+- `SBAGENXLIB_PATH` — `sbagenxlib` shared-library path or loader name
+
+Without overrides, PySbagen checks PATH for `sbagenx` and asks the platform dynamic-library resolver for `sbagenx`/`sbagenxlib`.
+
+## Reported identity
+
+The probe records where available:
+
+- executable path and `--version` response;
+- native-library path;
+- `sbx_version()`;
+- `sbx_api_version()`;
+- presence of symbols needed for:
+  - native float rendering;
+  - SBG validation;
+  - SBGF validation;
+  - container writing;
+  - live parameter control;
+  - mix-stream processing.
+
+A path or version is not permission to render. Later beads add exact ctypes signatures, API-version gates, cleanup rules, validation adapters, parity fixtures, and provenance sidecars before native output becomes selectable.
+
+## Missing backend
+
+When SBaGenX is not installed, the command reports that explicitly. Existing PySbagen behavior remains available:
+
+- SBG/DRG inspection and preservation;
+- local-first library;
+- audio/path qualification;
+- current Python rendering;
+- Sleep Guide and exact sleep recipes.
+
+## Safety and trust boundary
+
+Running the normal probe may execute the configured `sbagenx --version` command and load the configured shared library to read its API and symbols. Use `--discover-only` when inspecting an unfamiliar path without executing/loading it.
+
+PySbagen does not download, install, vendor, or update SBaGenX automatically.
+
+## Next implementation gates
+
+Native validation/rendering remains blocked until:
+
+1. every used C function has an exact typed binding;
+2. supported API revisions are declared;
+3. required symbols are checked per operation;
+4. native diagnostics preserve PySbagen compatibility findings;
+5. cross-engine fixture comparisons are recorded;
+6. backend identity and output hashes appear in render receipts.
+
+See:
+
+- `docs/planning/SBAGENX_DIFFERENTIATION_AND_INTEROP_MATRIX.md`
+- `.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md`

--- a/docs/compatibility/SBAGENX_BACKEND_GUIDE.md
+++ b/docs/compatibility/SBAGENX_BACKEND_GUIDE.md
@@ -46,7 +46,7 @@ Without overrides, PySbagen checks PATH for `sbagenx` and asks the platform dyna
 
 The probe records where available:
 
-- executable path and `--version` response;
+- executable path and version parsed from the first `sbagenx -h` banner line;
 - native-library path;
 - `sbx_version()`;
 - `sbx_api_version()`;
@@ -57,6 +57,8 @@ The probe records where available:
   - container writing;
   - live parameter control;
   - mix-stream processing.
+
+SBaGenX uses `-V` for master volume; it does not publish a `--version` contract in the reviewed source. The adapter therefore uses the documented help banner for CLI identity and the native functions for authoritative library identity.
 
 A path or version is not permission to render. Later beads add exact ctypes signatures, API-version gates, cleanup rules, validation adapters, parity fixtures, and provenance sidecars before native output becomes selectable.
 
@@ -72,7 +74,7 @@ When SBaGenX is not installed, the command reports that explicitly. Existing PyS
 
 ## Safety and trust boundary
 
-Running the normal probe may execute the configured `sbagenx --version` command and load the configured shared library to read its API and symbols. Use `--discover-only` when inspecting an unfamiliar path without executing/loading it.
+Running the normal probe may execute the configured `sbagenx -h` command and load the configured shared library to read its API and symbols. Use `--discover-only` when inspecting an unfamiliar path without executing/loading it.
 
 PySbagen does not download, install, vendor, or update SBaGenX automatically.
 

--- a/docs/compatibility/SBAGENX_BACKEND_GUIDE.md
+++ b/docs/compatibility/SBAGENX_BACKEND_GUIDE.md
@@ -1,13 +1,13 @@
 # Optional SBaGenX Backend Guide
 
-**Status:** Initial interoperability foundation  
+**Status:** Discovery and API-47 native validation foundation  
 **PySbagen behavior:** SBaGenX is optional; native rendering is not enabled yet
 
 ## Product boundary
 
 SBaGenX is the advanced native SBaGen engine. PySbagen remains responsible for compatibility truth, DRG/SBGF preservation, provenance, local library records, listening-path qualification, guided products, session history, and research workflows.
 
-The first adapter stage discovers and qualifies an installed SBaGenX runtime. It does not silently change rendering behavior.
+The current adapter can discover and qualify an installed SBaGenX runtime and validate `.sbg`/`.sbgf` source through the reviewed API-47 diagnostic contract. It does not silently change rendering behavior.
 
 ## Probe an installation
 
@@ -35,6 +35,31 @@ sbgpy-inspect backend \
   --library /path/to/libsbagenx.so
 ```
 
+## Validate SBG or SBGF through SBaGenX
+
+```bash
+sbgpy-inspect backend \
+  --library /path/to/libsbagenx.so \
+  --validate session.sbg
+```
+
+```bash
+sbgpy-inspect backend \
+  --validate curve.sbgf \
+  --json
+```
+
+Native validation records:
+
+- immutable source byte count and SHA-256;
+- detected UTF-8 BOM, UTF-8, or Latin-1 decoding;
+- source kind and absolute path;
+- native library path, `sbx_version()`, and `sbx_api_version()`;
+- structured severity, code, line, column, range, and message diagnostics;
+- a truthful validity result that does not erase PySbagen compatibility findings.
+
+The binding is deliberately fail-closed and currently qualifies **SBaGenX API 47 only**, matching the source revision reviewed for this train. New API revisions require an explicit binding review rather than automatic acceptance.
+
 ## Environment overrides
 
 - `SBAGENX_BIN` — SBaGenX command-line executable
@@ -60,7 +85,7 @@ The probe records where available:
 
 SBaGenX uses `-V` for master volume; it does not publish a `--version` contract in the reviewed source. The adapter therefore uses the documented help banner for CLI identity and the native functions for authoritative library identity.
 
-A path or version is not permission to render. Later beads add exact ctypes signatures, API-version gates, cleanup rules, validation adapters, parity fixtures, and provenance sidecars before native output becomes selectable.
+A discovered candidate is not automatically a usable backend. Normal probing succeeds only when the executable or library returns a qualified identity. Discovery-only mode reports locations without claiming qualification.
 
 ## Missing backend
 
@@ -76,18 +101,19 @@ When SBaGenX is not installed, the command reports that explicitly. Existing PyS
 
 Running the normal probe may execute the configured `sbagenx -h` command and load the configured shared library to read its API and symbols. Use `--discover-only` when inspecting an unfamiliar path without executing/loading it.
 
-PySbagen does not download, install, vendor, or update SBaGenX automatically.
+Native validation loads and calls the selected shared library. It never downloads, installs, vendors, updates, or renders through SBaGenX automatically.
 
-## Next implementation gates
+## Remaining implementation gates
 
-Native validation/rendering remains blocked until:
+Native rendering remains blocked until:
 
-1. every used C function has an exact typed binding;
-2. supported API revisions are declared;
-3. required symbols are checked per operation;
-4. native diagnostics preserve PySbagen compatibility findings;
-5. cross-engine fixture comparisons are recorded;
-6. backend identity and output hashes appear in render receipts.
+1. render/context/writer functions have exact typed bindings and cleanup rules;
+2. representative shared semantics pass parity/discrepancy fixtures;
+3. backend selection is explicit and capability-based;
+4. native output receives source, backend, API, configuration, and output-hash receipts;
+5. Python fallback and existing guided products remain green.
+
+Native validation still needs composition into a single dual-engine compatibility/discrepancy report; the standalone API-47 result is the completed foundation for that step.
 
 See:
 

--- a/docs/planning/CURRENT_PRODUCT_PRIORITY.md
+++ b/docs/planning/CURRENT_PRODUCT_PRIORITY.md
@@ -76,7 +76,7 @@ SBaGenX remains optional. The Python renderer remains the portable fallback and 
 
 ## Implementation delivered on the active branch
 
-### Backend discovery
+### Backend discovery and qualification
 
 - `pysbagen/sbagenx_backend.py`
 - `sbgpy-inspect backend`
@@ -85,14 +85,44 @@ SBaGenX remains optional. The Python renderer remains the portable fallback and 
 ### Typed native validation
 
 - `pysbagen/sbagenx_native.py`
-- `sbgpy-inspect backend --validate SOURCE`
 - exact API-47 ctypes signatures and diagnostic layout
-- fail-closed unknown-API and missing-symbol behavior
+- fail-closed unknown-API, missing-symbol, malformed-pointer, and false-banner behavior
 - immutable source byte count and SHA-256
 - SBG/SBGF diagnostics with severity, code, location, range, and message
 - native library/version/API identity in deterministic reports
 
-Native rendering remains deliberately disabled. It waits for render/context/writer bindings, dual-engine discrepancy reports, parity fixtures, explicit backend policy, and complete provenance sidecars.
+### Combined compatibility truth
+
+- `pysbagen/interoperability.py`
+- `sbgpy-inspect backend --validate SOURCE`
+- PySbagen compatibility disposition and SBaGenX validity remain separate
+- exact-source identity comparison
+- explicit discrepancies for cross-engine acceptance/rejection and semantic differences
+- native success cannot erase PySbagen blockers, missing sources, unsupported states, or approximations
+
+### First-class SBGF preservation
+
+- `pysbagen/sbgf.py`
+- ordinary `sbgpy-inspect inspect SOURCE.sbgf`
+- immutable bytes/hash/encoding
+- parameters, solve directives, assignments, function inventory, media dependencies, and unknown-line preservation
+- local content-addressed library storage and offline verification
+- explicit `inspection-only` state and native-runtime requirement
+- no invented replacement curve language or fake SBG timeline
+
+## Next implementation bead
+
+**SBX-006 — Optional native render backend with receipts** is next.
+
+Native rendering remains deliberately disabled until the same change delivers:
+
+- exact typed context/render/writer bindings and cleanup;
+- representative parity/discrepancy fixtures;
+- explicit `python`, `sbagenx`, and capability-gated `auto` policy;
+- source/backend/API/configuration/output-hash receipts;
+- preserved Python fallback and guided-product behavior.
+
+The current implementation passed Python 3.10–3.13 qualification with **59 tests** and a successful source distribution/wheel build.
 
 ## Creativity status
 

--- a/docs/planning/CURRENT_PRODUCT_PRIORITY.md
+++ b/docs/planning/CURRENT_PRODUCT_PRIORITY.md
@@ -3,14 +3,9 @@
 **Date:** July 31, 2026  
 **Status:** Compatibility delivered; SBaGenX interoperability and PySbagen differentiation are the active priority
 
-## Delivered foundation
+## Delivered compatibility foundation
 
-The I-Doser/SBaGen compatibility, preservation, inspection, qualification, and local-library train was implemented and merged through:
-
-- `.beads/pysbagen_compatibility_preservation_train_2026_07_31.md`
-- PR `#9` — **Build the SBaGen and DRG compatibility product**
-- merge commit `0c95a67ca65db22d6441b123a5709bcaf929a064`
-- completion receipt `.beads/pysbagen_compatibility_preservation_train_2026_07_31_COMPLETION.md`
+The I-Doser/SBaGen compatibility, preservation, inspection, qualification, and local-library train was merged through PR `#9` at `0c95a67ca65db22d6441b123a5709bcaf929a064`.
 
 Delivered capabilities remain:
 
@@ -23,31 +18,30 @@ Delivered capabilities remain:
 
 ## Product-direction correction
 
-The original SBaGen TODO identified many missing workstation and DSP features. A first follow-up plan assumed PySbagen should implement them all.
-
-A source-level review of `lm7137/SBaGenX` showed that this would duplicate the active modern SBaGen lineage. SBaGenX already provides substantial native engine, `.sbg`/`.sbgf`, curve, mix-effect, live-control, multivoice, export, plotting, packaging, desktop, and Android work.
+A source-level review of `lm7137/SBaGenX` showed that the broad Python workstation plan would duplicate the active modern SBaGen lineage. SBaGenX already provides substantial native engine, `.sbg`/`.sbgf`, curve, mix-effect, live-control, multivoice, export, plotting, packaging, desktop, and Android work.
 
 Therefore:
 
 > PySbagen will not rebuild SBaGenX in Python.
 
-The broad workstation recreation train is superseded:
+The broad workstation recreation train is retained only as a superseded record:
 
 - `.beads/pysbagen_experimenter_workstation_train_2026_07_31.md`
 
 ## Active priority
 
-The authoritative boundary is:
+Authoritative boundary:
 
 - `docs/planning/SBAGENX_DIFFERENTIATION_AND_INTEROP_MATRIX.md`
 
-The active implementation train is:
+Active implementation train:
 
 - `.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md`
 
-Active branch:
+Active branch and PR:
 
 - `agent/sbagenx-interoperability-train-20260731`
+- PR `#11` — **Differentiate PySbagen and begin SBaGenX interoperability**
 
 ## Product responsibilities
 
@@ -57,7 +51,7 @@ Treat SBaGenX as the optional advanced native SBaGen engine for:
 
 - advanced SBG sequencing and DSP;
 - `.sbgf` curves and built-in programs;
-- native validation and rendering;
+- native validation and future optional rendering;
 - mixspin/mixbeat/mixpulse/mixam;
 - native live parameter controls;
 - multiple voices, auxiliary tones, plotting, export, and frontend work.
@@ -76,35 +70,48 @@ Keep PySbagen focused on:
 - outcome history and local preference learning;
 - evidence-position and claim provenance;
 - consent-aware research workflows;
-- one-shot cue/session orchestration only after verifying it is not already available upstream.
+- one-shot cue/session orchestration only after checking upstream.
 
 SBaGenX remains optional. The Python renderer remains the portable fallback and current guided-product engine.
 
-## Implementation started
+## Implementation delivered on the active branch
 
-The first interoperability foundation is now implemented:
+### Backend discovery
 
 - `pysbagen/sbagenx_backend.py`
 - `sbgpy-inspect backend`
+- executable/library discovery, candidate-versus-usable status, version/API identity, and symbol-backed capabilities
 
-It discovers `SBAGENX_BIN`, `SBAGENXLIB_PATH`, system candidates, native version/API, and symbol-backed capabilities. It does not yet route rendering through SBaGenX; native rendering waits for typed bindings, parity fixtures, and complete provenance receipts.
+### Typed native validation
+
+- `pysbagen/sbagenx_native.py`
+- `sbgpy-inspect backend --validate SOURCE`
+- exact API-47 ctypes signatures and diagnostic layout
+- fail-closed unknown-API and missing-symbol behavior
+- immutable source byte count and SHA-256
+- SBG/SBGF diagnostics with severity, code, location, range, and message
+- native library/version/API identity in deterministic reports
+
+Native rendering remains deliberately disabled. It waits for render/context/writer bindings, dual-engine discrepancy reports, parity fixtures, explicit backend policy, and complete provenance sidecars.
 
 ## Creativity status
 
-The creativity research and product gap remain valid and preserved in:
+The creativity research remains preserved in:
 
 - `docs/research/CREATIVITY_AUDIO_RESEARCH_FOUNDATIONS.md`
 - `docs/planning/CREATIVITY_PRODUCT_GAP_CHECK.md`
 
-However, **creativity implementation remains deferred**. Interoperability and the differentiated session-intelligence foundation take precedence.
+**Creativity implementation remains deferred.** Interoperability and the differentiated session-intelligence foundation take precedence.
 
 ## Completion rule
 
 This priority is complete only when:
 
 - native integration is version- and symbol-gated;
-- SBG/SBGF validation and optional rendering retain compatibility truth and provenance;
+- native validation and rendering cannot bypass compatibility truth or provenance;
+- SBGF and DRG remain first-class preserved artifacts;
 - backend choice is visible and reproducible;
 - Python fallback remains supported;
 - PySbagen-owned session/event/outcome features work above either backend;
-- remaining verify-later rows are explicitly resolved rather than guessed.
+- full tests and package builds pass before merge;
+- verify-later rows are resolved rather than guessed.

--- a/docs/planning/CURRENT_PRODUCT_PRIORITY.md
+++ b/docs/planning/CURRENT_PRODUCT_PRIORITY.md
@@ -1,60 +1,93 @@
 # PySbagen Current Product Priority
 
 **Date:** July 31, 2026  
-**Status:** Compatibility phase delivered; original-SBaGen workstation completion is the active next priority
+**Status:** Compatibility delivered; SBaGenX interoperability and PySbagen differentiation are the active priority
 
-## Scope correction
+## Delivered foundation
 
-The I-Doser/SBaGen compatibility, preservation, inspection, and local-library train was successfully implemented and merged through:
+The I-Doser/SBaGen compatibility, preservation, inspection, qualification, and local-library train was implemented and merged through:
 
 - `.beads/pysbagen_compatibility_preservation_train_2026_07_31.md`
 - PR `#9` — **Build the SBaGen and DRG compatibility product**
 - merge commit `0c95a67ca65db22d6441b123a5709bcaf929a064`
 - completion receipt `.beads/pysbagen_compatibility_preservation_train_2026_07_31_COMPLETION.md`
 
-That train completed the six priorities explicitly listed under the pain-point scout's **next compatibility train** section.
+Delivered capabilities remain:
 
-It did **not** complete the separate workstation/product features recorded by the original SBaGen website and bundled TODO. The previous wording "compatibility priority delivered" was accurate only for that bounded phase, but it could be read as though the entire pain-point handoff had been delivered. This document corrects that interpretation.
+1. honest SBG/DRG import reports and render dispositions;
+2. complete DRG package preservation;
+3. original-SBaGen semantic compatibility matrix;
+4. timeline/source inspection before playback;
+5. audio-source and listening-path qualification;
+6. local-first provenance library.
 
-## Delivered compatibility foundation
+## Product-direction correction
 
-1. Honest SBG/DRG import reports and render dispositions.
-2. Complete DRG package preservation.
-3. Original-SBaGen semantic compatibility matrix.
-4. Timeline/source inspection before playback.
-5. Audio-source and listening-path qualification.
-6. Local-first provenance library.
+The original SBaGen TODO identified many missing workstation and DSP features. A first follow-up plan assumed PySbagen should implement them all.
 
-These remain delivered and are the foundation for the next train.
+A source-level review of `lm7137/SBaGenX` showed that this would duplicate the active modern SBaGen lineage. SBaGenX already provides substantial native engine, `.sbg`/`.sbgf`, curve, mix-effect, live-control, multivoice, export, plotting, packaging, desktop, and Android work.
 
-## Active next priority: experimenter workstation
+Therefore:
 
-The original SBaGen TODO gap is now mapped in:
+> PySbagen will not rebuild SBaGenX in Python.
 
-- `docs/planning/SBAGEN_ORIGINAL_TODO_GAP_MATRIX.md`
-
-The implementation plan is:
+The broad workstation recreation train is superseded:
 
 - `.beads/pysbagen_experimenter_workstation_train_2026_07_31.md`
 
-Planned implementation branch:
+## Active priority
 
-- `agent/experimenter-workstation-train-20260731`
+The authoritative boundary is:
 
-The active train covers the missing or partial product layer, including:
+- `docs/planning/SBAGENX_DIFFERENTIATION_AND_INTEROP_MATRIX.md`
 
-- a full editable schedule/project workstation;
-- independent channels and concurrent slides;
-- one-shot WAV/MP3/voice triggers;
-- reproducible random ranges and organic variation;
-- master volume and backend-neutral live transport;
-- keyboard scene crossfades;
-- session markers and user-event timing records;
-- generalized modulation, sweep curves, logarithmic fades, and broader colored noise;
-- `mixspin` and qualified experimental `mixbeat` processing;
-- Gnaural XML interchange and explicit WAV/AIFF output;
-- desktop file association and launch behavior;
-- explicit safety/hardware disposition for flashing, AudioStrobe, light-glasses, and obsolete LPT1 control.
+The active implementation train is:
+
+- `.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md`
+
+Active branch:
+
+- `agent/sbagenx-interoperability-train-20260731`
+
+## Product responsibilities
+
+### SBaGenX
+
+Treat SBaGenX as the optional advanced native SBaGen engine for:
+
+- advanced SBG sequencing and DSP;
+- `.sbgf` curves and built-in programs;
+- native validation and rendering;
+- mixspin/mixbeat/mixpulse/mixam;
+- native live parameter controls;
+- multiple voices, auxiliary tones, plotting, export, and frontend work.
+
+### PySbagen
+
+Keep PySbagen focused on:
+
+- SBG/SBGF/DRG inspection and preservation;
+- explicit compatibility-loss reports;
+- immutable protocol/package/session/output provenance;
+- local-first protocol library;
+- audio-source and listening-path qualification;
+- guided human-question products;
+- backend-independent session markers and event ledger;
+- outcome history and local preference learning;
+- evidence-position and claim provenance;
+- consent-aware research workflows;
+- one-shot cue/session orchestration only after verifying it is not already available upstream.
+
+SBaGenX remains optional. The Python renderer remains the portable fallback and current guided-product engine.
+
+## Implementation started
+
+The first interoperability foundation is now implemented:
+
+- `pysbagen/sbagenx_backend.py`
+- `sbgpy-inspect backend`
+
+It discovers `SBAGENX_BIN`, `SBAGENXLIB_PATH`, system candidates, native version/API, and symbol-backed capabilities. It does not yet route rendering through SBaGenX; native rendering waits for typed bindings, parity fixtures, and complete provenance receipts.
 
 ## Creativity status
 
@@ -63,12 +96,15 @@ The creativity research and product gap remain valid and preserved in:
 - `docs/research/CREATIVITY_AUDIO_RESEARCH_FOUNDATIONS.md`
 - `docs/planning/CREATIVITY_PRODUCT_GAP_CHECK.md`
 
-However, **creativity implementation remains deferred**. The experimenter workstation train takes precedence and does not silently authorize the Creative Cycle train.
+However, **creativity implementation remains deferred**. Interoperability and the differentiated session-intelligence foundation take precedence.
 
 ## Completion rule
 
-The full pain-point handoff must not be described as complete until every row in `SBAGEN_ORIGINAL_TODO_GAP_MATRIX.md` is either:
+This priority is complete only when:
 
-- delivered through a supported, tested product path;
-- retained as an explicit experimental lane with appropriate safeguards; or
-- intentionally excluded with a documented rationale.
+- native integration is version- and symbol-gated;
+- SBG/SBGF validation and optional rendering retain compatibility truth and provenance;
+- backend choice is visible and reproducible;
+- Python fallback remains supported;
+- PySbagen-owned session/event/outcome features work above either backend;
+- remaining verify-later rows are explicitly resolved rather than guessed.

--- a/docs/planning/SBAGENX_DIFFERENTIATION_AND_INTEROP_MATRIX.md
+++ b/docs/planning/SBAGENX_DIFFERENTIATION_AND_INTEROP_MATRIX.md
@@ -1,0 +1,116 @@
+# SBaGenX Differentiation and Interoperability Matrix
+
+**Date:** July 31, 2026  
+**Status:** Active product boundary  
+**SBaGenX source reviewed:** `lm7137/SBaGenX` at `be7c74d378774a759f1e4149dc9df3617b4d0d3b`  
+**PySbagen source:** `acrinym/MindManipulation`
+
+## Decision
+
+PySbagen will not rebuild SBaGenX in Python.
+
+SBaGenX is the modern native continuation of the SBaGen engine and already owns substantial authoring, sequencing, DSP, curve, mix-processing, live-control, export, plotting, packaging, and frontend work. PySbagen's strongest product is a different layer: compatibility truth, DRG preservation, provenance, guided experiences, local session intelligence, personalization, and research workflows.
+
+The intended relationship is:
+
+> **SBaGenX performs advanced SBaGen-native synthesis and authoring.**  
+> **PySbagen inspects, preserves, guides, records, personalizes, and qualifies protocols and sessions.**
+
+SBaGenX remains optional. PySbagen's existing Python renderer stays available as a portable fallback and for current guided products.
+
+## State vocabulary
+
+- **delegate** — SBaGenX already owns the stronger implementation; do not recreate it.
+- **interoperate** — PySbagen should inspect, invoke, wrap, or preserve the SBaGenX capability with versioned receipts.
+- **shared/fallback** — PySbagen retains its current implementation, but SBaGenX may become an optional backend.
+- **PySbagen-owned** — a distinct product capability not found as a central SBaGenX feature.
+- **verify-later** — source evidence is incomplete; do not claim absence or duplicate it yet.
+
+## Capability matrix
+
+| Capability | SBaGenX observed state | PySbagen decision |
+|---|---|---|
+| Native SBaGen parsing, timing, sequencing, and DSP | Library-first `sbagenxlib` owns core behavior. | **delegate/interoperate** — bind to the native API rather than reproduce advanced semantics. |
+| `.sbg` editor and diagnostics | Tauri/Svelte/Monaco GUI with multi-document editing and native validation. | **delegate** — PySbagen may link/open in SBaGenX, not build a competing editor. |
+| `.sbgf` function and curve language | Native curve program loading, solving, preparation, sampling, and GUI editing. | **interoperate** — preserve and inspect `.sbgf`; do not invent a competing curve/project language first. |
+| Built-in `drop`, `slide`, `sigmoid`, and `curve` programs | Implemented through the native runtime. | **delegate/interoperate**. |
+| Live carrier, beat, amplitude, and mix ramps | Native live-control API and GUI controls exist. | **delegate/interoperate** — attach session receipts and event history around them. |
+| `mixspin`, `mixbeat`, `mixpulse`, and `mixam` | Native mix-effect parsing and processing exist. | **delegate** — remove independent reimplementation beads. |
+| Multiple voices and auxiliary tones | Native context API exposes multiple voice lanes and auxiliary overlays. | **delegate/interoperate**; qualify exact behavior before claiming parity with every historical construct. |
+| Isochronic, monaural, binaural, spin, bell, orbitbeat | Native engine support exists. | **shared/fallback** — retain Python support where present; prefer native backend only after parity gates. |
+| White, pink, brown, custom-spectrum noise | Native support exists; PySbagen currently has white/pink. | **delegate/interoperate** for advanced native noise; retain Python fallback. |
+| Raw/WAV/OGG/FLAC/MP3 export and PCM conversion | Native writer API exists. | **interoperate** — record selected backend, API version, format, and output hash. |
+| Plot, beat, envelope, and graph-video inspection | SBaGenX exposes sampling and frontend plotting paths. | **interoperate** where useful; PySbagen retains its compatibility timeline and source inspector. |
+| Desktop and Android frontends | Desktop GUI and separate Android frontend use the same engine. | **delegate** — do not make frontend duplication a product priority. |
+| DRG package decoding and complete element preservation | No central SBaGenX DRG product path found in the reviewed repository. | **PySbagen-owned**. |
+| Immutable source/package hashes and provenance chain | Not observed as a central SBaGenX product contract. | **PySbagen-owned**. |
+| Explicit supported/equivalent/partial/approximated/blocked import states | Not observed as the same product-wide compatibility contract. | **PySbagen-owned**. |
+| Local content-addressed protocol library | Not observed as a central SBaGenX feature. | **PySbagen-owned**. |
+| Listening-route and source suitability qualification | Not observed as a central SBaGenX workflow. | **PySbagen-owned**. |
+| Guided human-question products such as Sleep Guide | SBaGenX ships general-purpose programs/examples, not PySbagen's guided request model. | **PySbagen-owned**. |
+| Session markers and append-only user-event ledger | No completed equivalent found during the reviewed source pass. | **PySbagen-owned**, while remaining open to native telemetry integration. |
+| Outcome history and local preference learning | No central equivalent found. | **PySbagen-owned**. |
+| One-shot voice/sample cues tied to protocol events | Not confirmed as a completed native capability. | **verify-later**, then build as PySbagen session orchestration only if still absent. |
+| Scene banks and complete-sequence crossfades | Native live parameter ramps exist; complete scene-bank behavior was not confirmed. | **verify-later**; prefer orchestration above native contexts over another DSP engine. |
+| Research consent, sham/control assignment, adverse-event capture | Not a central SBaGenX product responsibility. | **PySbagen-owned** future Research Dose Environment. |
+| Evidence-position labels and claim provenance | Not observed as a central SBaGenX feature. | **PySbagen-owned**. |
+| Gnaural interchange | Not confirmed in the reviewed source pass. | **verify-later**; any converter must be loss-aware and protocol-manifest driven. |
+| JACK/device backend evolution | SBaGenX's library intentionally leaves live device I/O to hosts. | **do not duplicate prematurely**; backend integration follows real user/platform need. |
+
+## Architecture boundary
+
+### SBaGenX adapter layer
+
+The optional adapter may:
+
+- discover the CLI and native library;
+- read `sbx_version()` and `sbx_api_version()`;
+- capability-gate on actual exported symbols;
+- validate `.sbg` and `.sbgf` through the native library;
+- render through the native library only after fixture parity and receipt support;
+- expose native telemetry/live controls to PySbagen session records;
+- fail closed when the installed API is unknown or lacks required symbols.
+
+The adapter must not:
+
+- make SBaGenX mandatory for inspection, DRG preservation, or existing guided products;
+- shell out silently when a native library path was expected;
+- call an installed backend without recording exact backend identity;
+- describe cross-engine output as identical unless fixture-proven;
+- redistribute SBaGenX binaries without satisfying its license and dependency obligations.
+
+### PySbagen product layer
+
+PySbagen continues to own:
+
+- SBG/DRG compatibility reports and loss disclosure;
+- complete DRG preservation;
+- source, package, recipe, session, and output provenance;
+- local-first library and lifecycle states;
+- listening-path and source qualification;
+- guided experiences and exact recipe capture;
+- session markers, event ledgers, outcome history, and local preference learning;
+- consent-aware research workflows;
+- evidence and claim-position records.
+
+## Immediate implementation result
+
+The first interoperability foundation is `pysbagen.sbagenx_backend` and:
+
+```bash
+sbgpy-inspect backend
+sbgpy-inspect backend --json
+sbgpy-inspect backend --discover-only
+```
+
+It discovers `SBAGENX_BIN`, `SBAGENXLIB_PATH`, system candidates, native version/API, and symbol-backed capabilities. Discovery does not yet authorize native rendering.
+
+## Superseded plan
+
+The broad workstation recreation plan is archived as superseded:
+
+- `.beads/pysbagen_experimenter_workstation_train_2026_07_31.md`
+
+The active plan is:
+
+- `.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md`

--- a/docs/planning/SBAGEN_ORIGINAL_TODO_GAP_MATRIX.md
+++ b/docs/planning/SBAGEN_ORIGINAL_TODO_GAP_MATRIX.md
@@ -1,67 +1,68 @@
-# Original SBaGen TODO — PySbagen Product Gap Matrix
+# Original SBaGen TODO — Ecosystem Reconciliation
 
 **Date:** July 31, 2026  
-**Status:** Active source-to-product reconciliation  
+**Status:** Superseded as a Python-only implementation plan  
 **Primary sources:**
 
 - `sbagen-1.4.5/sbagen-1.4.5/TODO.txt`
-- `https://uazu.net/sbagen/` — official SBaGen TODO and unmaintained-project notice
+- `https://uazu.net/sbagen/`
 - `docs/research/IDOSER_SBAGEN_PAIN_POINT_SCOUT.md`
+- `lm7137/SBaGenX@be7c74d378774a759f1e4149dc9df3617b4d0d3b`
 
-## Why this matrix exists
+## Scope correction
 
-The compatibility, preservation, and inspection train completed the six priorities under the scout's **"Priority pain points for the next compatibility train"** section. It did **not** complete the separate workstation/product features listed in the original SBaGen TODO.
+The previous version of this matrix compared the original SBaGen TODO only against PySbagen. That correctly exposed missing capabilities inside PySbagen, but it led to the wrong product conclusion: rebuild the entire experimenter workstation and advanced DSP stack in Python.
 
-Those TODO items were not incidental research notes. Together they describe the missing experimenter's workstation around the synthesis engine: editable authoring, reusable sequencing, independent channels, live control, event capture, richer modulation, sample cues, conversion, and desktop integration.
+Inspection of the actual SBaGenX repository shows that many original TODO requests have already been implemented or substantially advanced in the modern SBaGen lineage, including:
 
-The previous product-priority record incorrectly allowed "compatibility delivered" to read as though the entire pain-point handoff had been delivered. This matrix corrects that scope.
+- reusable `sbagenxlib` engine architecture;
+- `.sbg` and `.sbgf` editing and validation;
+- built-in drop/slide/sigmoid/curve programs;
+- live carrier, beat, amplitude, and mix controls;
+- multiple voices and auxiliary tones;
+- `mixspin`, `mixbeat`, `mixpulse`, and `mixam`;
+- isochronic, monaural, binaural, spin, bell, orbitbeat, and noise families;
+- raw/WAV/OGG/FLAC/MP3 export;
+- plotting, graph video, desktop packaging, and an Android frontend.
 
-## State vocabulary
+Those capabilities should not be independently recreated in PySbagen merely because PySbagen itself lacks them.
 
-- **delivered** — available through a supported product path and covered by current tests/docs;
-- **partial** — some foundation exists, but the original user capability is not complete;
-- **missing** — no supported product path currently provides the capability;
-- **experimental-lane** — valid idea, but requires explicit safety, hardware, or platform qualification;
-- **intentionally-excluded** — understood and explicitly rejected from the modern product, with rationale.
+## Active source-to-product matrix
 
-## Reconciliation matrix
+The authoritative reconciliation is now:
 
-| Original SBaGen TODO / website request | Current PySbagen state | Evidence and gap | Product disposition |
-|---|---|---|---|
-| Easy clickable GUI separate from the command line | **partial** | `sbgpy-gui`, the Sleep Guide, and Compatibility Inspector exist, but the advanced studio is not yet a complete open/edit/validate/play/transport/write workstation for SBG documents. | Build the full experimenter workstation rather than another disconnected GUI. |
-| Minimal GUI with open/save, editor, test, play, and write-WAV views | **partial** | Schedule selection and export exist. Raw schedule editing, syntax diagnostics tied to source locations, save/save-as, transport position, and reversible visual editing are incomplete. | Deliver as the workstation document/editor shell. |
-| Reusable `sbagenlib` sequencing/audio engine | **delivered** | `pysbagen.api`, parser, mixer, generators, importer, and plugin entry-point foundations provide a reusable Python engine used by multiple front ends. | Preserve and harden; do not rebuild. |
-| Several independent channels with independent slides | **missing** | The compatibility matrix classifies `spin:` and `slide:` as approximated; the underlying tone may render, but motion semantics and concurrently sliding channels do not. | Build channel buses, per-channel envelopes, and fixture-proven independent motion. |
-| Trigger WAV/MP3 samples or voice cues at sequence points | **missing** | Background files can be layered, but there is no event-triggered one-shot sample/cue model. | Add scheduled one-shot cues, overlap policy, gain, pan, and provenance. |
-| Mark interesting combinations during a session without leaving the experience | **missing** | No live marker command or transport-bound session marker exists. | Add keyboard/button markers captured against the exact session clock and recipe identity. |
-| Record timing of user events from clicks or keypresses | **missing** | No local event ledger accompanies playback. | Add append-only session event records and privacy-safe export. |
-| Random variation within declared frequency ranges | **missing** | `SBG-RANDOM-001` is currently unsupported. Generated sleep worlds may use deterministic variation, but ordinary SBG range semantics do not exist. | Add seeded, bounded, inspectable random/range modulation with exact replay manifests. |
-| Global volume control without editing the sequence | **missing** | Individual amplitudes exist, but there is no canonical master gain shared by CLI, GUI, live playback, and render receipts. | Add master gain with clipping forecast and receipt capture. |
-| Keyboard control to fade between sequences in real time | **missing** | No scene bank, live crossfade transport, or keyboard mapping exists. | Add safe live scene crossfades using the shared callback/transport engine. |
-| General volume modulation in addition to beating | **partial** | Isochronic and sleep envelopes modulate amplitude in specialized generators. There is no general schedule-level modulation/envelope object applicable to arbitrary channels and sources. | Add reusable amplitude modulation/envelope semantics. |
-| Sinusoidal, Gaussian, or user-defined sweeps | **missing** | Linear interval crossfades exist, but sweep-shape selection and reusable curves do not. | Add curve-defined parameter automation with serializable shapes. |
-| Logarithmic fades | **missing** | Current crossfades are documented as linear. | Add explicit linear, equal-power, logarithmic, and custom-curve fades. |
-| Colored noise beyond the original basics | **partial** | White and pink noise are supported. Brown/red, blue, violet, gray, and configurable spectral slopes are not. | Add qualified colored-noise generators with deterministic seeds and spectra tests. |
-| Noise amplitude and pitch/filter modulation | **missing** | Noise is not exposed through the same automation system as tones and source buses. | Add bounded modulation through the general automation engine. |
-| More organic low-frequency variation in carriers/beats | **partial** | Some guided generators evolve over time, but ordinary studio recipes cannot apply reproducible drift to arbitrary parameters. | Add seeded drift/LFO controls as an authoring feature. |
-| Isochronic tones | **delivered** | `IsochronicSpec`, CLI, GUI, and sleep routes already provide isochronic layers. | Keep; extend through the common automation/channel model. |
-| `mixspin:` on imported/mixed audio | **missing** | No mix-stream spin implementation exists. | Add a fixture-proven spatial/motion processor with clear headphone/speaker behavior. |
-| `mixbeat:` to create binaural shifting from recordings | **missing** | No Hilbert/analytic-signal mixbeat processor exists. | Research, implement, and verify as an advanced processor; never label it equivalent before signal tests pass. |
-| Convert to and from Gnaural XML | **missing** | Import reports and manifests exist, but Gnaural XML interchange does not. | Add loss-aware import/export with explicit reversible/approximated fields. |
-| Automatic conversion of old SBG into a new visual format | **partial** | SBG parsing and a serializable timeline exist, but there is no editable canonical project document with round-trip visual editing. | Add a project schema that preserves raw source and records every semantic edit. |
-| AIFF output in addition to WAV | **partial** | SoundFile may support AIFF depending on runtime, but the public CLI/GUI, tests, estimates, and docs are WAV-centered. | Add explicit capability detection, AIFF output selection, and qualification tests. |
-| Mac desktop access / double-click SBG files | **missing** | No packaged desktop file association or launcher integration is recorded. | Add platform launchers/file associations after the workstation command is stable. |
-| Callback-model backend and JACK support | **partial** | Modern Python playback exists through PyAudio, but there is no canonical callback transport/backend abstraction or JACK path. | Build backend-neutral transport first; provide JACK where available without coupling core logic to it. |
-| Screen flashing synchronized to beats | **experimental-lane** | Not implemented or dispositioned. Flashing visuals carry photosensitive-seizure risk. | Only as disabled-by-default, strongly warned, rate/contrast-limited experimental output with no ordinary-user default. |
-| AudioStrobe / light-glasses output | **experimental-lane** | Not implemented; hardware and safety qualification are absent. | Document and isolate behind an explicit hardware research interface before any implementation. |
-| LPT1 light-glasses control | **intentionally-excluded** | Obsolete, platform-specific direct hardware control conflicts with a modern cross-platform product and lacks available test hardware. | Do not implement in core; allow future third-party hardware plugins through a documented interface. |
+- `docs/planning/SBAGENX_DIFFERENTIATION_AND_INTEROP_MATRIX.md`
 
-## Correct product conclusion
+It classifies each capability as:
 
-The compatibility train was valuable and remains complete **within its declared scope**. The full pain-point handoff is not complete until the workstation train addresses the missing and partial product rows above, or explicitly records a justified exclusion.
+- **delegate** to SBaGenX;
+- **interoperate** through a version-gated optional adapter;
+- **shared/fallback** between engines;
+- **PySbagen-owned** product work;
+- **verify-later** before building anything.
 
-The active implementation plan is:
+## PySbagen-owned gaps that remain valid
+
+The following are still distinct PySbagen product responsibilities:
+
+- complete DRG package preservation;
+- immutable source/package/recipe/session/output provenance;
+- explicit compatibility-loss and render-disposition reports;
+- local content-addressed protocol library;
+- listening-path and source suitability qualification;
+- guided human-question products;
+- backend-independent session markers and event ledgers;
+- outcome history and local preference learning;
+- consent-aware research workflows;
+- evidence-position and claim provenance;
+- one-shot cue/session orchestration only if SBaGenX does not already provide it.
+
+## Active implementation plan
+
+- `.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md`
+
+The earlier broad Python workstation recreation plan is archived as superseded:
 
 - `.beads/pysbagen_experimenter_workstation_train_2026_07_31.md`
 
-Creativity remains parked. This train completes the SBaGen experimenter/workstation foundation before outcome-specific creativity product work begins.
+Creativity remains parked. The immediate work is ecosystem interoperability and PySbagen's genuinely differentiated session-intelligence layer.

--- a/pysbagen/__init__.py
+++ b/pysbagen/__init__.py
@@ -11,6 +11,14 @@ from .api import (
 from .compatibility import CompatibilityState, ImportReport, RenderDisposition
 from .importers import ImportedArtifact, import_artifact, import_drg, import_sbg
 from .sbagenx_backend import BackendCapability, SBaGenXProbe, probe_sbagenx
+from .sbagenx_native import (
+    NativeDiagnostic,
+    NativeValidationReport,
+    SBaGenXNative,
+    SBaGenXNativeError,
+    UnsupportedSBaGenXAPI,
+    validate_sbagenx_source,
+)
 from .sleep import SleepLayers, SleepRecipe, SleepRequest, build_sleep_recipe
 
 __all__ = [
@@ -18,12 +26,17 @@ __all__ = [
     "CompatibilityState",
     "ImportReport",
     "ImportedArtifact",
+    "NativeDiagnostic",
+    "NativeValidationReport",
     "RenderDisposition",
     "RenderResult",
+    "SBaGenXNative",
+    "SBaGenXNativeError",
     "SBaGenXProbe",
     "SleepLayers",
     "SleepRecipe",
     "SleepRequest",
+    "UnsupportedSBaGenXAPI",
     "build_sleep_recipe",
     "import_artifact",
     "import_drg",
@@ -33,6 +46,7 @@ __all__ = [
     "render_schedule",
     "render_sleep",
     "render_specs",
+    "validate_sbagenx_source",
     "write_audio",
 ]
 __version__ = "0.4.0"

--- a/pysbagen/__init__.py
+++ b/pysbagen/__init__.py
@@ -10,6 +10,7 @@ from .api import (
 )
 from .compatibility import CompatibilityState, ImportReport, RenderDisposition
 from .importers import ImportedArtifact, import_artifact, import_drg, import_sbg
+from .interoperability import EngineDiscrepancy, InteroperabilityReport, inspect_with_sbagenx
 from .sbagenx_backend import BackendCapability, SBaGenXProbe, probe_sbagenx
 from .sbagenx_native import (
     NativeDiagnostic,
@@ -19,13 +20,16 @@ from .sbagenx_native import (
     UnsupportedSBaGenXAPI,
     validate_sbagenx_source,
 )
+from .sbgf import import_sbgf
 from .sleep import SleepLayers, SleepRecipe, SleepRequest, build_sleep_recipe
 
 __all__ = [
     "BackendCapability",
     "CompatibilityState",
+    "EngineDiscrepancy",
     "ImportReport",
     "ImportedArtifact",
+    "InteroperabilityReport",
     "NativeDiagnostic",
     "NativeValidationReport",
     "RenderDisposition",
@@ -41,7 +45,9 @@ __all__ = [
     "import_artifact",
     "import_drg",
     "import_sbg",
+    "import_sbgf",
     "inspect_artifact",
+    "inspect_with_sbagenx",
     "probe_sbagenx",
     "render_schedule",
     "render_sleep",

--- a/pysbagen/__init__.py
+++ b/pysbagen/__init__.py
@@ -10,14 +10,17 @@ from .api import (
 )
 from .compatibility import CompatibilityState, ImportReport, RenderDisposition
 from .importers import ImportedArtifact, import_artifact, import_drg, import_sbg
+from .sbagenx_backend import BackendCapability, SBaGenXProbe, probe_sbagenx
 from .sleep import SleepLayers, SleepRecipe, SleepRequest, build_sleep_recipe
 
 __all__ = [
+    "BackendCapability",
     "CompatibilityState",
     "ImportReport",
     "ImportedArtifact",
     "RenderDisposition",
     "RenderResult",
+    "SBaGenXProbe",
     "SleepLayers",
     "SleepRecipe",
     "SleepRequest",
@@ -26,6 +29,7 @@ __all__ = [
     "import_drg",
     "import_sbg",
     "inspect_artifact",
+    "probe_sbagenx",
     "render_schedule",
     "render_sleep",
     "render_specs",

--- a/pysbagen/inspect_cli.py
+++ b/pysbagen/inspect_cli.py
@@ -82,7 +82,11 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"SBaGenX interoperability validation failed: {exc}", file=sys.stderr)
                 return 2
             print(json.dumps(report.to_dict(), indent=2, sort_keys=True) if args.as_json else report.to_text())
-            return 0 if report.source_identity_matches and report.native_valid else 2
+            if not report.source_identity_matches or not report.native_valid:
+                return 2
+            if report.discrepancies or report.pysbagen_disposition is not RenderDisposition.SAFE:
+                return 1
+            return 0
         report = probe_sbagenx(
             executable=args.executable,
             library=args.library,

--- a/pysbagen/inspect_cli.py
+++ b/pysbagen/inspect_cli.py
@@ -8,10 +8,11 @@ from .compatibility import RenderDisposition
 from .importers import import_artifact
 from .inspector import build_timeline, inspect_audio_source, qualify_audio_path, timeline_to_dict, timeline_to_text
 from .library import LocalLibrary
+from .sbagenx_backend import probe_sbagenx
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="sbgpy-inspect", description="Inspect SBG/DRG compatibility, audio sources, output routes, and the local library.")
+    parser = argparse.ArgumentParser(prog="sbgpy-inspect", description="Inspect SBG/DRG compatibility, audio sources, output routes, optional SBaGenX backends, and the local library.")
     subparsers = parser.add_subparsers(dest="command", required=True)
     inspect_parser = subparsers.add_parser("inspect", help="Inspect an SBG or DRG artifact")
     inspect_parser.add_argument("source")
@@ -35,6 +36,11 @@ def build_parser() -> argparse.ArgumentParser:
     path_parser.add_argument("--bluetooth", action="store_true")
     path_parser.add_argument("--json", action="store_true", dest="as_json")
     path_parser.add_argument("--save")
+    backend_parser = subparsers.add_parser("backend", help="Discover and qualify an optional SBaGenX executable/native library")
+    backend_parser.add_argument("--executable", help="Explicit SBaGenX executable path; otherwise use SBAGENX_BIN/PATH")
+    backend_parser.add_argument("--library", help="Explicit sbagenxlib path; otherwise use SBAGENXLIB_PATH/system lookup")
+    backend_parser.add_argument("--discover-only", action="store_true", help="Locate candidates without executing or loading them")
+    backend_parser.add_argument("--json", action="store_true", dest="as_json")
     library_parser = subparsers.add_parser("library", help="Inspect or verify the local-first library")
     library_parser.add_argument("action", choices=["list", "show", "verify", "archive", "export"])
     library_parser.add_argument("item_id", nargs="?")
@@ -60,6 +66,15 @@ def main(argv: list[str] | None = None) -> int:
             Path(args.save).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
             print(f"Saved path qualification: {Path(args.save).resolve()}")
         return 0 if report.safe_to_start else 2
+    if args.command == "backend":
+        report = probe_sbagenx(
+            executable=args.executable,
+            library=args.library,
+            query_executable=not args.discover_only,
+            load_library=not args.discover_only,
+        )
+        print(json.dumps(report.to_dict(), indent=2, sort_keys=True) if args.as_json else report.to_text())
+        return 0 if report.available else 2
     if args.command == "library":
         return _library_command(args)
     raise AssertionError(f"Unhandled command: {args.command}")

--- a/pysbagen/inspect_cli.py
+++ b/pysbagen/inspect_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 from .compatibility import RenderDisposition
@@ -9,6 +10,7 @@ from .importers import import_artifact
 from .inspector import build_timeline, inspect_audio_source, qualify_audio_path, timeline_to_dict, timeline_to_text
 from .library import LocalLibrary
 from .sbagenx_backend import probe_sbagenx
+from .sbagenx_native import SBaGenXNativeError, validate_sbagenx_source
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -36,10 +38,11 @@ def build_parser() -> argparse.ArgumentParser:
     path_parser.add_argument("--bluetooth", action="store_true")
     path_parser.add_argument("--json", action="store_true", dest="as_json")
     path_parser.add_argument("--save")
-    backend_parser = subparsers.add_parser("backend", help="Discover and qualify an optional SBaGenX executable/native library")
+    backend_parser = subparsers.add_parser("backend", help="Discover, qualify, or validate through an optional SBaGenX native library")
     backend_parser.add_argument("--executable", help="Explicit SBaGenX executable path; otherwise use SBAGENX_BIN/PATH")
     backend_parser.add_argument("--library", help="Explicit sbagenxlib path; otherwise use SBAGENXLIB_PATH/system lookup")
     backend_parser.add_argument("--discover-only", action="store_true", help="Locate candidates without executing or loading them")
+    backend_parser.add_argument("--validate", metavar="SOURCE", help="Validate a .sbg or .sbgf source through qualified API 47")
     backend_parser.add_argument("--json", action="store_true", dest="as_json")
     library_parser = subparsers.add_parser("library", help="Inspect or verify the local-first library")
     library_parser.add_argument("action", choices=["list", "show", "verify", "archive", "export"])
@@ -67,6 +70,17 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Saved path qualification: {Path(args.save).resolve()}")
         return 0 if report.safe_to_start else 2
     if args.command == "backend":
+        if args.validate:
+            if args.discover_only:
+                print("--discover-only cannot be combined with --validate", file=sys.stderr)
+                return 2
+            try:
+                report = validate_sbagenx_source(args.validate, library=args.library)
+            except (OSError, ValueError, SBaGenXNativeError) as exc:
+                print(f"SBaGenX native validation failed: {exc}", file=sys.stderr)
+                return 2
+            print(json.dumps(report.to_dict(), indent=2, sort_keys=True) if args.as_json else report.to_text())
+            return 0 if report.valid else 2
         report = probe_sbagenx(
             executable=args.executable,
             library=args.library,

--- a/pysbagen/inspect_cli.py
+++ b/pysbagen/inspect_cli.py
@@ -74,7 +74,8 @@ def main(argv: list[str] | None = None) -> int:
             load_library=not args.discover_only,
         )
         print(json.dumps(report.to_dict(), indent=2, sort_keys=True) if args.as_json else report.to_text())
-        return 0 if report.available else 2
+        qualified = report.candidate_found if args.discover_only else report.usable
+        return 0 if qualified else 2
     if args.command == "library":
         return _library_command(args)
     raise AssertionError(f"Unhandled command: {args.command}")

--- a/pysbagen/inspect_cli.py
+++ b/pysbagen/inspect_cli.py
@@ -8,15 +8,17 @@ from pathlib import Path
 from .compatibility import RenderDisposition
 from .importers import import_artifact
 from .inspector import build_timeline, inspect_audio_source, qualify_audio_path, timeline_to_dict, timeline_to_text
+from .interoperability import inspect_with_sbagenx
 from .library import LocalLibrary
 from .sbagenx_backend import probe_sbagenx
-from .sbagenx_native import SBaGenXNativeError, validate_sbagenx_source
+from .sbagenx_native import SBaGenXNativeError
+from .sbgf import import_sbgf
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="sbgpy-inspect", description="Inspect SBG/DRG compatibility, audio sources, output routes, optional SBaGenX backends, and the local library.")
+    parser = argparse.ArgumentParser(prog="sbgpy-inspect", description="Inspect SBG/SBGF/DRG compatibility, audio sources, output routes, optional SBaGenX backends, and the local library.")
     subparsers = parser.add_subparsers(dest="command", required=True)
-    inspect_parser = subparsers.add_parser("inspect", help="Inspect an SBG or DRG artifact")
+    inspect_parser = subparsers.add_parser("inspect", help="Inspect an SBG, SBGF, or DRG artifact")
     inspect_parser.add_argument("source")
     inspect_parser.add_argument("--json", action="store_true", dest="as_json")
     inspect_parser.add_argument("--timeline-json", action="store_true")
@@ -42,7 +44,7 @@ def build_parser() -> argparse.ArgumentParser:
     backend_parser.add_argument("--executable", help="Explicit SBaGenX executable path; otherwise use SBAGENX_BIN/PATH")
     backend_parser.add_argument("--library", help="Explicit sbagenxlib path; otherwise use SBAGENXLIB_PATH/system lookup")
     backend_parser.add_argument("--discover-only", action="store_true", help="Locate candidates without executing or loading them")
-    backend_parser.add_argument("--validate", metavar="SOURCE", help="Validate a .sbg or .sbgf source through qualified API 47")
+    backend_parser.add_argument("--validate", metavar="SOURCE", help="Inspect and compare a .sbg or .sbgf source through PySbagen and qualified API 47")
     backend_parser.add_argument("--json", action="store_true", dest="as_json")
     library_parser = subparsers.add_parser("library", help="Inspect or verify the local-first library")
     library_parser.add_argument("action", choices=["list", "show", "verify", "archive", "export"])
@@ -75,12 +77,12 @@ def main(argv: list[str] | None = None) -> int:
                 print("--discover-only cannot be combined with --validate", file=sys.stderr)
                 return 2
             try:
-                report = validate_sbagenx_source(args.validate, library=args.library)
+                report = inspect_with_sbagenx(args.validate, library=args.library)
             except (OSError, ValueError, SBaGenXNativeError) as exc:
-                print(f"SBaGenX native validation failed: {exc}", file=sys.stderr)
+                print(f"SBaGenX interoperability validation failed: {exc}", file=sys.stderr)
                 return 2
             print(json.dumps(report.to_dict(), indent=2, sort_keys=True) if args.as_json else report.to_text())
-            return 0 if report.valid else 2
+            return 0 if report.source_identity_matches and report.native_valid else 2
         report = probe_sbagenx(
             executable=args.executable,
             library=args.library,
@@ -96,7 +98,37 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _inspect_command(args: argparse.Namespace) -> int:
-    artifact = import_artifact(args.source, preserve_to=args.preserve_to)
+    source_path = Path(args.source).expanduser().resolve()
+    artifact = import_sbgf(source_path) if source_path.suffix.lower() == ".sbgf" else import_artifact(source_path, preserve_to=args.preserve_to)
+
+    if source_path.suffix.lower() == ".sbgf":
+        if args.as_json:
+            print(json.dumps(artifact.report.to_dict(), indent=2, sort_keys=True))
+        else:
+            print(artifact.report.to_text())
+        if args.timeline_json:
+            destination = Path("timeline.json")
+            destination.write_text(
+                json.dumps(
+                    {
+                        "schema": "pysbagen.sbgf-structure.v1",
+                        "source_sha256": artifact.report.source_sha256,
+                        "source_type": "sbgf",
+                        "timeline": None,
+                        "reason": "SBGF is function-driven; use native curve sampling rather than an invented SBG timeline.",
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            print(f"SBGF structure receipt: {destination.resolve()}")
+        if args.add_to_library:
+            item = LocalLibrary(args.library_root).add(artifact)
+            print(f"Library item: {item.item_id} ({item.state}) at {item.path}")
+        return 2
+
     timeline = build_timeline(artifact, duration=args.duration)
     if args.as_json:
         payload = artifact.report.to_dict()

--- a/pysbagen/interoperability.py
+++ b/pysbagen/interoperability.py
@@ -1,0 +1,211 @@
+"""Combined PySbagen/SBaGenX inspection without weakening either engine's findings."""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+from .compatibility import CompatibilityState, ImportReport, RenderDisposition
+from .importers import import_sbg
+from .sbgf import import_sbgf
+from .sbagenx_native import NativeValidationReport, validate_sbagenx_source
+
+
+@dataclass(frozen=True)
+class EngineDiscrepancy:
+    """One explicit difference between PySbagen and SBaGenX conclusions."""
+
+    code: str
+    severity: str
+    title: str
+    detail: str
+
+
+@dataclass
+class InteroperabilityReport:
+    """One source inspected through PySbagen and a qualified SBaGenX library."""
+
+    source_path: str
+    source_kind: str
+    source_sha256: str
+    pysbagen_report: ImportReport
+    sbagenx_report: NativeValidationReport
+    discrepancies: list[EngineDiscrepancy] = field(default_factory=list)
+    schema_version: str = "pysbagen.sbagenx-interoperability.v1"
+
+    @property
+    def source_identity_matches(self) -> bool:
+        """Return whether both engines inspected the same preserved source bytes."""
+
+        return self.pysbagen_report.source_sha256 == self.sbagenx_report.source_sha256
+
+    @property
+    def native_valid(self) -> bool:
+        """Return SBaGenX's validation result without changing PySbagen policy."""
+
+        return self.sbagenx_report.valid
+
+    @property
+    def pysbagen_disposition(self) -> RenderDisposition:
+        """Return PySbagen's independent render/inspection disposition."""
+
+        return self.pysbagen_report.render_disposition
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize both reports and their discrepancies deterministically."""
+
+        return {
+            "schema_version": self.schema_version,
+            "source_path": self.source_path,
+            "source_kind": self.source_kind,
+            "source_sha256": self.source_sha256,
+            "source_identity_matches": self.source_identity_matches,
+            "native_valid": self.native_valid,
+            "pysbagen_disposition": self.pysbagen_disposition.value,
+            "pysbagen_report": self.pysbagen_report.to_dict(),
+            "sbagenx_report": self.sbagenx_report.to_dict(),
+            "discrepancies": [asdict(item) for item in self.discrepancies],
+        }
+
+    def to_text(self) -> str:
+        """Render both engines' conclusions without flattening them together."""
+
+        lines = [
+            "PySbagen × SBaGenX interoperability report",
+            f"Source: {self.source_path}",
+            f"Type: {self.source_kind}",
+            f"SHA-256: {self.source_sha256}",
+            f"Source identity matches: {'yes' if self.source_identity_matches else 'NO'}",
+            f"PySbagen disposition: {self.pysbagen_disposition.value}",
+            f"SBaGenX native valid: {'yes' if self.native_valid else 'no'}",
+            "",
+            "--- PySbagen compatibility truth ---",
+            self.pysbagen_report.to_text(),
+            "",
+            "--- SBaGenX native validation ---",
+            self.sbagenx_report.to_text(),
+            "",
+            "--- Discrepancies ---",
+        ]
+        if self.discrepancies:
+            for item in self.discrepancies:
+                lines.append(f"[{item.severity.upper()}] {item.title}: {item.detail}")
+        else:
+            lines.append("none")
+        return "\n".join(lines)
+
+
+def inspect_with_sbagenx(
+    source: str | Path,
+    *,
+    library: str | Path | None = None,
+    loader: Callable[[str], Any] = ctypes.CDLL,
+) -> InteroperabilityReport:
+    """Inspect one SBG/SBGF source through both product truth layers."""
+
+    source_path = Path(source).expanduser().resolve()
+    suffix = source_path.suffix.lower()
+    if suffix == ".sbg":
+        artifact = import_sbg(source_path)
+    elif suffix == ".sbgf":
+        artifact = import_sbgf(source_path)
+    else:
+        raise ValueError("Interoperability inspection requires a .sbg or .sbgf source")
+
+    native = validate_sbagenx_source(source_path, library=library, loader=loader)
+    discrepancies = _compare_reports(artifact.report, native)
+    return InteroperabilityReport(
+        source_path=str(source_path),
+        source_kind=suffix.lstrip("."),
+        source_sha256=artifact.report.source_sha256,
+        pysbagen_report=artifact.report,
+        sbagenx_report=native,
+        discrepancies=discrepancies,
+    )
+
+
+def _compare_reports(
+    pysbagen: ImportReport,
+    native: NativeValidationReport,
+) -> list[EngineDiscrepancy]:
+    """Describe meaningful differences while preserving PySbagen blockers."""
+
+    discrepancies: list[EngineDiscrepancy] = []
+    if pysbagen.source_sha256 != native.source_sha256:
+        discrepancies.append(
+            EngineDiscrepancy(
+                "source-identity-mismatch",
+                "error",
+                "The engines did not inspect identical source bytes",
+                f"PySbagen={pysbagen.source_sha256}; SBaGenX={native.source_sha256}",
+            )
+        )
+        return discrepancies
+
+    pysbagen_runnable = pysbagen.render_disposition in {
+        RenderDisposition.SAFE,
+        RenderDisposition.SAFE_WITH_DISCLOSED_CHANGES,
+    }
+    if pysbagen_runnable and not native.valid:
+        discrepancies.append(
+            EngineDiscrepancy(
+                "pysbagen-accepts-native-rejects",
+                "error",
+                "PySbagen accepts a source that SBaGenX rejects",
+                "Do not claim cross-engine portability until the native diagnostics are resolved.",
+            )
+        )
+    elif native.valid and not pysbagen_runnable:
+        limited_states = sorted(
+            {
+                finding.state.value
+                for finding in pysbagen.findings
+                if finding.state
+                in {
+                    CompatibilityState.PARTIAL,
+                    CompatibilityState.APPROXIMATED,
+                    CompatibilityState.UNSUPPORTED,
+                    CompatibilityState.UNKNOWN,
+                    CompatibilityState.MISSING_SOURCE,
+                    CompatibilityState.INTENTIONALLY_EXCLUDED,
+                    CompatibilityState.UNSAFE_TO_RENDER,
+                }
+            }
+        )
+        detail = (
+            "SBaGenX validates the source, while PySbagen keeps it "
+            f"{pysbagen.render_disposition.value} because of: {', '.join(limited_states) or 'product policy'}.",
+        )
+        discrepancies.append(
+            EngineDiscrepancy(
+                "native-accepts-pysbagen-limited",
+                "warning",
+                "Native validity does not erase PySbagen limitations",
+                detail[0],
+            )
+        )
+
+    native_errors = [item for item in native.diagnostics if item.severity == "error"]
+    if native_errors:
+        discrepancies.append(
+            EngineDiscrepancy(
+                "native-diagnostics-present",
+                "error",
+                "SBaGenX reported native errors",
+                f"{len(native_errors)} native error diagnostic(s) remain attached to this exact source hash.",
+            )
+        )
+
+    approximations = pysbagen.findings_by_state(CompatibilityState.APPROXIMATED)
+    if native.valid and approximations:
+        discrepancies.append(
+            EngineDiscrepancy(
+                "native-may-preserve-pysbagen-approximates",
+                "warning",
+                "SBaGenX may preserve semantics that PySbagen approximates",
+                "; ".join(finding.title for finding in approximations),
+            )
+        )
+    return discrepancies

--- a/pysbagen/sbagenx_backend.py
+++ b/pysbagen/sbagenx_backend.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import os
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class BackendCapability:
+    """One capability observed on an installed SBaGenX backend."""
+
+    name: str
+    available: bool
+    evidence: str
+
+
+@dataclass
+class SBaGenXProbe:
+    """Discovery and capability result for an optional SBaGenX installation."""
+
+    executable_path: str | None = None
+    executable_version: str | None = None
+    library_path: str | None = None
+    library_version: str | None = None
+    api_version: int | None = None
+    capabilities: list[BackendCapability] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def available(self) -> bool:
+        return bool(self.executable_path or self.library_path)
+
+    @property
+    def native_api_available(self) -> bool:
+        return self.api_version is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["available"] = self.available
+        payload["native_api_available"] = self.native_api_available
+        return payload
+
+    def to_text(self) -> str:
+        lines = ["SBaGenX backend probe"]
+        lines.append(f"Executable: {self.executable_path or 'not found'}")
+        if self.executable_version:
+            lines.append(f"Executable version: {self.executable_version}")
+        lines.append(f"Native library: {self.library_path or 'not found'}")
+        if self.library_version:
+            lines.append(f"Library version: {self.library_version}")
+        if self.api_version is not None:
+            lines.append(f"Library API: {self.api_version}")
+        if self.capabilities:
+            lines.append("Capabilities:")
+            for capability in self.capabilities:
+                marker = "yes" if capability.available else "no"
+                lines.append(f"  {capability.name}: {marker} ({capability.evidence})")
+        if self.warnings:
+            lines.append("Warnings:")
+            lines.extend(f"  - {warning}" for warning in self.warnings)
+        return "\n".join(lines)
+
+
+_CAPABILITY_SYMBOLS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("native_float_render", ("sbx_context_render_f32",)),
+    ("sbg_validation", ("sbx_validate_sbg_text",)),
+    ("sbgf_validation", ("sbx_validate_sbgf_text",)),
+    ("container_writing", ("sbx_audio_writer_create_path", "sbx_audio_writer_write_f32")),
+    ("live_parameter_control", ("sbx_context_set_live_control", "sbx_context_ramp_live_control")),
+    ("mix_stream_processing", ("sbx_context_mix_stream_sample",)),
+)
+
+
+def _normalize_candidate(value: str | os.PathLike[str] | None) -> str | None:
+    if value is None:
+        return None
+    text = os.fspath(value).strip()
+    return str(Path(text).expanduser()) if text else None
+
+
+def _find_executable(explicit: str | os.PathLike[str] | None) -> str | None:
+    candidate = _normalize_candidate(explicit) or _normalize_candidate(os.getenv("SBAGENX_BIN"))
+    if candidate:
+        path = Path(candidate)
+        if path.is_file():
+            return str(path.resolve())
+        resolved = shutil.which(candidate)
+        return str(Path(resolved).resolve()) if resolved else candidate
+    resolved = shutil.which("sbagenx")
+    return str(Path(resolved).resolve()) if resolved else None
+
+
+def _find_library(explicit: str | os.PathLike[str] | None) -> str | None:
+    candidate = _normalize_candidate(explicit) or _normalize_candidate(os.getenv("SBAGENXLIB_PATH"))
+    if candidate:
+        return candidate
+    for name in ("sbagenx", "sbagenxlib"):
+        discovered = ctypes.util.find_library(name)
+        if discovered:
+            return discovered
+    return None
+
+
+def _probe_executable(path: str, timeout: float = 3.0) -> tuple[str | None, str | None]:
+    try:
+        completed = subprocess.run(
+            [path, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, f"Could not query SBaGenX executable: {exc}"
+    output = (completed.stdout or completed.stderr).strip()
+    if completed.returncode != 0:
+        return None, f"SBaGenX --version exited with status {completed.returncode}: {output or 'no output'}"
+    return output.splitlines()[0] if output else None, None
+
+
+def _read_c_string(function: Any) -> str | None:
+    function.restype = ctypes.c_char_p
+    value = function()
+    if not value:
+        return None
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+def _probe_library(
+    path: str,
+    loader: Callable[[str], Any] = ctypes.CDLL,
+) -> tuple[str | None, int | None, list[BackendCapability], str | None]:
+    try:
+        library = loader(path)
+    except OSError as exc:
+        return None, None, [], f"Could not load SBaGenX library: {exc}"
+
+    library_version: str | None = None
+    api_version: int | None = None
+    warnings: list[str] = []
+
+    try:
+        library_version = _read_c_string(getattr(library, "sbx_version"))
+    except (AttributeError, OSError, TypeError, ValueError) as exc:
+        warnings.append(f"Could not read sbx_version: {exc}")
+
+    try:
+        function = getattr(library, "sbx_api_version")
+        function.restype = ctypes.c_int
+        api_version = int(function())
+    except (AttributeError, OSError, TypeError, ValueError) as exc:
+        warnings.append(f"Could not read sbx_api_version: {exc}")
+
+    capabilities = []
+    for name, symbols in _CAPABILITY_SYMBOLS:
+        missing = [symbol for symbol in symbols if not hasattr(library, symbol)]
+        capabilities.append(
+            BackendCapability(
+                name=name,
+                available=not missing,
+                evidence="symbols present" if not missing else f"missing {', '.join(missing)}",
+            )
+        )
+
+    return library_version, api_version, capabilities, "; ".join(warnings) if warnings else None
+
+
+def probe_sbagenx(
+    *,
+    executable: str | os.PathLike[str] | None = None,
+    library: str | os.PathLike[str] | None = None,
+    query_executable: bool = True,
+    load_library: bool = True,
+) -> SBaGenXProbe:
+    """Discover an optional SBaGenX installation without making it mandatory.
+
+    Environment overrides:
+
+    - ``SBAGENX_BIN`` points at the CLI executable.
+    - ``SBAGENXLIB_PATH`` points at the shared library.
+
+    Discovery never changes PySbagen's rendering policy. Later integration
+    layers must still version-gate every native operation and attach the
+    selected backend to provenance/render receipts.
+    """
+
+    report = SBaGenXProbe(
+        executable_path=_find_executable(executable),
+        library_path=_find_library(library),
+    )
+
+    if report.executable_path and query_executable:
+        version, warning = _probe_executable(report.executable_path)
+        report.executable_version = version
+        if warning:
+            report.warnings.append(warning)
+
+    if report.library_path and load_library:
+        version, api_version, capabilities, warning = _probe_library(report.library_path)
+        report.library_version = version
+        report.api_version = api_version
+        report.capabilities = capabilities
+        if warning:
+            report.warnings.append(warning)
+
+    if not report.available:
+        report.warnings.append(
+            "SBaGenX was not found. Install it separately or set SBAGENX_BIN/SBAGENXLIB_PATH; "
+            "PySbagen's existing Python backend remains available."
+        )
+    return report

--- a/pysbagen/sbagenx_backend.py
+++ b/pysbagen/sbagenx_backend.py
@@ -1,3 +1,5 @@
+"""Optional, version-aware discovery for locally installed SBaGenX runtimes."""
+
 from __future__ import annotations
 
 import ctypes
@@ -34,23 +36,31 @@ class SBaGenXProbe:
 
     @property
     def candidate_found(self) -> bool:
+        """Return whether discovery found an executable or library candidate."""
+
         return bool(self.executable_path or self.library_path)
 
     @property
     def native_api_available(self) -> bool:
+        """Return whether a native library exposed a readable API revision."""
+
         return self.api_version is not None
 
     @property
     def usable(self) -> bool:
+        """Return whether at least one candidate passed identity qualification."""
+
         return bool(self.executable_version or self.native_api_available)
 
     @property
     def available(self) -> bool:
-        """Backward-friendly alias for a backend that passed identity probing."""
+        """Return a backward-friendly alias for a qualified usable backend."""
 
         return self.usable
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize the probe result for deterministic JSON output."""
+
         payload = asdict(self)
         payload["candidate_found"] = self.candidate_found
         payload["native_api_available"] = self.native_api_available
@@ -59,6 +69,8 @@ class SBaGenXProbe:
         return payload
 
     def to_text(self) -> str:
+        """Render a compact human-readable qualification report."""
+
         lines = ["SBaGenX backend probe"]
         lines.append(f"Candidate found: {'yes' if self.candidate_found else 'no'}")
         lines.append(f"Usable backend: {'yes' if self.usable else 'no'}")
@@ -92,6 +104,8 @@ _CAPABILITY_SYMBOLS: tuple[tuple[str, tuple[str, ...]], ...] = (
 
 
 def _normalize_candidate(value: str | os.PathLike[str] | None) -> str | None:
+    """Normalize an optional path/name while preserving loader-friendly names."""
+
     if value is None:
         return None
     text = os.fspath(value).strip()
@@ -99,6 +113,8 @@ def _normalize_candidate(value: str | os.PathLike[str] | None) -> str | None:
 
 
 def _find_executable(explicit: str | os.PathLike[str] | None) -> str | None:
+    """Resolve an explicit/environment/PATH SBaGenX executable candidate."""
+
     candidate = _normalize_candidate(explicit) or _normalize_candidate(os.getenv("SBAGENX_BIN"))
     if candidate:
         path = Path(candidate)
@@ -111,6 +127,8 @@ def _find_executable(explicit: str | os.PathLike[str] | None) -> str | None:
 
 
 def _find_library(explicit: str | os.PathLike[str] | None) -> str | None:
+    """Resolve an explicit/environment/system SBaGenX shared-library candidate."""
+
     candidate = _normalize_candidate(explicit) or _normalize_candidate(os.getenv("SBAGENXLIB_PATH"))
     if candidate:
         path = Path(candidate)
@@ -125,9 +143,9 @@ def _find_library(explicit: str | os.PathLike[str] | None) -> str | None:
 
 
 def _probe_executable(path: str, timeout: float = 3.0) -> tuple[str | None, str | None]:
-    """Read the version from SBaGenX's stable `-h` banner.
+    """Read the version from SBaGenX's stable ``-h`` banner.
 
-    SBaGenX uses `-V` for master volume and does not publish a `--version`
+    SBaGenX uses ``-V`` for master volume and does not publish a ``--version``
     interface in the reviewed source. The first help line contains the version.
     """
 
@@ -152,6 +170,8 @@ def _probe_executable(path: str, timeout: float = 3.0) -> tuple[str | None, str 
 
 
 def _read_c_string(function: Any) -> str | None:
+    """Call a no-argument C function returning a UTF-8-compatible string."""
+
     function.restype = ctypes.c_char_p
     value = function()
     if not value:
@@ -165,6 +185,8 @@ def _probe_library(
     path: str,
     loader: Callable[[str], Any] = ctypes.CDLL,
 ) -> tuple[str | None, int | None, list[BackendCapability], str | None]:
+    """Load a candidate library and report identity plus required symbols."""
+
     try:
         library = loader(path)
     except (OSError, TypeError) as exc:

--- a/pysbagen/sbagenx_backend.py
+++ b/pysbagen/sbagenx_backend.py
@@ -166,7 +166,9 @@ def _probe_executable(path: str, timeout: float = 3.0) -> tuple[str | None, str 
         return None, "SBaGenX -h returned no identity banner"
     first_line = output.splitlines()[0].strip()
     match = re.search(r"\bversion\s+([^\s]+)", first_line, flags=re.IGNORECASE)
-    return (match.group(1) if match else first_line), None
+    if not match:
+        return None, f"Could not parse SBaGenX version from help banner: {first_line}"
+    return match.group(1), None
 
 
 def _read_c_string(function: Any) -> str | None:

--- a/pysbagen/sbagenx_backend.py
+++ b/pysbagen/sbagenx_backend.py
@@ -33,21 +33,35 @@ class SBaGenXProbe:
     warnings: list[str] = field(default_factory=list)
 
     @property
-    def available(self) -> bool:
+    def candidate_found(self) -> bool:
         return bool(self.executable_path or self.library_path)
 
     @property
     def native_api_available(self) -> bool:
         return self.api_version is not None
 
+    @property
+    def usable(self) -> bool:
+        return bool(self.executable_version or self.native_api_available)
+
+    @property
+    def available(self) -> bool:
+        """Backward-friendly alias for a backend that passed identity probing."""
+
+        return self.usable
+
     def to_dict(self) -> dict[str, Any]:
         payload = asdict(self)
-        payload["available"] = self.available
+        payload["candidate_found"] = self.candidate_found
         payload["native_api_available"] = self.native_api_available
+        payload["usable"] = self.usable
+        payload["available"] = self.available
         return payload
 
     def to_text(self) -> str:
         lines = ["SBaGenX backend probe"]
+        lines.append(f"Candidate found: {'yes' if self.candidate_found else 'no'}")
+        lines.append(f"Usable backend: {'yes' if self.usable else 'no'}")
         lines.append(f"Executable: {self.executable_path or 'not found'}")
         if self.executable_version:
             lines.append(f"Executable version: {self.executable_version}")
@@ -99,6 +113,9 @@ def _find_executable(explicit: str | os.PathLike[str] | None) -> str | None:
 def _find_library(explicit: str | os.PathLike[str] | None) -> str | None:
     candidate = _normalize_candidate(explicit) or _normalize_candidate(os.getenv("SBAGENXLIB_PATH"))
     if candidate:
+        path = Path(candidate)
+        if path.is_absolute() or path.parent != Path("."):
+            return str(path.resolve()) if path.is_file() else None
         return candidate
     for name in ("sbagenx", "sbagenxlib"):
         discovered = ctypes.util.find_library(name)
@@ -150,7 +167,7 @@ def _probe_library(
 ) -> tuple[str | None, int | None, list[BackendCapability], str | None]:
     try:
         library = loader(path)
-    except OSError as exc:
+    except (OSError, TypeError) as exc:
         return None, None, [], f"Could not load SBaGenX library: {exc}"
 
     library_version: str | None = None
@@ -202,10 +219,17 @@ def probe_sbagenx(
     selected backend to provenance/render receipts.
     """
 
+    requested_executable = _normalize_candidate(executable) or _normalize_candidate(os.getenv("SBAGENX_BIN"))
+    requested_library = _normalize_candidate(library) or _normalize_candidate(os.getenv("SBAGENXLIB_PATH"))
     report = SBaGenXProbe(
         executable_path=_find_executable(executable),
         library_path=_find_library(library),
     )
+
+    if requested_executable and not report.executable_path:
+        report.warnings.append(f"Configured SBaGenX executable was not found: {requested_executable}")
+    if requested_library and not report.library_path:
+        report.warnings.append(f"Configured SBaGenX library was not found: {requested_library}")
 
     if report.executable_path and query_executable:
         version, warning = _probe_executable(report.executable_path)
@@ -221,9 +245,11 @@ def probe_sbagenx(
         if warning:
             report.warnings.append(warning)
 
-    if not report.available:
+    if not report.candidate_found:
         report.warnings.append(
             "SBaGenX was not found. Install it separately or set SBAGENX_BIN/SBAGENXLIB_PATH; "
             "PySbagen's existing Python backend remains available."
         )
+    elif (query_executable or load_library) and not report.usable:
+        report.warnings.append("SBaGenX candidates were found, but none passed identity qualification.")
     return report

--- a/pysbagen/sbagenx_backend.py
+++ b/pysbagen/sbagenx_backend.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ctypes
 import ctypes.util
 import os
+import re
 import shutil
 import subprocess
 from dataclasses import asdict, dataclass, field
@@ -90,7 +91,7 @@ def _find_executable(explicit: str | os.PathLike[str] | None) -> str | None:
         if path.is_file():
             return str(path.resolve())
         resolved = shutil.which(candidate)
-        return str(Path(resolved).resolve()) if resolved else candidate
+        return str(Path(resolved).resolve()) if resolved else None
     resolved = shutil.which("sbagenx")
     return str(Path(resolved).resolve()) if resolved else None
 
@@ -107,9 +108,15 @@ def _find_library(explicit: str | os.PathLike[str] | None) -> str | None:
 
 
 def _probe_executable(path: str, timeout: float = 3.0) -> tuple[str | None, str | None]:
+    """Read the version from SBaGenX's stable `-h` banner.
+
+    SBaGenX uses `-V` for master volume and does not publish a `--version`
+    interface in the reviewed source. The first help line contains the version.
+    """
+
     try:
         completed = subprocess.run(
-            [path, "--version"],
+            [path, "-h"],
             check=False,
             capture_output=True,
             text=True,
@@ -117,10 +124,14 @@ def _probe_executable(path: str, timeout: float = 3.0) -> tuple[str | None, str 
         )
     except (OSError, subprocess.SubprocessError) as exc:
         return None, f"Could not query SBaGenX executable: {exc}"
-    output = (completed.stdout or completed.stderr).strip()
+    output = "\n".join(part for part in (completed.stdout, completed.stderr) if part).strip()
     if completed.returncode != 0:
-        return None, f"SBaGenX --version exited with status {completed.returncode}: {output or 'no output'}"
-    return output.splitlines()[0] if output else None, None
+        return None, f"SBaGenX -h exited with status {completed.returncode}: {output or 'no output'}"
+    if not output:
+        return None, "SBaGenX -h returned no identity banner"
+    first_line = output.splitlines()[0].strip()
+    match = re.search(r"\bversion\s+([^\s]+)", first_line, flags=re.IGNORECASE)
+    return (match.group(1) if match else first_line), None
 
 
 def _read_c_string(function: Any) -> str | None:

--- a/pysbagen/sbagenx_native.py
+++ b/pysbagen/sbagenx_native.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ctypes
+import hashlib
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Callable
@@ -58,6 +59,8 @@ class NativeValidationReport:
     source_path: str
     source_kind: str
     source_encoding: str
+    source_size: int
+    source_sha256: str
     library_path: str
     library_version: str
     api_version: int
@@ -84,6 +87,8 @@ class NativeValidationReport:
             f"SBaGenX native validation: {self.source_path}",
             f"Kind: {self.source_kind}",
             f"Encoding: {self.source_encoding}",
+            f"Source bytes: {self.source_size}",
+            f"Source SHA-256: {self.source_sha256}",
             f"Library: {self.library_path}",
             f"Version/API: {self.library_version} / {self.api_version}",
             f"Valid: {'yes' if self.valid else 'no'}",
@@ -131,6 +136,8 @@ class SBaGenXNative:
         self._free_diagnostics.restype = None
 
         version_value = self._version()
+        if not version_value:
+            raise SBaGenXNativeError("SBaGenX library returned an empty sbx_version value")
         self.version = _decode_c_value(version_value)
         self.api_version = int(self._api_version())
         if not api_min <= self.api_version <= api_max:
@@ -177,6 +184,10 @@ class SBaGenXNative:
         )
         items: list[NativeDiagnostic] = []
         try:
+            if count.value and not diagnostics:
+                raise SBaGenXNativeError(
+                    f"SBaGenX returned {count.value} diagnostics with a null diagnostic pointer"
+                )
             for index in range(count.value):
                 raw = diagnostics[index]
                 items.append(
@@ -210,16 +221,16 @@ def _decode_c_value(value: Any) -> str:
     return raw.split(b"\0", 1)[0].decode("utf-8", errors="replace")
 
 
-def _read_source(path: Path) -> tuple[str, str]:
-    """Read a preserved source using UTF-8 BOM, UTF-8, then Latin-1 fallback."""
+def _read_source(path: Path) -> tuple[str, str, bytes]:
+    """Read source bytes and decode with UTF-8 BOM, UTF-8, then Latin-1 fallback."""
 
     data = path.read_bytes()
     if data.startswith(b"\xef\xbb\xbf"):
-        return data.decode("utf-8-sig"), "utf-8-sig"
+        return data.decode("utf-8-sig"), "utf-8-sig", data
     try:
-        return data.decode("utf-8"), "utf-8"
+        return data.decode("utf-8"), "utf-8", data
     except UnicodeDecodeError:
-        return data.decode("latin-1"), "latin-1"
+        return data.decode("latin-1"), "latin-1", data
 
 
 def validate_sbagenx_source(
@@ -239,13 +250,15 @@ def validate_sbagenx_source(
         raise SBaGenXNativeError(
             "SBaGenX native library was not found; set SBAGENXLIB_PATH or pass --library"
         )
-    text, encoding = _read_source(path)
+    text, encoding, source_bytes = _read_source(path)
     native = SBaGenXNative(library_path, loader=loader)
     status, diagnostics = native.validate_text(text, str(path), source_kind)
     return NativeValidationReport(
         source_path=str(path),
         source_kind=source_kind,
         source_encoding=encoding,
+        source_size=len(source_bytes),
+        source_sha256=hashlib.sha256(source_bytes).hexdigest(),
         library_path=library_path,
         library_version=native.version,
         api_version=native.api_version,

--- a/pysbagen/sbagenx_native.py
+++ b/pysbagen/sbagenx_native.py
@@ -1,0 +1,254 @@
+"""Typed, fail-closed bindings for the reviewed SBaGenX native validation API."""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+from .sbagenx_backend import _find_library
+
+SBX_OK = 0
+SBX_API_MIN = 47
+SBX_API_MAX = 47
+SBX_DIAG_ERROR = 1
+SBX_DIAG_WARNING = 2
+
+
+class SBaGenXNativeError(RuntimeError):
+    """Base error for native SBaGenX loading, versioning, or calls."""
+
+
+class UnsupportedSBaGenXAPI(SBaGenXNativeError):
+    """Raised when a native library API revision is outside the qualified range."""
+
+
+class _SbxDiagnostic(ctypes.Structure):
+    """ctypes mirror of SBaGenX API-47 ``SbxDiagnostic``."""
+
+    _fields_ = [
+        ("severity", ctypes.c_int),
+        ("code", ctypes.c_char * 32),
+        ("line", ctypes.c_uint32),
+        ("column", ctypes.c_uint32),
+        ("end_line", ctypes.c_uint32),
+        ("end_column", ctypes.c_uint32),
+        ("message", ctypes.c_char * 256),
+    ]
+
+
+@dataclass(frozen=True)
+class NativeDiagnostic:
+    """One structured diagnostic returned by ``sbagenxlib``."""
+
+    severity: str
+    code: str
+    line: int
+    column: int
+    end_line: int
+    end_column: int
+    message: str
+
+
+@dataclass
+class NativeValidationReport:
+    """Versioned SBaGenX validation result for one preserved source artifact."""
+
+    source_path: str
+    source_kind: str
+    source_encoding: str
+    library_path: str
+    library_version: str
+    api_version: int
+    status_code: int
+    diagnostics: list[NativeDiagnostic] = field(default_factory=list)
+
+    @property
+    def valid(self) -> bool:
+        """Return whether validation completed with no error-severity diagnostics."""
+
+        return self.status_code == SBX_OK and not any(item.severity == "error" for item in self.diagnostics)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the report for manifests and JSON CLI output."""
+
+        payload = asdict(self)
+        payload["valid"] = self.valid
+        return payload
+
+    def to_text(self) -> str:
+        """Render a concise human-readable validation report."""
+
+        lines = [
+            f"SBaGenX native validation: {self.source_path}",
+            f"Kind: {self.source_kind}",
+            f"Encoding: {self.source_encoding}",
+            f"Library: {self.library_path}",
+            f"Version/API: {self.library_version} / {self.api_version}",
+            f"Valid: {'yes' if self.valid else 'no'}",
+        ]
+        if not self.diagnostics:
+            lines.append("Diagnostics: none")
+        else:
+            lines.append("Diagnostics:")
+            for item in self.diagnostics:
+                location = f"{item.line}:{item.column}" if item.line else "unknown"
+                code = f" [{item.code}]" if item.code else ""
+                lines.append(f"  {item.severity} {location}{code}: {item.message}")
+        return "\n".join(lines)
+
+
+class SBaGenXNative:
+    """Narrow API-47 native binding used only for qualified operations."""
+
+    def __init__(
+        self,
+        library_path: str,
+        *,
+        loader: Callable[[str], Any] = ctypes.CDLL,
+        api_min: int = SBX_API_MIN,
+        api_max: int = SBX_API_MAX,
+    ) -> None:
+        """Load, type, and version-gate one SBaGenX shared library."""
+
+        self.library_path = library_path
+        try:
+            self._library = loader(library_path)
+        except (OSError, TypeError) as exc:
+            raise SBaGenXNativeError(f"Could not load SBaGenX library {library_path}: {exc}") from exc
+
+        self._version = self._required("sbx_version")
+        self._version.argtypes = []
+        self._version.restype = ctypes.c_char_p
+        self._api_version = self._required("sbx_api_version")
+        self._api_version.argtypes = []
+        self._api_version.restype = ctypes.c_int
+        self._validate_sbg = self._bind_validator("sbx_validate_sbg_text")
+        self._validate_sbgf = self._bind_validator("sbx_validate_sbgf_text")
+        self._free_diagnostics = self._required("sbx_free_diagnostics")
+        self._free_diagnostics.argtypes = [ctypes.POINTER(_SbxDiagnostic)]
+        self._free_diagnostics.restype = None
+
+        version_value = self._version()
+        self.version = _decode_c_value(version_value)
+        self.api_version = int(self._api_version())
+        if not api_min <= self.api_version <= api_max:
+            raise UnsupportedSBaGenXAPI(
+                f"Unsupported SBaGenX API {self.api_version}; qualified range is {api_min}..{api_max}"
+            )
+
+    def _required(self, name: str) -> Any:
+        """Return one required exported symbol or fail with a precise message."""
+
+        try:
+            return getattr(self._library, name)
+        except AttributeError as exc:
+            raise SBaGenXNativeError(f"SBaGenX library is missing required symbol: {name}") from exc
+
+    def _bind_validator(self, name: str) -> Any:
+        """Apply the exact API-47 signature to one validation function."""
+
+        function = self._required(name)
+        function.argtypes = [
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+            ctypes.POINTER(ctypes.POINTER(_SbxDiagnostic)),
+            ctypes.POINTER(ctypes.c_size_t),
+        ]
+        function.restype = ctypes.c_int
+        return function
+
+    def validate_text(self, text: str, source_name: str, source_kind: str) -> tuple[int, list[NativeDiagnostic]]:
+        """Validate UTF-8 text as ``sbg`` or ``sbgf`` and always free native diagnostics."""
+
+        if source_kind not in {"sbg", "sbgf"}:
+            raise ValueError(f"Unsupported SBaGenX source kind: {source_kind}")
+        validator = self._validate_sbg if source_kind == "sbg" else self._validate_sbgf
+        diagnostics = ctypes.POINTER(_SbxDiagnostic)()
+        count = ctypes.c_size_t(0)
+        status = int(
+            validator(
+                text.encode("utf-8"),
+                source_name.encode("utf-8", errors="replace"),
+                ctypes.byref(diagnostics),
+                ctypes.byref(count),
+            )
+        )
+        items: list[NativeDiagnostic] = []
+        try:
+            for index in range(count.value):
+                raw = diagnostics[index]
+                items.append(
+                    NativeDiagnostic(
+                        severity={SBX_DIAG_ERROR: "error", SBX_DIAG_WARNING: "warning"}.get(
+                            int(raw.severity), f"unknown-{int(raw.severity)}"
+                        ),
+                        code=_decode_c_value(raw.code),
+                        line=int(raw.line),
+                        column=int(raw.column),
+                        end_line=int(raw.end_line),
+                        end_column=int(raw.end_column),
+                        message=_decode_c_value(raw.message),
+                    )
+                )
+        finally:
+            if diagnostics:
+                self._free_diagnostics(diagnostics)
+        if status != SBX_OK:
+            raise SBaGenXNativeError(f"SBaGenX validation call failed with status {status}")
+        return status, items
+
+
+def _decode_c_value(value: Any) -> str:
+    """Decode bytes or fixed ctypes character arrays without trailing NULs."""
+
+    if isinstance(value, bytes):
+        raw = value
+    else:
+        raw = bytes(value)
+    return raw.split(b"\0", 1)[0].decode("utf-8", errors="replace")
+
+
+def _read_source(path: Path) -> tuple[str, str]:
+    """Read a preserved source using UTF-8 BOM, UTF-8, then Latin-1 fallback."""
+
+    data = path.read_bytes()
+    if data.startswith(b"\xef\xbb\xbf"):
+        return data.decode("utf-8-sig"), "utf-8-sig"
+    try:
+        return data.decode("utf-8"), "utf-8"
+    except UnicodeDecodeError:
+        return data.decode("latin-1"), "latin-1"
+
+
+def validate_sbagenx_source(
+    source: str | Path,
+    *,
+    library: str | Path | None = None,
+    loader: Callable[[str], Any] = ctypes.CDLL,
+) -> NativeValidationReport:
+    """Discover a native library and validate one ``.sbg`` or ``.sbgf`` file."""
+
+    path = Path(source).expanduser().resolve()
+    source_kind = path.suffix.lower().lstrip(".")
+    if source_kind not in {"sbg", "sbgf"}:
+        raise ValueError("Native SBaGenX validation requires a .sbg or .sbgf source")
+    library_path = _find_library(library)
+    if not library_path:
+        raise SBaGenXNativeError(
+            "SBaGenX native library was not found; set SBAGENXLIB_PATH or pass --library"
+        )
+    text, encoding = _read_source(path)
+    native = SBaGenXNative(library_path, loader=loader)
+    status, diagnostics = native.validate_text(text, str(path), source_kind)
+    return NativeValidationReport(
+        source_path=str(path),
+        source_kind=source_kind,
+        source_encoding=encoding,
+        library_path=library_path,
+        library_version=native.version,
+        api_version=native.api_version,
+        status_code=status,
+        diagnostics=diagnostics,
+    )

--- a/pysbagen/sbgf.py
+++ b/pysbagen/sbgf.py
@@ -1,0 +1,194 @@
+"""First-class preservation and structural inspection for SBaGenX ``.sbgf`` files."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from .compatibility import (
+    CompatibilityFinding,
+    CompatibilityState,
+    ImportReport,
+    MissingSource,
+    RenderDisposition,
+    SourceLocation,
+    sha256_bytes,
+)
+from .importers import ImportedArtifact
+
+_PARAM_RE = re.compile(r"^\s*param\s+([A-Za-z_]\w*)\s*=\s*(.+?)\s*$", re.IGNORECASE)
+_ASSIGN_RE = re.compile(r"^\s*([A-Za-z_]\w*)\s*=\s*(.+?)\s*$")
+_SOLVE_RE = re.compile(r"^\s*solve\b(.*)$", re.IGNORECASE)
+_FUNCTION_RE = re.compile(r"\b([A-Za-z_]\w*)\s*\(")
+_MEDIA_RE = re.compile(
+    r"(?P<quote>['\"])(?P<path>[^'\"]+\.(?:wav|wave|aif|aiff|flac|ogg|mp3))(?P=quote)",
+    re.IGNORECASE,
+)
+
+
+def import_sbgf(path: str | Path) -> ImportedArtifact:
+    """Preserve and structurally inspect one SBaGenX function-curve source."""
+
+    source_path = Path(path).expanduser().resolve()
+    if source_path.suffix.lower() != ".sbgf":
+        raise ValueError("SBGF import requires a .sbgf source")
+    data = source_path.read_bytes()
+    text, encoding = _decode_text(data)
+
+    parameters: dict[str, str] = {}
+    assignments: dict[str, str] = {}
+    solve_directives: list[dict[str, Any]] = []
+    expression_functions: set[str] = set()
+    referenced_media: dict[str, set[int]] = {}
+    findings: list[CompatibilityFinding] = [
+        CompatibilityFinding(
+            "sbgf-source-preserved",
+            "SBaGenX function source preserved",
+            CompatibilityState.SUPPORTED,
+            "The original bytes, encoding, source locations, and SHA-256 identity are retained.",
+        )
+    ]
+
+    for line_number, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        location = (SourceLocation(line=line_number, text=raw),)
+        parameter_match = _PARAM_RE.match(raw)
+        if parameter_match:
+            name, expression = parameter_match.groups()
+            if name in parameters:
+                findings.append(
+                    CompatibilityFinding(
+                        "sbgf-duplicate-parameter",
+                        "Duplicate SBGF parameter",
+                        CompatibilityState.PARTIAL,
+                        f"Parameter {name!r} is declared more than once; native validation decides final legality.",
+                        location,
+                    )
+                )
+            parameters[name] = expression
+            expression_functions.update(_FUNCTION_RE.findall(expression))
+            _record_media(expression, line_number, referenced_media)
+            continue
+        solve_match = _SOLVE_RE.match(raw)
+        if solve_match:
+            solve_directives.append({"line": line_number, "expression": solve_match.group(1).strip()})
+            expression_functions.update(_FUNCTION_RE.findall(solve_match.group(1)))
+            continue
+        assignment_match = _ASSIGN_RE.match(raw)
+        if assignment_match:
+            name, expression = assignment_match.groups()
+            if name in assignments:
+                findings.append(
+                    CompatibilityFinding(
+                        "sbgf-duplicate-assignment",
+                        "Duplicate SBGF assignment",
+                        CompatibilityState.PARTIAL,
+                        f"Output/expression {name!r} is assigned more than once; native validation decides final legality.",
+                        location,
+                    )
+                )
+            assignments[name] = expression
+            expression_functions.update(_FUNCTION_RE.findall(expression))
+            _record_media(expression, line_number, referenced_media)
+            continue
+        findings.append(
+            CompatibilityFinding(
+                "sbgf-unclassified-line",
+                "SBGF line preserved but not structurally classified",
+                CompatibilityState.UNKNOWN,
+                "PySbagen preserves this line and defers its exact semantics to qualified SBaGenX validation.",
+                location,
+            )
+        )
+
+    if not assignments:
+        findings.append(
+            CompatibilityFinding(
+                "sbgf-no-assignments",
+                "No SBGF output assignments were identified",
+                CompatibilityState.UNKNOWN,
+                "The artifact remains preserved, but PySbagen cannot infer a runnable curve program from structure alone.",
+            )
+        )
+
+    missing_sources: list[MissingSource] = []
+    media_records: list[dict[str, Any]] = []
+    for raw_path, lines in sorted(referenced_media.items()):
+        resolved = (source_path.parent / raw_path).resolve()
+        present = resolved.is_file()
+        media_records.append(
+            {
+                "declared_path": raw_path,
+                "resolved_path": str(resolved),
+                "source_lines": sorted(lines),
+                "present": present,
+            }
+        )
+        if not present:
+            missing_sources.append(MissingSource(str(resolved), tuple(f"line {line}" for line in sorted(lines))))
+            findings.append(
+                CompatibilityFinding(
+                    "sbgf-missing-media",
+                    "Referenced SBGF media is missing",
+                    CompatibilityState.MISSING_SOURCE,
+                    str(resolved),
+                    tuple(SourceLocation(line=line) for line in sorted(lines)),
+                    remediation="Restore the referenced media or deliberately relink it before native execution.",
+                )
+            )
+
+    findings.append(
+        CompatibilityFinding(
+            "sbgf-native-runtime-required",
+            "Qualified SBaGenX runtime required for execution",
+            CompatibilityState.UNSUPPORTED,
+            "PySbagen preserves and inspects SBGF but does not independently reinterpret its expression language or render it.",
+            remediation="Validate and later render through a supported SBaGenX native backend.",
+        )
+    )
+
+    report = ImportReport(
+        source_path=str(source_path),
+        source_type="sbgf",
+        source_size=len(data),
+        source_sha256=sha256_bytes(data),
+        encoding=encoding,
+        version_clues=["SBaGenX function-curve source"],
+        metadata={
+            "parameters": parameters,
+            "parameter_count": len(parameters),
+            "assignments": assignments,
+            "assignment_count": len(assignments),
+            "solve_directives": solve_directives,
+            "expression_functions": sorted(expression_functions),
+            "referenced_media": media_records,
+        },
+        findings=findings,
+        missing_sources=missing_sources,
+        start_mode="function-driven",
+        end_behavior="defined by SBGF program/runtime arguments",
+        loop_behavior="defined by SBaGenX runtime configuration",
+        render_disposition=RenderDisposition.INSPECTION_ONLY,
+    )
+    return ImportedArtifact(report, {}, [], source_text=text)
+
+
+def _record_media(expression: str, line_number: int, records: dict[str, set[int]]) -> None:
+    """Record quoted media references while retaining all source-line provenance."""
+
+    for match in _MEDIA_RE.finditer(expression):
+        records.setdefault(match.group("path"), set()).add(line_number)
+
+
+def _decode_text(data: bytes) -> tuple[str, str]:
+    """Decode source bytes without losing a deterministic encoding record."""
+
+    if data.startswith(b"\xef\xbb\xbf"):
+        return data.decode("utf-8-sig"), "utf-8-sig"
+    try:
+        return data.decode("utf-8"), "utf-8"
+    except UnicodeDecodeError:
+        return data.decode("latin-1"), "latin-1"

--- a/pysbagen/tests/test_sbagenx_backend.py
+++ b/pysbagen/tests/test_sbagenx_backend.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pysbagen.sbagenx_backend import _probe_library, probe_sbagenx
+
+
+class _FakeFunction:
+    def __init__(self, value):
+        self.value = value
+        self.restype = None
+
+    def __call__(self):
+        return self.value
+
+
+class _FakeLibrary:
+    sbx_version = _FakeFunction(b"3.9.0-alpha.15")
+    sbx_api_version = _FakeFunction(47)
+    sbx_context_render_f32 = object()
+    sbx_validate_sbg_text = object()
+    sbx_validate_sbgf_text = object()
+    sbx_audio_writer_create_path = object()
+    sbx_audio_writer_write_f32 = object()
+    sbx_context_set_live_control = object()
+    sbx_context_ramp_live_control = object()
+    sbx_context_mix_stream_sample = object()
+
+
+def test_probe_library_reports_version_api_and_symbols():
+    version, api_version, capabilities, warning = _probe_library(
+        "fake-sbagenxlib",
+        loader=lambda _: _FakeLibrary(),
+    )
+
+    assert version == "3.9.0-alpha.15"
+    assert api_version == 47
+    assert warning is None
+    assert capabilities
+    assert all(capability.available for capability in capabilities)
+
+
+def test_probe_can_record_explicit_paths_without_loading(tmp_path: Path):
+    executable = tmp_path / "sbagenx"
+    executable.write_text("not executed", encoding="utf-8")
+    library = tmp_path / "libsbagenx.so"
+    library.write_text("not loaded", encoding="utf-8")
+
+    report = probe_sbagenx(
+        executable=executable,
+        library=library,
+        query_executable=False,
+        load_library=False,
+    )
+
+    assert report.available
+    assert report.executable_path == str(executable.resolve())
+    assert report.library_path == str(library)
+    assert report.executable_version is None
+    assert report.api_version is None
+
+
+def test_probe_missing_backend_is_explicit(monkeypatch):
+    monkeypatch.delenv("SBAGENX_BIN", raising=False)
+    monkeypatch.delenv("SBAGENXLIB_PATH", raising=False)
+    monkeypatch.setattr("pysbagen.sbagenx_backend.shutil.which", lambda _: None)
+    monkeypatch.setattr("pysbagen.sbagenx_backend.ctypes.util.find_library", lambda _: None)
+
+    report = probe_sbagenx()
+
+    assert not report.available
+    assert report.warnings
+    assert "existing Python backend remains available" in report.warnings[-1]

--- a/pysbagen/tests/test_sbagenx_backend.py
+++ b/pysbagen/tests/test_sbagenx_backend.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
-from pysbagen.sbagenx_backend import _probe_library, probe_sbagenx
+from pysbagen.sbagenx_backend import _probe_executable, _probe_library, probe_sbagenx
 
 
 class _FakeFunction:
@@ -38,6 +39,26 @@ def test_probe_library_reports_version_api_and_symbols():
     assert warning is None
     assert capabilities
     assert all(capability.available for capability in capabilities)
+
+
+def test_probe_executable_uses_help_banner(monkeypatch):
+    observed = {}
+
+    def fake_run(command, **kwargs):
+        observed["command"] = command
+        return SimpleNamespace(
+            returncode=0,
+            stdout="SBaGenX - Sequenced Brainwave Generator, version 3.9.0-alpha.15\nmore help\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr("pysbagen.sbagenx_backend.subprocess.run", fake_run)
+
+    version, warning = _probe_executable("sbagenx")
+
+    assert observed["command"] == ["sbagenx", "-h"]
+    assert version == "3.9.0-alpha.15"
+    assert warning is None
 
 
 def test_probe_can_record_explicit_paths_without_loading(tmp_path: Path):

--- a/pysbagen/tests/test_sbagenx_backend.py
+++ b/pysbagen/tests/test_sbagenx_backend.py
@@ -74,11 +74,24 @@ def test_probe_can_record_explicit_paths_without_loading(tmp_path: Path):
         load_library=False,
     )
 
-    assert report.available
+    assert report.candidate_found
+    assert not report.usable
+    assert not report.available
     assert report.executable_path == str(executable.resolve())
-    assert report.library_path == str(library)
+    assert report.library_path == str(library.resolve())
     assert report.executable_version is None
     assert report.api_version is None
+
+
+def test_probe_missing_configured_backend_names_the_path(monkeypatch, tmp_path: Path):
+    missing = tmp_path / "missing-sbagenx"
+    monkeypatch.setattr("pysbagen.sbagenx_backend.shutil.which", lambda _: None)
+    monkeypatch.setattr("pysbagen.sbagenx_backend.ctypes.util.find_library", lambda _: None)
+
+    report = probe_sbagenx(executable=missing, query_executable=False, load_library=False)
+
+    assert not report.candidate_found
+    assert any(str(missing) in warning for warning in report.warnings)
 
 
 def test_probe_missing_backend_is_explicit(monkeypatch):
@@ -90,5 +103,6 @@ def test_probe_missing_backend_is_explicit(monkeypatch):
     report = probe_sbagenx()
 
     assert not report.available
+    assert not report.candidate_found
     assert report.warnings
     assert "existing Python backend remains available" in report.warnings[-1]

--- a/pysbagen/tests/test_sbagenx_backend.py
+++ b/pysbagen/tests/test_sbagenx_backend.py
@@ -61,6 +61,22 @@ def test_probe_executable_uses_help_banner(monkeypatch):
     assert warning is None
 
 
+def test_probe_executable_rejects_unrecognized_help_banner(monkeypatch):
+    monkeypatch.setattr(
+        "pysbagen.sbagenx_backend.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="Some unrelated executable\nusage follows\n",
+            stderr="",
+        ),
+    )
+
+    version, warning = _probe_executable("not-sbagenx")
+
+    assert version is None
+    assert warning == "Could not parse SBaGenX version from help banner: Some unrelated executable"
+
+
 def test_probe_can_record_explicit_paths_without_loading(tmp_path: Path):
     executable = tmp_path / "sbagenx"
     executable.write_text("not executed", encoding="utf-8")
@@ -81,6 +97,38 @@ def test_probe_can_record_explicit_paths_without_loading(tmp_path: Path):
     assert report.library_path == str(library.resolve())
     assert report.executable_version is None
     assert report.api_version is None
+
+
+def test_non_executable_candidate_is_not_usable(monkeypatch, tmp_path: Path):
+    executable = tmp_path / "sbagenx"
+    executable.write_text("not executable", encoding="utf-8")
+    monkeypatch.setattr(
+        "pysbagen.sbagenx_backend.subprocess.run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(PermissionError("permission denied")),
+    )
+    monkeypatch.setattr("pysbagen.sbagenx_backend.ctypes.util.find_library", lambda _: None)
+
+    report = probe_sbagenx(executable=executable)
+
+    assert report.candidate_found
+    assert not report.usable
+    assert any("permission denied" in warning for warning in report.warnings)
+
+
+def test_unloadable_library_candidate_is_not_usable(monkeypatch, tmp_path: Path):
+    library = tmp_path / "libsbagenx.so"
+    library.write_text("not a shared library", encoding="utf-8")
+    monkeypatch.setattr(
+        "pysbagen.sbagenx_backend._probe_library",
+        lambda path: (None, None, [], "Could not load SBaGenX library: invalid image"),
+    )
+    monkeypatch.setattr("pysbagen.sbagenx_backend.shutil.which", lambda _: None)
+
+    report = probe_sbagenx(library=library, query_executable=False)
+
+    assert report.candidate_found
+    assert not report.usable
+    assert any("invalid image" in warning for warning in report.warnings)
 
 
 def test_probe_missing_configured_backend_names_the_path(monkeypatch, tmp_path: Path):

--- a/pysbagen/tests/test_sbagenx_interoperability.py
+++ b/pysbagen/tests/test_sbagenx_interoperability.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import ctypes
+from pathlib import Path
+
+from pysbagen.compatibility import RenderDisposition
+from pysbagen.interoperability import inspect_with_sbagenx
+from pysbagen.library import LocalLibrary
+from pysbagen.sbagenx_native import _SbxDiagnostic
+from pysbagen.sbgf import import_sbgf
+
+
+class _FakeFunction:
+    def __init__(self, implementation):
+        self.implementation = implementation
+        self.argtypes = None
+        self.restype = None
+
+    def __call__(self, *args):
+        return self.implementation(*args)
+
+
+class _ValidationLibrary:
+    def __init__(self, *, error: bool = False):
+        self._array = None
+        self._error = error
+        self.sbx_version = _FakeFunction(lambda: b"3.9.0-alpha.15")
+        self.sbx_api_version = _FakeFunction(lambda: 47)
+        self.sbx_validate_sbg_text = _FakeFunction(self._validate)
+        self.sbx_validate_sbgf_text = _FakeFunction(self._validate)
+        self.sbx_free_diagnostics = _FakeFunction(lambda pointer: None)
+
+    def _validate(self, text, source, out_diags, out_count):
+        count = ctypes.cast(out_count, ctypes.POINTER(ctypes.c_size_t))
+        pointer = ctypes.cast(out_diags, ctypes.POINTER(ctypes.POINTER(_SbxDiagnostic)))
+        if not self._error:
+            count[0] = 0
+            return 0
+        array = (_SbxDiagnostic * 1)()
+        array[0].severity = 1
+        array[0].code = b"native-error"
+        array[0].line = 2
+        array[0].column = 1
+        array[0].end_line = 2
+        array[0].end_column = 4
+        array[0].message = b"Synthetic native rejection"
+        self._array = array
+        pointer[0] = ctypes.cast(array, ctypes.POINTER(_SbxDiagnostic))
+        count[0] = 1
+        return 0
+
+
+def test_sbgf_preserves_structure_identity_and_library_record(tmp_path: Path):
+    source = tmp_path / "curve.sbgf"
+    source.write_text(
+        "# function program\n"
+        "param l = 0.125\n"
+        "param h = 0\n"
+        "solve target = 6\n"
+        "beat = b0 + (b1 - b0) * tanh(l * (m - h))\n"
+        "carrier = c0 + (c1 - c0) * ramp(m, 0, T)\n",
+        encoding="utf-8",
+    )
+
+    artifact = import_sbgf(source)
+
+    assert artifact.report.source_type == "sbgf"
+    assert artifact.report.render_disposition is RenderDisposition.INSPECTION_ONLY
+    assert artifact.report.metadata["parameter_count"] == 2
+    assert artifact.report.metadata["assignment_count"] == 2
+    assert artifact.report.metadata["expression_functions"] == ["ramp", "tanh"]
+    assert artifact.report.metadata["solve_directives"][0]["line"] == 4
+
+    item = LocalLibrary(tmp_path / "library").add(artifact)
+    verification = LocalLibrary(tmp_path / "library").verify(item.item_id)
+    assert item.state == "incompatible"
+    assert verification["valid"]
+
+
+def test_sbgf_missing_media_remains_visible(tmp_path: Path):
+    source = tmp_path / "media.sbgf"
+    source.write_text('param bed = "missing.flac"\nbeat = 8\n', encoding="utf-8")
+
+    artifact = import_sbgf(source)
+
+    assert artifact.report.missing_sources
+    assert artifact.report.metadata["referenced_media"][0]["present"] is False
+
+
+def test_dual_sbgf_report_keeps_native_validity_and_pysbagen_limits(tmp_path: Path):
+    source = tmp_path / "curve.sbgf"
+    source.write_text("param l = 0.125\nbeat = tanh(l * m)\n", encoding="utf-8")
+
+    report = inspect_with_sbagenx(
+        source,
+        library="fake-library",
+        loader=lambda _: _ValidationLibrary(),
+    )
+
+    assert report.source_identity_matches
+    assert report.native_valid
+    assert report.pysbagen_disposition is RenderDisposition.INSPECTION_ONLY
+    assert any(item.code == "native-accepts-pysbagen-limited" for item in report.discrepancies)
+
+
+def test_dual_sbg_report_surfaces_native_rejection(tmp_path: Path):
+    source = tmp_path / "session.sbg"
+    source.write_text(
+        "tone: 200+10/20\n"
+        "off: -\n"
+        "NOW tone\n"
+        "+00:00:01 off\n",
+        encoding="utf-8",
+    )
+
+    report = inspect_with_sbagenx(
+        source,
+        library="fake-library",
+        loader=lambda _: _ValidationLibrary(error=True),
+    )
+
+    assert report.source_identity_matches
+    assert not report.native_valid
+    assert any(item.code == "pysbagen-accepts-native-rejects" for item in report.discrepancies)
+    assert any(item.code == "native-diagnostics-present" for item in report.discrepancies)

--- a/pysbagen/tests/test_sbagenx_native.py
+++ b/pysbagen/tests/test_sbagenx_native.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import ctypes
+import hashlib
 from pathlib import Path
 
 import pytest
 
 from pysbagen.sbagenx_native import (
     SBaGenXNative,
+    SBaGenXNativeError,
     UnsupportedSBaGenXAPI,
     _SbxDiagnostic,
     validate_sbagenx_source,
@@ -24,8 +26,14 @@ class _FakeFunction:
 
 
 class _FakeLibrary:
-    def __init__(self, api_version: int = 47, with_diagnostic: bool = True):
+    def __init__(
+        self,
+        api_version: int = 47,
+        with_diagnostic: bool = True,
+        null_diagnostic_pointer: bool = False,
+    ):
         self._diagnostic_array = None
+        self._null_diagnostic_pointer = null_diagnostic_pointer
         self.sbx_version = _FakeFunction(lambda: b"3.9.0-alpha.15")
         self.sbx_api_version = _FakeFunction(lambda: api_version)
         self.sbx_validate_sbg_text = _FakeFunction(
@@ -45,6 +53,9 @@ class _FakeLibrary:
         if not with_diagnostic:
             count_pointer[0] = 0
             return 0
+        count_pointer[0] = 1
+        if self._null_diagnostic_pointer:
+            return 0
         array = (_SbxDiagnostic * 1)()
         array[0].severity = 2
         array[0].code = b"native-warning"
@@ -55,7 +66,6 @@ class _FakeLibrary:
         array[0].message = b"Synthetic native diagnostic"
         self._diagnostic_array = array
         diagnostic_pointer[0] = ctypes.cast(array, ctypes.POINTER(_SbxDiagnostic))
-        count_pointer[0] = 1
         return 0
 
 
@@ -78,9 +88,20 @@ def test_native_binding_rejects_unknown_api_revision():
         SBaGenXNative("fake", loader=lambda _: _FakeLibrary(api_version=48))
 
 
+def test_native_binding_rejects_null_diagnostic_pointer():
+    native = SBaGenXNative(
+        "fake",
+        loader=lambda _: _FakeLibrary(null_diagnostic_pointer=True),
+    )
+
+    with pytest.raises(SBaGenXNativeError, match="null diagnostic pointer"):
+        native.validate_text("NOW tone", "fixture.sbg", "sbg")
+
+
 def test_validate_source_preserves_encoding_and_identity(tmp_path: Path):
     source = tmp_path / "latin1.sbg"
-    source.write_bytes("# café\nNOW off\n".encode("latin-1"))
+    source_bytes = "# café\nNOW off\n".encode("latin-1")
+    source.write_bytes(source_bytes)
 
     report = validate_sbagenx_source(
         source,
@@ -91,6 +112,8 @@ def test_validate_source_preserves_encoding_and_identity(tmp_path: Path):
     assert report.valid
     assert report.source_kind == "sbg"
     assert report.source_encoding == "latin-1"
+    assert report.source_size == len(source_bytes)
+    assert report.source_sha256 == hashlib.sha256(source_bytes).hexdigest()
     assert report.api_version == 47
     assert report.library_version == "3.9.0-alpha.15"
     assert report.diagnostics == []

--- a/pysbagen/tests/test_sbagenx_native.py
+++ b/pysbagen/tests/test_sbagenx_native.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import ctypes
+from pathlib import Path
+
+import pytest
+
+from pysbagen.sbagenx_native import (
+    SBaGenXNative,
+    UnsupportedSBaGenXAPI,
+    _SbxDiagnostic,
+    validate_sbagenx_source,
+)
+
+
+class _FakeFunction:
+    def __init__(self, implementation):
+        self.implementation = implementation
+        self.argtypes = None
+        self.restype = None
+
+    def __call__(self, *args):
+        return self.implementation(*args)
+
+
+class _FakeLibrary:
+    def __init__(self, api_version: int = 47, with_diagnostic: bool = True):
+        self._diagnostic_array = None
+        self.sbx_version = _FakeFunction(lambda: b"3.9.0-alpha.15")
+        self.sbx_api_version = _FakeFunction(lambda: api_version)
+        self.sbx_validate_sbg_text = _FakeFunction(
+            lambda text, source, out_diags, out_count: self._validate(out_diags, out_count, with_diagnostic)
+        )
+        self.sbx_validate_sbgf_text = _FakeFunction(
+            lambda text, source, out_diags, out_count: self._validate(out_diags, out_count, with_diagnostic)
+        )
+        self.sbx_free_diagnostics = _FakeFunction(lambda diagnostics: None)
+
+    def _validate(self, out_diags, out_count, with_diagnostic):
+        count_pointer = ctypes.cast(out_count, ctypes.POINTER(ctypes.c_size_t))
+        diagnostic_pointer = ctypes.cast(
+            out_diags,
+            ctypes.POINTER(ctypes.POINTER(_SbxDiagnostic)),
+        )
+        if not with_diagnostic:
+            count_pointer[0] = 0
+            return 0
+        array = (_SbxDiagnostic * 1)()
+        array[0].severity = 2
+        array[0].code = b"native-warning"
+        array[0].line = 4
+        array[0].column = 2
+        array[0].end_line = 4
+        array[0].end_column = 3
+        array[0].message = b"Synthetic native diagnostic"
+        self._diagnostic_array = array
+        diagnostic_pointer[0] = ctypes.cast(array, ctypes.POINTER(_SbxDiagnostic))
+        count_pointer[0] = 1
+        return 0
+
+
+def test_native_binding_types_and_decodes_diagnostics():
+    native = SBaGenXNative("fake", loader=lambda _: _FakeLibrary())
+
+    status, diagnostics = native.validate_text("NOW tone", "fixture.sbg", "sbg")
+
+    assert status == 0
+    assert native.version == "3.9.0-alpha.15"
+    assert native.api_version == 47
+    assert diagnostics[0].severity == "warning"
+    assert diagnostics[0].code == "native-warning"
+    assert diagnostics[0].line == 4
+    assert diagnostics[0].message == "Synthetic native diagnostic"
+
+
+def test_native_binding_rejects_unknown_api_revision():
+    with pytest.raises(UnsupportedSBaGenXAPI, match="Unsupported SBaGenX API 48"):
+        SBaGenXNative("fake", loader=lambda _: _FakeLibrary(api_version=48))
+
+
+def test_validate_source_preserves_encoding_and_identity(tmp_path: Path):
+    source = tmp_path / "latin1.sbg"
+    source.write_bytes("# café\nNOW off\n".encode("latin-1"))
+
+    report = validate_sbagenx_source(
+        source,
+        library="fake-library",
+        loader=lambda _: _FakeLibrary(with_diagnostic=False),
+    )
+
+    assert report.valid
+    assert report.source_kind == "sbg"
+    assert report.source_encoding == "latin-1"
+    assert report.api_version == 47
+    assert report.library_version == "3.9.0-alpha.15"
+    assert report.diagnostics == []


### PR DESCRIPTION
## What changed

- replaces the broad Python workstation-recreation plan with a source-pinned SBaGenX differentiation and interoperability strategy;
- archives the superseded WST-001 through WST-015 train before duplicated implementation begins;
- records which capabilities belong to SBaGenX, which remain PySbagen-owned, and which require verification;
- adds the active 13-bead SBaGenX interoperability train;
- adds optional SBaGenX executable/native-library discovery and truthful candidate qualification;
- reads the real CLI identity from `sbagenx -h` and native identity from `sbx_version()` / `sbx_api_version()`;
- adds an exact, fail-closed API-47 ctypes validation binding;
- adds first-class `.sbgf` preservation, structural inspection, media dependency reporting, and local-library storage;
- composes PySbagen compatibility truth and SBaGenX validation into one source-hash-bound discrepancy report;
- exposes `sbgpy-inspect backend --validate SOURCE` for combined `.sbg`/`.sbgf` inspection;
- records source byte count/SHA-256, encoding, native diagnostics, library version, and API identity;
- rejects unknown API revisions, missing symbols, empty identity, malformed diagnostic pointers, and unrecognized CLI banners;
- keeps native rendering deliberately disabled behind typed render bindings, parity fixtures, explicit backend policy, and exact receipts.

## Product boundary

SBaGenX remains the advanced native SBaGen engine for `.sbg`/`.sbgf`, curves, mix effects, live controls, multivoice DSP, export, plotting, packaging, and frontends.

PySbagen remains the provenance-first protocol/session layer for DRG/SBGF preservation, compatibility truth, local library identity, listening-path qualification, guided products, markers, outcomes, personalization, and research workflows.

SBaGenX is optional. The existing Python renderer remains the portable fallback.

## User paths

```bash
sbgpy-inspect backend
sbgpy-inspect backend --discover-only
sbgpy-inspect backend --validate session.sbg --json
sbgpy-inspect backend --validate curve.sbgf --json
sbgpy-inspect inspect curve.sbgf --add-to-library
```

Combined validation returns:

- `0` only for identity-matched, native-valid, PySbagen-safe content without discrepancies;
- `1` for disclosed PySbagen limitations or cross-engine discrepancies;
- `2` for identity mismatch, native rejection, unsupported API, missing backend, or operational failure.

## Qualification

GitHub Actions Python qualification run #52 passed the final PR head:

- Python 3.10 product-path tests — passed;
- Python 3.11 product-path tests — passed;
- Python 3.12 product-path tests — passed;
- Python 3.13 product-path tests — passed;
- complete repository result — **59 tests passed**;
- Python 3.12 source distribution and wheel build — passed;
- wheel includes backend discovery, native validation, SBGF preservation, and interoperability modules.

CodeRabbit is green. Its two correctness findings were fixed and resolved:

1. candidate discovery is distinct from successful backend qualification;
2. unrecognized help banners cannot become fake version strings.

An existing setuptools warning notes that the TOML-table form of `project.license` must be modernized before February 18, 2027; it does not fail this PR.

## Next bead

SBX-006 adds optional native rendering only together with exact context/writer bindings, parity/discrepancy fixtures, explicit `python` / `sbagenx` / capability-gated `auto` selection, and complete provenance receipts.

## SBaGenX source reviewed

`lm7137/SBaGenX@be7c74d378774a759f1e4149dc9df3617b4d0d3b`
