### PR TITLE
Build memorable Living Sessions above the audio engines

### DIFF
--- a/.beads/pysbagen_living_sessions_train_2026_07_31.md
+++ b/.beads/pysbagen_living_sessions_train_2026_07_31.md
@@ -1,0 +1,288 @@
+# PySbagen Living Sessions Product Train
+
+**Date:** July 31, 2026  
+**Status:** Active — first complete return loop implemented  
+**Branch:** `agent/living-sessions-train-20260731`  
+**Stack base:** `agent/sbagenx-interoperability-train-20260731` / PR `#11`  
+**Research input:** `docs/research/HTE_LIVING_SESSIONS_GAP_SYNTHESIS_2026_07_31.md`
+
+## Train goal
+
+Make PySbagen a repeatedly useful, memorable personal session system without duplicating SBaGenX DSP and without relying on manipulative engagement mechanics.
+
+A completed session must create future value through exact identity, lineage, remembered moments, transparent variation, and optional local learning.
+
+## Product boundary
+
+### SBaGenX remains responsible for
+
+- advanced native SBG/SBGF execution;
+- curves and expression programs;
+- native DSP, export, plotting, authoring, and frontends;
+- future qualified native rendering selected by explicit policy.
+
+### PySbagen owns
+
+- session identity and exact recipe provenance;
+- human-guided products;
+- backend-independent lineage and event records;
+- echoes and remembered moments;
+- transparent variation planning;
+- optional outcome history and descriptive local pattern detection;
+- local-first archives and exportable receipts.
+
+## Anti-patterns
+
+- no points, badges, loot mechanics, leaderboards, or coercive streaks;
+- no hidden parameter changes;
+- no random frequency generation outside validated product choices;
+- no cloud account requirement;
+- no opaque recommendation model;
+- no medical-efficacy inference;
+- no copying HTE runtime code into PySbagen;
+- no changing the stated user problem merely to manufacture novelty.
+
+---
+
+## LIV-001 — HTE and InvisiSynth product-gap synthesis
+
+**Status:** complete
+
+Applied the supplied HTE-Newest pack's InvisiSynth, Learning, Affect, Parallel Oracle, Synthesis, Intersection, and Lateral concepts.
+
+**Delivered:**
+
+- `docs/research/HTE_LIVING_SESSIONS_GAP_SYNTHESIS_2026_07_31.md`;
+- explicit domain-gap findings;
+- cross-domain mechanism table;
+- anti-drawer acceptance test;
+- rejected manipulative or disposable concepts.
+
+## LIV-002 — Memorable identity bound to exact recipes
+
+**Status:** complete
+
+Delivered deterministic:
+
+- two-word session title;
+- three-word motif;
+- recipe SHA-256;
+- stable lineage ID;
+- unique session occurrence ID;
+- human memory phrase that never replaces machine provenance.
+
+## LIV-003 — Return, branch, contrast, and wander modes
+
+**Status:** complete
+
+Delivered four explicit routes:
+
+- `return` — exact recipe and remembered identity;
+- `branch` — exactly one disclosed change;
+- `contrast` — one high-salience disclosed change;
+- `wander` — at most two compatible disclosed changes, marked experimental and less causally interpretable.
+
+Current mutation dimensions are restricted to existing product-level controls:
+
+- generated-bed seed;
+- duration;
+- intensity;
+- sound world and its user-audio binding;
+- one underlying layer toggle.
+
+The stated sleep problem remains unchanged.
+
+## LIV-004 — Local append-only archive
+
+**Status:** complete
+
+Delivered a platform-local archive containing:
+
+- immutable plan JSON;
+- append-only event JSONL;
+- immutable outcome JSON;
+- content-derived identifiers;
+- idempotent plan creation;
+- lineage queries;
+- chronological session listing.
+
+## LIV-005 — Echo memory markers
+
+**Status:** complete
+
+Delivered named `echo`, `shift`, `insight`, `discomfort`, and custom events with:
+
+- session/lineage identity;
+- optional transport position;
+- timestamp;
+- human label;
+- optional structured payload.
+
+Echoes remain metadata anchors. Audio extraction/recomposition is deferred to a later orchestration bead.
+
+## LIV-006 — Affect-tagged optional outcomes
+
+**Status:** complete
+
+Delivered optional:
+
+- pre-session valence, arousal, and agency snapshot;
+- post-session snapshot;
+- rating;
+- comfort state;
+- would-repeat signal;
+- notes and tags;
+- immutable outcome records.
+
+These records are personal description, not clinical measurement.
+
+## LIV-007 — Transparent next-mode recommendation
+
+**Status:** complete
+
+Delivered simple explainable rules:
+
+- no outcome → branch;
+- uncomfortable or low-rated outcome → contrast;
+- strong first outcome with repeat intent → exact return;
+- repeated strong exact return → branch;
+- otherwise → branch.
+
+No hidden score or remote model is involved.
+
+## LIV-008 — Personal atlas
+
+**Status:** complete
+
+Delivered:
+
+- planned, active, completed, lineage, and echo counts;
+- average optional rating;
+- would-repeat rate;
+- average recorded affect delta;
+- lineage title histories;
+- descriptive sound-world and mode pattern candidates after repeated observations.
+
+## LIV-009 — Living Sessions CLI
+
+**Status:** complete
+
+Delivered `sbgpy-session` commands:
+
+- `new-sleep`;
+- `next`;
+- `show`;
+- `list`;
+- `mark`;
+- `finish`;
+- `render`;
+- `atlas`.
+
+The render command reconstructs and validates the exact stored SleepRequest, renders through the current Python backend, hashes the output, and appends a backend/recipe/output event receipt.
+
+## LIV-010 — Qualification and package integration
+
+**Status:** in progress
+
+Required:
+
+- Python 3.10–3.13 test matrix;
+- complete repository tests;
+- source distribution and wheel build;
+- wheel contains `living_sessions.py` and `session_cli.py`;
+- installed `sbgpy-session --help` works;
+- no regression in PR #11 interoperability, SBGF, DRG, library, rendering, or Sleep Guide paths;
+- review comments and nits resolved where compatible with product philosophy.
+
+## LIV-011 — Constellation view
+
+**Status:** queued
+
+Build a visual or TUI graph showing:
+
+- root sessions;
+- returns and branches;
+- mutations on edges;
+- echoes on nodes;
+- outcome context;
+- backend identity;
+- source/recipe hashes on demand.
+
+The graph must remain useful with no network connection.
+
+## LIV-012 — Confluence sessions
+
+**Status:** queued after lineage qualification
+
+Combine two understood lineages while preserving both parent identities.
+
+Requirements:
+
+- two-parent provenance;
+- compatible-dimension checks;
+- every inherited and changed dimension disclosed;
+- no silent blending of contradictory intents;
+- mark lower causal interpretability;
+- exact reproducibility.
+
+## LIV-013 — Echo weaving
+
+**Status:** queued after one-shot cue verification
+
+Turn selected echoes into backend-independent orchestration anchors:
+
+- structural reprise;
+- cue trigger;
+- gentle contrast point;
+- marker-relative event;
+- no blind audio copying;
+- complete receipt.
+
+Coordinate with SBX-011 so SBaGenX capabilities are not duplicated.
+
+## LIV-014 — Shareable seed capsule
+
+**Status:** queued
+
+Export a self-contained identity and recipe capsule that includes:
+
+- exact recipe/source hashes;
+- title and motif;
+- lineage summary;
+- backend requirements;
+- optional referenced media manifest;
+- no personal affect/outcome history unless explicitly selected.
+
+## LIV-015 — Cross-product Living Sessions
+
+**Status:** queued
+
+Generalize the archive and lineage model beyond Sleep Guide to:
+
+- imported SBG sessions;
+- native-required SBGF programs;
+- research protocols;
+- future guided creativity, pain, cessation, or focus products;
+- Python and SBaGenX backends through the same experience layer.
+
+## Current implementation files
+
+- `pysbagen/living_sessions.py`
+- `pysbagen/session_cli.py`
+- `pysbagen/tests/test_living_sessions.py`
+- `docs/research/HTE_LIVING_SESSIONS_GAP_SYNTHESIS_2026_07_31.md`
+- `docs/product/LIVING_SESSIONS_GUIDE.md`
+
+## Definition of done
+
+This train is complete only when:
+
+- continued use creates honest new value;
+- exact return and disclosed variation both work;
+- user memory never weakens recipe provenance;
+- local history remains inspectable and reversible;
+- backend selection remains explicit;
+- native DSP is not duplicated;
+- no manipulative retention mechanism is introduced;
+- full tests and package builds are green;
+- queued visual, confluence, echo-weaving, capsule, and cross-product work is either delivered or handed off explicitly.

--- a/.beads/pysbagen_living_sessions_train_2026_07_31.md
+++ b/.beads/pysbagen_living_sessions_train_2026_07_31.md
@@ -1,94 +1,74 @@
 # PySbagen Living Sessions Product Train
 
 **Date:** July 31, 2026  
-**Status:** Active — first complete return loop implemented  
+**Status:** Wave 1 complete and qualified; Wave 2 product queue active  
 **Branch:** `agent/living-sessions-train-20260731`  
+**Pull request:** `#12` — Build memorable Living Sessions above the audio engines  
 **Stack base:** `agent/sbagenx-interoperability-train-20260731` / PR `#11`  
-**Research input:** `docs/research/HTE_LIVING_SESSIONS_GAP_SYNTHESIS_2026_07_31.md`
+**Research:** `docs/research/HTE_LIVING_SESSIONS_GAP_SYNTHESIS_2026_07_31.md`  
+**Wave 1 receipt:** `.beads/pysbagen_living_sessions_train_2026_07_31_WAVE1_COMPLETION.md`
 
-## Train goal
+## Goal
 
-Make PySbagen a repeatedly useful, memorable personal session system without duplicating SBaGenX DSP and without relying on manipulative engagement mechanics.
+Make PySbagen a repeatedly useful, memorable personal session system without duplicating SBaGenX DSP and without using manipulative retention mechanics.
 
-A completed session must create future value through exact identity, lineage, remembered moments, transparent variation, and optional local learning.
+Repeated use must create honest new value through exact identity, lineage, remembered moments, transparent variation, and optional local learning.
 
-## Product boundary
+## Boundary
 
-### SBaGenX remains responsible for
+### SBaGenX owns
 
 - advanced native SBG/SBGF execution;
-- curves and expression programs;
-- native DSP, export, plotting, authoring, and frontends;
-- future qualified native rendering selected by explicit policy.
+- curves, native DSP, export, plotting, authoring, and frontend work;
+- future qualified native rendering.
 
 ### PySbagen owns
 
 - session identity and exact recipe provenance;
-- human-guided products;
+- guided human products;
 - backend-independent lineage and event records;
 - echoes and remembered moments;
 - transparent variation planning;
-- optional outcome history and descriptive local pattern detection;
+- optional outcome history and descriptive local patterns;
 - local-first archives and exportable receipts.
 
 ## Anti-patterns
 
 - no points, badges, loot mechanics, leaderboards, or coercive streaks;
 - no hidden parameter changes;
-- no random frequency generation outside validated product choices;
+- no random frequency invention outside validated product choices;
 - no cloud account requirement;
 - no opaque recommendation model;
 - no medical-efficacy inference;
-- no copying HTE runtime code into PySbagen;
-- no changing the stated user problem merely to manufacture novelty.
+- no copied HTE runtime code;
+- no changing the user's stated problem merely to manufacture novelty.
 
 ---
 
-## LIV-001 — HTE and InvisiSynth product-gap synthesis
+# Wave 1 — Complete
+
+## LIV-001 — HTE and InvisiSynth gap synthesis
 
 **Status:** complete
 
-Applied the supplied HTE-Newest pack's InvisiSynth, Learning, Affect, Parallel Oracle, Synthesis, Intersection, and Lateral concepts.
-
-**Delivered:**
-
-- `docs/research/HTE_LIVING_SESSIONS_GAP_SYNTHESIS_2026_07_31.md`;
-- explicit domain-gap findings;
-- cross-domain mechanism table;
-- anti-drawer acceptance test;
-- rejected manipulative or disposable concepts.
+Applied the supplied HTE pack's InvisiSynth, Learning, Affect, Parallel Oracle, Synthesis, Intersection, and Lateral mechanisms. Recorded gaps, combinations, rejected ideas, and anti-drawer acceptance criteria.
 
 ## LIV-002 — Memorable identity bound to exact recipes
 
 **Status:** complete
 
-Delivered deterministic:
+Delivered deterministic two-word titles, three unique motifs, exact recipe SHA-256, stable lineage IDs, unique occurrence IDs, parents, and generations.
 
-- two-word session title;
-- three-word motif;
-- recipe SHA-256;
-- stable lineage ID;
-- unique session occurrence ID;
-- human memory phrase that never replaces machine provenance.
+Human identity never replaces machine provenance.
 
-## LIV-003 — Return, branch, contrast, and wander modes
+## LIV-003 — Return, branch, contrast, and wander
 
 **Status:** complete
 
-Delivered four explicit routes:
-
 - `return` — exact recipe and remembered identity;
 - `branch` — exactly one disclosed change;
-- `contrast` — one high-salience disclosed change;
-- `wander` — at most two compatible disclosed changes, marked experimental and less causally interpretable.
-
-Current mutation dimensions are restricted to existing product-level controls:
-
-- generated-bed seed;
-- duration;
-- intensity;
-- sound world and its user-audio binding;
-- one underlying layer toggle.
+- `contrast` — exactly one high-salience audible change; seed-only novelty is excluded when an audible choice exists;
+- `wander` — at most two compatible disclosed changes, marked less causally interpretable.
 
 The stated sleep problem remains unchanged.
 
@@ -96,78 +76,47 @@ The stated sleep problem remains unchanged.
 
 **Status:** complete
 
-Delivered a platform-local archive containing:
-
-- immutable plan JSON;
-- append-only event JSONL;
-- immutable outcome JSON;
-- content-derived identifiers;
-- idempotent plan creation;
-- lineage queries;
-- chronological session listing.
+Delivered immutable plan JSON, append-only event JSONL, immutable outcome JSON, idempotent creation, lineage queries, and chronological listing.
 
 ## LIV-005 — Echo memory markers
 
 **Status:** complete
 
-Delivered named `echo`, `shift`, `insight`, `discomfort`, and custom events with:
+Delivered named echo, shift, insight, discomfort, and custom events with optional transport positions and structured local payloads.
 
-- session/lineage identity;
-- optional transport position;
-- timestamp;
-- human label;
-- optional structured payload.
-
-Echoes remain metadata anchors. Audio extraction/recomposition is deferred to a later orchestration bead.
+Echoes are metadata anchors; audio extraction remains deferred.
 
 ## LIV-006 — Affect-tagged optional outcomes
 
 **Status:** complete
 
-Delivered optional:
+Delivered optional pre/post valence, arousal, and agency; rating; comfort; would-repeat; notes; tags; and immutable outcome history.
 
-- pre-session valence, arousal, and agency snapshot;
-- post-session snapshot;
-- rating;
-- comfort state;
-- would-repeat signal;
-- notes and tags;
-- immutable outcome records.
-
-These records are personal description, not clinical measurement.
+These are personal descriptive records, not clinical measurements.
 
 ## LIV-007 — Transparent next-mode recommendation
 
 **Status:** complete
 
-Delivered simple explainable rules:
+Rules are explicit:
 
 - no outcome → branch;
-- uncomfortable or low-rated outcome → contrast;
-- strong first outcome with repeat intent → exact return;
+- uncomfortable or rating 1–2 → contrast;
+- strong first result with repeat intent → return;
 - repeated strong exact return → branch;
 - otherwise → branch.
-
-No hidden score or remote model is involved.
 
 ## LIV-008 — Personal atlas
 
 **Status:** complete
 
-Delivered:
+Delivered session/lineage/echo counts, optional average rating and repeat rate, affect deltas, lineage title histories, and descriptive local pattern candidates after repeated observations.
 
-- planned, active, completed, lineage, and echo counts;
-- average optional rating;
-- would-repeat rate;
-- average recorded affect delta;
-- lineage title histories;
-- descriptive sound-world and mode pattern candidates after repeated observations.
-
-## LIV-009 — Living Sessions CLI
+## LIV-009 — Product CLI
 
 **Status:** complete
 
-Delivered `sbgpy-session` commands:
+Delivered `sbgpy-session`:
 
 - `new-sleep`;
 - `next`;
@@ -178,111 +127,82 @@ Delivered `sbgpy-session` commands:
 - `render`;
 - `atlas`.
 
-The render command reconstructs and validates the exact stored SleepRequest, renders through the current Python backend, hashes the output, and appends a backend/recipe/output event receipt.
+Rendering reconstructs the exact stored request and records recipe, actual backend, backend reason, output properties, and output SHA-256.
+
+Backend policy is fail-closed:
+
+- `python` → Python;
+- `auto` → currently Python with recorded reason;
+- `sbagenx` → refusal until native rendering is qualified.
 
 ## LIV-010 — Qualification and package integration
 
-**Status:** in progress
+**Status:** complete
 
-Required:
+GitHub Actions Python qualification run `#57` passed:
 
-- Python 3.10–3.13 test matrix;
-- complete repository tests;
-- source distribution and wheel build;
-- wheel contains `living_sessions.py` and `session_cli.py`;
-- installed `sbgpy-session --help` works;
-- no regression in PR #11 interoperability, SBGF, DRG, library, rendering, or Sleep Guide paths;
-- review comments and nits resolved where compatible with product philosophy.
+- Python 3.10 — passed;
+- Python 3.11 — passed;
+- Python 3.12 — passed;
+- Python 3.13 — passed;
+- **68 tests passed**;
+- source distribution and wheel built;
+- wheel includes Living Sessions runtime, policy, and CLI modules;
+- SPDX license metadata removed the previous setuptools license-table warning.
+
+Review truth:
+
+- self-review found and fixed seed-only contrast and silent native-policy fallback;
+- Bugbot was unavailable;
+- CodeRabbit auto-review skipped the stacked base;
+- manual CodeRabbit request produced success status but no submitted review or inline thread at receipt time.
+
+---
+
+# Wave 2 — Product Queue
 
 ## LIV-011 — Constellation view
 
-**Status:** queued
+**Status:** next
 
-Build a visual or TUI graph showing:
+Build an offline visual/TUI graph showing roots, returns, branches, edge mutations, echoes, outcomes, backend identities, and hashes on demand.
 
-- root sessions;
-- returns and branches;
-- mutations on edges;
-- echoes on nodes;
-- outcome context;
-- backend identity;
-- source/recipe hashes on demand.
-
-The graph must remain useful with no network connection.
+This must be a usable navigation surface, not a decorative graph.
 
 ## LIV-012 — Confluence sessions
 
-**Status:** queued after lineage qualification
+**Status:** queued after constellation foundation
 
-Combine two understood lineages while preserving both parent identities.
+Combine two understood lineages while preserving both parents, checking compatible dimensions, disclosing all inheritance/changes, marking reduced causal interpretability, and remaining exactly reproducible.
 
-Requirements:
+## LIV-013 — Echo Weaving
 
-- two-parent provenance;
-- compatible-dimension checks;
-- every inherited and changed dimension disclosed;
-- no silent blending of contradictory intents;
-- mark lower causal interpretability;
-- exact reproducibility.
+**Status:** queued after upstream cue verification
 
-## LIV-013 — Echo weaving
-
-**Status:** queued after one-shot cue verification
-
-Turn selected echoes into backend-independent orchestration anchors:
-
-- structural reprise;
-- cue trigger;
-- gentle contrast point;
-- marker-relative event;
-- no blind audio copying;
-- complete receipt.
-
-Coordinate with SBX-011 so SBaGenX capabilities are not duplicated.
+Turn selected echoes into structural or cue anchors above either renderer. Coordinate with SBX-011; do not duplicate native DSP or blindly copy rendered audio.
 
 ## LIV-014 — Shareable seed capsule
 
 **Status:** queued
 
-Export a self-contained identity and recipe capsule that includes:
-
-- exact recipe/source hashes;
-- title and motif;
-- lineage summary;
-- backend requirements;
-- optional referenced media manifest;
-- no personal affect/outcome history unless explicitly selected.
+Export exact identity, recipe/source hashes, lineage summary, backend requirements, and referenced-media manifest. Exclude personal affect/outcome history by default.
 
 ## LIV-015 — Cross-product Living Sessions
 
 **Status:** queued
 
-Generalize the archive and lineage model beyond Sleep Guide to:
-
-- imported SBG sessions;
-- native-required SBGF programs;
-- research protocols;
-- future guided creativity, pain, cessation, or focus products;
-- Python and SBaGenX backends through the same experience layer.
+Generalize the model to imported SBG, native-required SBGF, research protocols, future guided products, and both Python/SBaGenX backends.
 
 ## Current implementation files
 
 - `pysbagen/living_sessions.py`
+- `pysbagen/living_session_policy.py`
 - `pysbagen/session_cli.py`
 - `pysbagen/tests/test_living_sessions.py`
 - `docs/research/HTE_LIVING_SESSIONS_GAP_SYNTHESIS_2026_07_31.md`
 - `docs/product/LIVING_SESSIONS_GUIDE.md`
+- `.beads/pysbagen_living_sessions_train_2026_07_31_WAVE1_COMPLETION.md`
 
-## Definition of done
+## Next execution target
 
-This train is complete only when:
-
-- continued use creates honest new value;
-- exact return and disclosed variation both work;
-- user memory never weakens recipe provenance;
-- local history remains inspectable and reversible;
-- backend selection remains explicit;
-- native DSP is not duplicated;
-- no manipulative retention mechanism is introduced;
-- full tests and package builds are green;
-- queued visual, confluence, echo-weaving, capsule, and cross-product work is either delivered or handed off explicitly.
+Run **LIV-011 — Constellation view** as the next product train. Do not reopen Wave 1 as another audit layer unless a real regression appears.

--- a/.beads/pysbagen_living_sessions_train_2026_07_31_WAVE1_COMPLETION.md
+++ b/.beads/pysbagen_living_sessions_train_2026_07_31_WAVE1_COMPLETION.md
@@ -1,0 +1,134 @@
+# PySbagen Living Sessions — Wave 1 Completion Receipt
+
+**Date:** July 31, 2026  
+**Status:** Complete and qualified  
+**Branch:** `agent/living-sessions-train-20260731`  
+**Pull request:** `#12` — Build memorable Living Sessions above the audio engines  
+**Stack base:** PR `#11` / `agent/sbagenx-interoperability-train-20260731`
+
+## Product delivered
+
+Wave 1 turns a disposable rendered session into a continuing, local-first experience with:
+
+- a deterministic human title and three-word motif bound to the exact recipe hash;
+- stable lineage, parent, generation, and unique session-occurrence identity;
+- exact `return` sessions;
+- one-change `branch` sessions;
+- one-audible-change `contrast` sessions;
+- bounded two-change `wander` sessions marked as less causally interpretable;
+- append-only echoes and session events;
+- optional before/after valence, arousal, and agency context;
+- immutable rating, comfort, would-repeat, note, and tag outcomes;
+- transparent next-mode rules;
+- a local personal atlas;
+- exact stored SleepRequest reconstruction and rendering;
+- backend-policy, recipe, output, and output-SHA-256 receipts.
+
+## Product boundary retained
+
+Wave 1 adds no duplicate native DSP.
+
+- SBaGenX remains the optional advanced native SBG/SBGF engine.
+- PySbagen owns session identity, memory, lineage, outcomes, and orchestration above either backend.
+- `python` plans render through Python.
+- `auto` plans currently select Python and record why.
+- `sbagenx`-required plans fail closed until native rendering is qualified.
+
+## HTE / InvisiSynth use
+
+The project-owner supplied `HTE-Newest.zip` was inspected as a reasoning corpus. The synthesis used:
+
+- InvisiSynth gap detection;
+- Learning prediction/outcome/mismatch loops;
+- Affect-tagged memory;
+- Parallel Oracle combination search;
+- Synthesis, Intersection, and Lateral mechanisms.
+
+No HTE scripts, private configuration, or runtime dependencies were copied into PySbagen.
+
+The applied research receipt is:
+
+- `docs/research/HTE_LIVING_SESSIONS_GAP_SYNTHESIS_2026_07_31.md`
+
+## Files delivered
+
+Runtime:
+
+- `pysbagen/living_sessions.py`
+- `pysbagen/living_session_policy.py`
+- `pysbagen/session_cli.py`
+- public exports in `pysbagen/__init__.py`
+- `sbgpy-session` package entry point
+
+Tests:
+
+- `pysbagen/tests/test_living_sessions.py`
+
+Documentation:
+
+- `docs/product/LIVING_SESSIONS_GUIDE.md`
+- `docs/research/HTE_LIVING_SESSIONS_GAP_SYNTHESIS_2026_07_31.md`
+- `.beads/pysbagen_living_sessions_train_2026_07_31.md`
+- this completion receipt
+- updated `docs/planning/CURRENT_PRODUCT_PRIORITY.md`
+
+## Qualification
+
+GitHub Actions Python qualification run `#57` passed on implementation head `09f1fb50f294b6e59aee23d85c699639321b14df`:
+
+- Python 3.10 product-path tests — passed;
+- Python 3.11 product-path tests — passed;
+- Python 3.12 product-path tests — passed;
+- Python 3.13 product-path tests — passed;
+- complete repository result — **68 tests passed**;
+- Python 3.12 source distribution — passed;
+- Python 3.12 wheel build — passed;
+- wheel includes all three Living Sessions runtime modules;
+- modern SPDX license metadata removed the previous license-table deprecation warning.
+
+Focused Wave 1 coverage includes:
+
+- deterministic memorable identity;
+- three unique motifs;
+- exact return identity;
+- one-change branch;
+- audible, non-seed-only contrast;
+- bounded wander;
+- append-only echoes;
+- immutable outcomes;
+- affect-delta atlas summaries;
+- transparent automatic return/branch progression;
+- refusal to render a native-required plan through Python.
+
+## Review state
+
+- PR is mergeable.
+- Bugbot is not enabled for the account and performed no review.
+- CodeRabbit automatic review was skipped because the PR is stacked on a non-default base.
+- A manual `@coderabbitai review` request was posted.
+- At the time of this receipt, CodeRabbit reported a successful status but produced no submitted review and no inline threads.
+- Self-review found and fixed two policy errors before qualification:
+  1. contrast could select seed-only novelty;
+  2. native-required plans could silently render through Python.
+
+## Anti-drawer acceptance
+
+Wave 1 passes the initial anti-drawer test because continued use creates new, inspectable value:
+
+- exact past experiences can be returned to;
+- variations disclose what changed;
+- marked moments remain available as echoes;
+- outcomes remain immutable history;
+- lineages and the atlas become more informative over time;
+- no points, badges, streak pressure, social ranking, cloud account, or hidden recommendation model is required.
+
+## Next queued wave
+
+Wave 2 remains product work, not an audit loop:
+
+1. constellation lineage visualization;
+2. two-parent Confluence sessions;
+3. Echo Weaving into backend-independent orchestration;
+4. shareable seed capsules without personal history by default;
+5. Living Sessions for imported SBG, native-required SBGF, and research protocols;
+6. SBaGenX native rendering beneath the same session and receipt layer.

--- a/docs/planning/CURRENT_PRODUCT_PRIORITY.md
+++ b/docs/planning/CURRENT_PRODUCT_PRIORITY.md
@@ -1,7 +1,7 @@
 # PySbagen Current Product Priority
 
 **Date:** July 31, 2026  
-**Status:** Compatibility delivered; SBaGenX interoperability and PySbagen differentiation are the active priority
+**Status:** Compatibility and native validation foundations delivered; Living Sessions is the active differentiated product train
 
 ## Delivered compatibility foundation
 
@@ -16,113 +16,139 @@ Delivered capabilities remain:
 5. audio-source and listening-path qualification;
 6. local-first provenance library.
 
-## Product-direction correction
+## Product boundary
 
-A source-level review of `lm7137/SBaGenX` showed that the broad Python workstation plan would duplicate the active modern SBaGen lineage. SBaGenX already provides substantial native engine, `.sbg`/`.sbgf`, curve, mix-effect, live-control, multivoice, export, plotting, packaging, desktop, and Android work.
+A source-level review of `lm7137/SBaGenX` showed that rebuilding the modern SBaGen workstation in Python would duplicate active native work.
 
 Therefore:
 
-> PySbagen will not rebuild SBaGenX in Python.
+> SBaGenX performs advanced native SBaGen DSP and authoring. PySbagen preserves, explains, guides, remembers, and learns locally.
 
-The broad workstation recreation train is retained only as a superseded record:
+The broad workstation recreation train remains only as a superseded record:
 
 - `.beads/pysbagen_experimenter_workstation_train_2026_07_31.md`
 
-## Active priority
-
-Authoritative boundary:
+The authoritative boundary remains:
 
 - `docs/planning/SBAGENX_DIFFERENTIATION_AND_INTEROP_MATRIX.md`
 
-Active implementation train:
+## Stacked active work
 
-- `.beads/pysbagen_sbagenx_interoperability_train_2026_07_31.md`
+### Interoperability foundation
 
-Active branch and PR:
+Branch and PR:
 
 - `agent/sbagenx-interoperability-train-20260731`
 - PR `#11` — **Differentiate PySbagen and begin SBaGenX interoperability**
 
-## Product responsibilities
+Delivered there:
 
-### SBaGenX
+- optional SBaGenX executable/library discovery;
+- truthful candidate-versus-qualified status;
+- exact API-47 ctypes validation contract;
+- combined PySbagen/SBaGenX source-hash-bound discrepancy reports;
+- first-class SBGF preservation and local-library storage;
+- Python 3.10–3.13 qualification with 59 tests and a successful package build.
 
-Treat SBaGenX as the optional advanced native SBaGen engine for:
+Native rendering remains intentionally disabled until SBX-006 delivers typed render/context/writer bindings, parity fixtures, explicit selection policy, and complete receipts in the same change.
 
-- advanced SBG sequencing and DSP;
-- `.sbgf` curves and built-in programs;
-- native validation and future optional rendering;
-- mixspin/mixbeat/mixpulse/mixam;
-- native live parameter controls;
-- multiple voices, auxiliary tones, plotting, export, and frontend work.
+### Active product train — Living Sessions
 
-### PySbagen
+Branch:
 
-Keep PySbagen focused on:
+- `agent/living-sessions-train-20260731`
 
-- SBG/SBGF/DRG inspection and preservation;
-- explicit compatibility-loss reports;
-- immutable protocol/package/session/output provenance;
-- local-first protocol library;
-- audio-source and listening-path qualification;
-- guided human-question products;
-- backend-independent session markers and event ledger;
-- outcome history and local preference learning;
-- evidence-position and claim provenance;
-- consent-aware research workflows;
-- one-shot cue/session orchestration only after checking upstream.
+Train:
 
-SBaGenX remains optional. The Python renderer remains the portable fallback and current guided-product engine.
+- `.beads/pysbagen_living_sessions_train_2026_07_31.md`
 
-## Implementation delivered on the active branch
+Research synthesis:
 
-### Backend discovery and qualification
+- `docs/research/HTE_LIVING_SESSIONS_GAP_SYNTHESIS_2026_07_31.md`
 
-- `pysbagen/sbagenx_backend.py`
-- `sbgpy-inspect backend`
-- executable/library discovery, candidate-versus-usable status, version/API identity, and symbol-backed capabilities
+The train uses the project-owner supplied `HTE-Newest.zip` as a reasoning source, especially its InvisiSynth, Learning, Affect, Parallel Oracle, Synthesis, Intersection, and Lateral concepts. No HTE runtime code is vendored.
 
-### Typed native validation
+## Why Living Sessions is first
 
-- `pysbagen/sbagenx_native.py`
-- exact API-47 ctypes signatures and diagnostic layout
-- fail-closed unknown-API, missing-symbol, malformed-pointer, and false-banner behavior
-- immutable source byte count and SHA-256
-- SBG/SBGF diagnostics with severity, code, location, range, and message
-- native library/version/API identity in deterministic reports
+A more capable renderer does not by itself create a product someone returns to.
 
-### Combined compatibility truth
+PySbagen's differentiation is the continuing experience above either backend:
 
-- `pysbagen/interoperability.py`
-- `sbgpy-inspect backend --validate SOURCE`
-- PySbagen compatibility disposition and SBaGenX validity remain separate
-- exact-source identity comparison
-- explicit discrepancies for cross-engine acceptance/rejection and semantic differences
-- native success cannot erase PySbagen blockers, missing sources, unsupported states, or approximations
+- memorable identities bound to exact recipe hashes;
+- exact returns instead of disposable regenerated files;
+- one-variable branches for understandable learning;
+- high-salience contrast after poor outcomes;
+- bounded two-change wander experiments;
+- local echoes and remembered moments;
+- optional affect-tagged outcomes;
+- transparent next-mode recommendations;
+- a personal lineage atlas that becomes more useful with honest history.
 
-### First-class SBGF preservation
+This is not a badge or streak layer. Continued use creates value because the archive gains memory, the user gains reproducible choices, and future sessions can build on known lineages.
 
-- `pysbagen/sbgf.py`
-- ordinary `sbgpy-inspect inspect SOURCE.sbgf`
-- immutable bytes/hash/encoding
-- parameters, solve directives, assignments, function inventory, media dependencies, and unknown-line preservation
-- local content-addressed library storage and offline verification
-- explicit `inspection-only` state and native-runtime requirement
-- no invented replacement curve language or fake SBG timeline
+## Current Living Sessions implementation
 
-## Next implementation bead
+### Identity and provenance
 
-**SBX-006 — Optional native render backend with receipts** is next.
+- deterministic two-word title;
+- deterministic three-word motif;
+- exact recipe SHA-256;
+- stable lineage ID;
+- unique session occurrence ID;
+- parent and generation records.
 
-Native rendering remains deliberately disabled until the same change delivers:
+### Variation modes
 
-- exact typed context/render/writer bindings and cleanup;
-- representative parity/discrepancy fixtures;
-- explicit `python`, `sbagenx`, and capability-gated `auto` policy;
-- source/backend/API/configuration/output-hash receipts;
-- preserved Python fallback and guided-product behavior.
+- `return` — exact recipe, title, and motif;
+- `branch` — exactly one disclosed product-level change;
+- `contrast` — one high-salience disclosed change;
+- `wander` — at most two compatible disclosed changes, marked less causally interpretable.
 
-The current implementation passed Python 3.10–3.13 qualification with **59 tests** and a successful source distribution/wheel build.
+The user's stated sleep problem is never silently changed.
+
+### Local memory
+
+- immutable plan JSON;
+- append-only event/echo JSONL;
+- immutable optional outcome JSON;
+- before/after valence, arousal, and agency context;
+- rating, comfort, would-repeat, notes, and tags;
+- lineage and echo queries.
+
+### Personal atlas
+
+- session and lineage counts;
+- completion and echo counts;
+- optional average rating and would-repeat rate;
+- optional average affect delta;
+- lineage title history;
+- descriptive local pattern candidates after repeated observations.
+
+Patterns remain descriptive personal records, not medical-efficacy claims.
+
+### Product command
+
+- `sbgpy-session new-sleep`
+- `sbgpy-session render`
+- `sbgpy-session mark`
+- `sbgpy-session finish`
+- `sbgpy-session next`
+- `sbgpy-session show`
+- `sbgpy-session list`
+- `sbgpy-session atlas`
+
+The current render path reconstructs the exact stored SleepRequest and records the actual Python backend, recipe identity, and output hash. Future SBaGenX rendering will plug into the same experience layer through an explicit qualified backend policy.
+
+## Next original product work
+
+After the first Living Sessions foundation qualifies:
+
+1. constellation visualization of lineages, mutations, echoes, and outcomes;
+2. two-parent Confluence sessions with complete inherited-dimension receipts;
+3. Echo Weaving into backend-independent cue/orchestration anchors;
+4. shareable seed capsules without personal history by default;
+5. Living Sessions for imported SBG, native-required SBGF, and research protocols;
+6. resume SBX-006 native rendering beneath the same session identity and receipt layer.
 
 ## Creativity status
 
@@ -131,17 +157,18 @@ The creativity research remains preserved in:
 - `docs/research/CREATIVITY_AUDIO_RESEARCH_FOUNDATIONS.md`
 - `docs/planning/CREATIVITY_PRODUCT_GAP_CHECK.md`
 
-**Creativity implementation remains deferred.** Interoperability and the differentiated session-intelligence foundation take precedence.
+Creativity implementation remains deferred. Living Sessions and SBaGenX interoperability establish the durable product foundation creativity will later use.
 
 ## Completion rule
 
 This priority is complete only when:
 
-- native integration is version- and symbol-gated;
-- native validation and rendering cannot bypass compatibility truth or provenance;
+- native integration cannot bypass compatibility truth or provenance;
 - SBGF and DRG remain first-class preserved artifacts;
 - backend choice is visible and reproducible;
 - Python fallback remains supported;
-- PySbagen-owned session/event/outcome features work above either backend;
+- session identity and memory work above either backend;
+- repeated use creates transparent new value without manipulative engagement;
+- local outcome history remains optional, inspectable, and non-medical;
 - full tests and package builds pass before merge;
-- verify-later rows are resolved rather than guessed.
+- remaining visual, confluence, echo-weaving, capsule, cross-product, and native-render work is delivered or handed off explicitly.

--- a/docs/planning/CYCLOSIDE_LIVING_SESSIONS_PERMISSION_GATE.md
+++ b/docs/planning/CYCLOSIDE_LIVING_SESSIONS_PERMISSION_GATE.md
@@ -1,0 +1,33 @@
+# Cycloside × Living Sessions — Permission-Gated Side Note
+
+**Recorded:** July 31, 2026  
+**Status:** Future question only — not approved work
+
+## Observation
+
+Living Sessions may be a useful conceptual or product fit for Cycloside under `/newideas`.
+
+This is preserved only as a side note so the possibility is not forgotten.
+
+## Mandatory permission gate
+
+Before any Cycloside-related pursuit, ask Justin explicitly whether he wants this path explored.
+
+Without explicit permission, do **not**:
+
+- design the integration;
+- perform a gap analysis or architecture pass for it;
+- create a branch, issue, beadtrain, prototype, mockup, or proof of concept;
+- modify Cycloside or PySbagen for this purpose;
+- copy Living Sessions concepts into Cycloside `/newideas`;
+- present the path as active, queued, approved, or inevitable.
+
+General Living Sessions work may continue independently. General Cycloside work may continue independently when requested. The cross-project path remains closed until Justin explicitly opens it.
+
+## Future prompt
+
+At an appropriate future planning point, ask:
+
+> Do you want to explore the permission-gated Living Sessions idea for Cycloside `/newideas`, or should it remain parked?
+
+An answer other than an explicit approval leaves this path parked.

--- a/docs/product/LIVING_SESSIONS_GUIDE.md
+++ b/docs/product/LIVING_SESSIONS_GUIDE.md
@@ -1,0 +1,237 @@
+# PySbagen Living Sessions Guide
+
+**Status:** Initial product foundation  
+**Command:** `sbgpy-session`  
+**Storage:** Local-only by default
+
+## What Living Sessions changes
+
+A PySbagen session is no longer only a generated WAV file. It has:
+
+- a memorable title and motif;
+- an exact recipe SHA-256;
+- a lineage and parent session;
+- a declared variation mode;
+- optional remembered moments called echoes;
+- optional before/after state context;
+- an immutable outcome record;
+- a transparent route to the next session.
+
+The memorable identity never replaces technical provenance. Every variation remains inspectable.
+
+## Create a root sleep session
+
+```bash
+sbgpy-session new-sleep \
+  --problem racing_mind \
+  --sound-world rain_room \
+  --intensity balanced \
+  --duration 45 \
+  --seed 17
+```
+
+Optional pre-session state context:
+
+```bash
+sbgpy-session new-sleep \
+  --problem racing_mind \
+  --sound-world rain_room \
+  --pre-valence -0.4 \
+  --pre-arousal 0.8 \
+  --pre-agency 0.3
+```
+
+Valence is recorded from `-1` to `1`. Arousal and agency are recorded from `0` to `1`. These are personal descriptive notes, not clinical measurements.
+
+The command prints an identity similar to:
+
+```text
+Velvet Threshold · rain / hush / return
+Session: 6f8d...
+Lineage: 3c2a... · generation 0 · mode root
+Recipe SHA-256: ...
+```
+
+Names and motifs are deterministic consequences of exact recipe identity. They are not random labels stored separately from the recipe.
+
+## Render the exact session
+
+```bash
+sbgpy-session render SESSION_ID -o tonight.wav
+```
+
+The command:
+
+1. loads the immutable plan;
+2. reconstructs and validates the stored `SleepRequest`;
+3. renders through the current Python backend;
+4. writes the normal exact sleep recipe manifest;
+5. hashes the output;
+6. appends a render event containing recipe, backend, and output identity.
+
+The plan may declare `python`, `sbagenx`, or `auto` as its future backend policy. The current Living Sessions render command uses the Python backend until the SBaGenX native-render train is qualified. It records the actual backend honestly.
+
+## Mark a memorable echo
+
+```bash
+sbgpy-session mark SESSION_ID \
+  --kind echo \
+  --at 123.5 \
+  --label "The rain became a room"
+```
+
+Other event kinds:
+
+- `shift`;
+- `insight`;
+- `discomfort`;
+- `custom`.
+
+An echo is a metadata anchor, not an extracted audio clip. Later orchestration can use selected echoes without silently copying or modifying audio.
+
+Optional structured payload:
+
+```bash
+sbgpy-session mark SESSION_ID \
+  --kind echo \
+  --label "Warm threshold" \
+  --payload '{"context":"lights off","certainty":"approximate"}'
+```
+
+## Finish with an optional outcome
+
+```bash
+sbgpy-session finish SESSION_ID \
+  --rating 5 \
+  --would-repeat yes \
+  --comfort comfortable \
+  --post-valence 0.4 \
+  --post-arousal 0.2 \
+  --post-agency 0.7 \
+  --tag rain \
+  --tag settled
+```
+
+Outcome records are immutable. The tool does not rewrite history when later sessions differ.
+
+## Choose the next route
+
+Automatic transparent route:
+
+```bash
+sbgpy-session next SESSION_ID --mode auto
+```
+
+Explicit route:
+
+```bash
+sbgpy-session next SESSION_ID --mode return
+sbgpy-session next SESSION_ID --mode branch
+sbgpy-session next SESSION_ID --mode contrast
+sbgpy-session next SESSION_ID --mode wander
+```
+
+### Return
+
+Reuses the exact recipe hash, title, and motif. It creates a new occurrence in the same lineage.
+
+### Branch
+
+Changes exactly one disclosed dimension. This is the preferred mode for learning what mattered.
+
+### Contrast
+
+Changes one high-salience dimension. Automatic mode selects contrast after an uncomfortable or low-rated outcome.
+
+### Wander
+
+Combines at most two compatible disclosed changes. The plan is marked experimental and less causally interpretable.
+
+## Inspect a session
+
+```bash
+sbgpy-session show SESSION_ID
+sbgpy-session show SESSION_ID --json
+```
+
+List all local sessions:
+
+```bash
+sbgpy-session list
+sbgpy-session list --json
+```
+
+## View the personal atlas
+
+```bash
+sbgpy-session atlas
+sbgpy-session atlas --json
+```
+
+The atlas can show:
+
+- session counts by state;
+- lineage count and title history;
+- echo count;
+- optional average rating;
+- optional would-repeat rate;
+- optional average affect delta;
+- descriptive sound-world or variation-mode candidates after repeated observations.
+
+The atlas does not claim medical effectiveness. It describes the user's own recorded history.
+
+## Local storage
+
+Default locations:
+
+- Linux: `$XDG_DATA_HOME/pysbagen/living-sessions` or `~/.local/share/pysbagen/living-sessions`;
+- Windows: `%LOCALAPPDATA%\PySbagen\living-sessions`;
+- macOS currently follows the XDG-style fallback unless `XDG_DATA_HOME` is configured.
+
+Use another root:
+
+```bash
+sbgpy-session --root ./my-session-atlas new-sleep ...
+sbgpy-session --root ./my-session-atlas atlas
+```
+
+Each session directory contains:
+
+- `plan.json` — immutable identity and exact recipe;
+- `events.jsonl` — append-only event and echo ledger;
+- `outcome.json` — optional immutable outcome.
+
+## Automatic recommendation rules
+
+`--mode auto` currently uses deliberately simple rules:
+
+- no outcome → branch;
+- uncomfortable or rating 1–2 → contrast;
+- rating 4–5 plus would-repeat → exact return once;
+- another strong exact return → branch;
+- otherwise → branch.
+
+These rules are visible in code and can be explained from the local record. There is no hidden model or remote scoring service.
+
+## What this deliberately avoids
+
+- points, badges, daily streaks, or leaderboards;
+- undisclosed random changes;
+- opaque personalization;
+- cloud accounts;
+- social comparison;
+- medical claims based on subjective history;
+- replacing SBaGenX DSP;
+- locking the experience layer to one GUI.
+
+## Next product work
+
+The active train records:
+
+- constellation visualization;
+- two-parent confluence sessions;
+- echo weaving into backend-independent orchestration;
+- shareable seed capsules;
+- Living Sessions for imported SBG, SBGF, and research protocols.
+
+See `.beads/pysbagen_living_sessions_train_2026_07_31.md`.

--- a/docs/product/LIVING_SESSIONS_GUIDE.md
+++ b/docs/product/LIVING_SESSIONS_GUIDE.md
@@ -1,6 +1,6 @@
 # PySbagen Living Sessions Guide
 
-**Status:** Initial product foundation  
+**Status:** Wave 1 qualified  
 **Command:** `sbgpy-session`  
 **Storage:** Local-only by default
 
@@ -64,12 +64,19 @@ The command:
 
 1. loads the immutable plan;
 2. reconstructs and validates the stored `SleepRequest`;
-3. renders through the current Python backend;
-4. writes the normal exact sleep recipe manifest;
-5. hashes the output;
-6. appends a render event containing recipe, backend, and output identity.
+3. enforces the declared backend policy;
+4. renders only through a currently qualified backend;
+5. writes the normal exact sleep recipe manifest;
+6. hashes the output;
+7. appends a render event containing recipe, backend, reason, and output identity.
 
-The plan may declare `python`, `sbagenx`, or `auto` as its future backend policy. The current Living Sessions render command uses the Python backend until the SBaGenX native-render train is qualified. It records the actual backend honestly.
+Backend behavior in Wave 1:
+
+- `python` — renders through the qualified portable Python backend and records that explicit policy;
+- `auto` — selects Python while native rendering remains unqualified and records the selection reason;
+- `sbagenx` — fails closed instead of silently rendering through Python.
+
+A native-required plan becomes renderable only after the typed SBaGenX render/context/writer and receipt train is qualified.
 
 ## Mark a memorable echo
 
@@ -141,7 +148,7 @@ Changes exactly one disclosed dimension. This is the preferred mode for learning
 
 ### Contrast
 
-Changes one high-salience dimension. Automatic mode selects contrast after an uncomfortable or low-rated outcome.
+Changes exactly one high-salience audible product dimension. Seed-only novelty is excluded whenever an audible contrast is available. Automatic mode selects contrast after an uncomfortable or low-rated outcome.
 
 ### Wander
 
@@ -212,6 +219,19 @@ Each session directory contains:
 - otherwise → branch.
 
 These rules are visible in code and can be explained from the local record. There is no hidden model or remote scoring service.
+
+## Qualification receipt
+
+Wave 1 passed GitHub Actions Python qualification run `#57`:
+
+- Python 3.10 — passed;
+- Python 3.11 — passed;
+- Python 3.12 — passed;
+- Python 3.13 — passed;
+- complete repository result — **68 tests passed**;
+- source distribution and wheel build — passed;
+- wheel contains `living_sessions.py`, `living_session_policy.py`, and `session_cli.py`;
+- modern SPDX license metadata builds without the prior setuptools license-table warning.
 
 ## What this deliberately avoids
 

--- a/docs/research/HTE_LIVING_SESSIONS_GAP_SYNTHESIS_2026_07_31.md
+++ b/docs/research/HTE_LIVING_SESSIONS_GAP_SYNTHESIS_2026_07_31.md
@@ -1,0 +1,224 @@
+# HTE / InvisiSynth Gap Synthesis: Living Sessions
+
+**Date:** July 31, 2026  
+**Source pack:** project-owner supplied `HTE-Newest.zip`  
+**Status:** Applied to product design and implementation  
+**Code boundary:** No HTE engine code was vendored into PySbagen
+
+## Question
+
+What would make PySbagen fun and memorable enough to become a repeatedly used personal system rather than a generator someone tries once and puts in a drawer?
+
+The answer must preserve the product boundary established by the SBaGenX interoperability train:
+
+- SBaGenX owns advanced native SBaGen DSP, SBGF execution, authoring, plotting, export, and frontend work.
+- PySbagen owns compatibility truth, provenance, guided products, local history, personal learning, research records, and backend-independent experience orchestration.
+
+## HTE material used
+
+The reasoning pass used the supplied pack's:
+
+- `11-invisisynth-updated-*` — gap detection, domain-gap analysis, confidence tiers;
+- `08-learning-*` — prediction, outcome, mismatch, and calibration loop;
+- `09-affect-*` — affect-tagged memory and state-context recall;
+- `10-parallel-oracle-*` — explicit combination/permutation search;
+- `06-synthesis-*` — collapse competing ideas into an implementable product;
+- `core-thinking-updated-*` — surprising cross-domain connections;
+- `holo_intersection-*` and `holo_lateral-*` concepts — mechanism intersections and lateral substitutions.
+
+The uploaded scripts were treated as reasoning references. They were not executed against private services, copied into the repository, or made runtime dependencies.
+
+## InvisiSynth gap report
+
+### Gap 1 — The generator is not the relationship
+
+Advanced audio generation, sequencing, and native rendering can be excellent while still producing a disposable experience. A rendered file has no continuing identity, no ancestry, no remembered moments, and no reason to return beyond manually repeating it.
+
+**Confidence:** high. The current repository already had exact recipes, seeds, hashes, manifests, and local library records, but no layer joining them into continuing personal sessions.
+
+### Gap 2 — Repetition and novelty are treated as opposites
+
+Audio products often force a bad choice:
+
+- exact repetition becomes stale;
+- uncontrolled novelty destroys reproducibility and learning.
+
+The missing mechanism is a lineage where the listener can deliberately choose:
+
+- exact return;
+- one-variable branch;
+- high-salience contrast;
+- bounded multi-variable exploration.
+
+Every change remains disclosed and reproducible.
+
+### Gap 3 — Personal history is stored but not made useful
+
+A manifest proves what happened technically. It does not help a person remember:
+
+- which experience felt meaningful;
+- where a shift happened;
+- what they would repeat;
+- which sound worlds or variation modes appear promising;
+- whether a new variation differs in one way or five.
+
+The missing product is an inspectable personal atlas built from immutable local records.
+
+### Gap 4 — Emotional memory is absent from protocol identity
+
+A SHA-256 is exact but not memorable. A marketing title is memorable but often disconnected from the exact recipe.
+
+The bridge is a deterministic human identity generated from the recipe hash:
+
+- evocative two-word title;
+- three-word motif;
+- exact recipe SHA-256 underneath.
+
+The identity is memorable without weakening provenance.
+
+### Gap 5 — Feedback systems usually become either manipulative or vague
+
+Streaks, points, fake achievements, and opaque recommendations create engagement without creating understanding. Pure journaling creates understanding but asks too much effort and may never affect the next session.
+
+The missing middle is:
+
+- an optional small outcome record;
+- transparent next-mode rules;
+- descriptive pattern candidates only after repeated observations;
+- no medical-efficacy inference;
+- no hidden scoring model;
+- no cloud account.
+
+## Cross-domain intersection synthesis
+
+| Domain | Useful mechanism | PySbagen combination |
+|---|---|---|
+| Version control | parent commits, branches, immutable identity | session lineage, parent session, recipe hash |
+| Music | motif, reprise, variation, memorable movement | title/motif identity, exact return, disclosed branch |
+| Experimental design | change one variable to learn causality | branch mode |
+| Procedural generation | deterministic seeds and bounded variation | reproducible generated-bed changes |
+| Journaling | event and outcome memory | echoes, notes, affect snapshots, outcome records |
+| Cartography | locations connected into a meaningful whole | personal session atlas and lineages |
+| Ritual | named return, threshold, remembered moment | stable session identity and echoes without mandatory mysticism |
+| Games | replayability through meaningful choice | return/branch/contrast/wander without points or coercive streaks |
+
+## Original product synthesis
+
+### Living Sessions
+
+A session is no longer a disposable output file. It is a reproducible experience with:
+
+- a memorable identity;
+- exact recipe identity;
+- a lineage;
+- optional state context;
+- append-only events;
+- a later outcome;
+- transparent next routes.
+
+### Four return modes
+
+#### Return
+
+Recreate the exact remembered recipe. Same recipe hash, same title, same motif, new session occurrence.
+
+#### Branch
+
+Change exactly one disclosed product-level dimension. This is the preferred learning mode.
+
+Current dimensions:
+
+- deterministic generated-bed seed;
+- duration;
+- intensity;
+- sound-world binding;
+- one underlying layer toggle.
+
+The stated sleep problem is never silently changed.
+
+#### Contrast
+
+Change one high-salience dimension to deliberately test a clearly different route after a poor or uncomfortable result.
+
+#### Wander
+
+Combine at most two compatible disclosed changes for exploration. The plan explicitly marks the result as less causally interpretable.
+
+### Echoes
+
+An echo is a user-marked moment worth remembering. It records:
+
+- session and lineage identity;
+- optional transport position;
+- a human label;
+- optional local structured payload.
+
+Echoes are not audio extraction yet. A later orchestration bead may turn selected echoes into cue or structural-reprise inputs without copying rendered audio blindly.
+
+### Personal atlas
+
+The atlas reports:
+
+- session, completion, lineage, and echo counts;
+- exact lineage histories;
+- average optional rating and would-repeat rate;
+- average recorded affect delta when before/after snapshots exist;
+- descriptive pattern candidates only after repeated observations.
+
+Patterns are labeled as local descriptive records, not medical conclusions.
+
+## Anti-drawer test
+
+A feature passes only when continued use creates new value.
+
+| Test | Requirement |
+|---|---|
+| Return value | A prior session can be recreated exactly |
+| Memory value | Marked moments and outcomes remain useful later |
+| Learning value | Branches reveal exactly what changed |
+| Surprise value | Exploration is bounded, named, and reproducible |
+| Identity value | A person can remember a session without losing its hash |
+| Accumulation value | The atlas becomes more informative with honest history |
+| Autonomy value | No account, cloud service, streak pressure, or hidden ranking |
+| Backend value | The experience layer works above Python now and SBaGenX later |
+
+## Rejected ideas
+
+- arbitrary badges, points, streaks, or daily-pressure mechanics;
+- random frequencies or undisclosed parameter mutation;
+- fake AI claims based on one session;
+- global leaderboards or social comparison;
+- opaque personalization;
+- importing game terminology directly into the user interface;
+- changing the user's stated problem merely to create novelty;
+- replacing exact recipes with only human-friendly names;
+- burying session memory inside a single GUI.
+
+## Implementation chosen
+
+The first product foundation is implemented as:
+
+- `pysbagen/living_sessions.py`;
+- `pysbagen/session_cli.py`;
+- `sbgpy-session`;
+- local archive under the platform data directory;
+- deterministic identities and lineages;
+- return/branch/contrast/wander planning;
+- exact sleep-recipe reconstruction and rendering;
+- echoes, outcomes, affect snapshots, and atlas summaries;
+- focused tests.
+
+## Next original combinations
+
+These remain product work, not promises that they already exist:
+
+1. **Constellation view** — a visual lineage/echo map rather than a file list.
+2. **Confluence** — combine two well-understood lineages while preserving both parent identities and disclosing every inherited dimension.
+3. **Echo weaving** — use selected remembered moments as structural or cue anchors above either renderer.
+4. **Seasonal return** — surface a remembered session because its context resembles a prior useful context, without push-pressure mechanics.
+5. **Shareable seed capsule** — export a self-contained recipe/lineage identity with no personal outcome history unless explicitly included.
+6. **Mystery with receipts** — reveal the evocative identity first, then show every exact parameter and source identity before playback.
+
+## Confidence and limits
+
+This pass establishes an original product synthesis for this repository. It does not claim worldwide patent novelty or prove that no adjacent product has ever used any individual primitive. The originality is in the explicit combination, product boundary, provenance rules, and implemented local-first loop.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pysbagen"
 version = "0.4.0"
-description = "Local-first SBaGen/DRG compatibility inspector and layered audio studio"
+description = "Local-first SBaGen/DRG compatibility, living-session memory, and layered audio studio"
 readme = "README.md"
-license = {text = "GPL-2.0-only"}
+license = "GPL-2.0-only"
 authors = [{name="Justin (acrinym)"}]
 requires-python = ">=3.10"
 dependencies = [
@@ -29,6 +29,7 @@ sbgpy-inspect = "pysbagen.inspect_cli:main"
 sbgpy-inspect-gui = "inspect_gui:main"
 sbgpy-sleep = "pysbagen.sleep_cli:main"
 sbgpy-sleep-gui = "sleep_gui:main"
+sbgpy-session = "pysbagen.session_cli:main"
 
 [project.entry-points."pysbagen.generators"]
 # Third parties can register generator plugins in this group.

--- a/pysbagen/__init__.py
+++ b/pysbagen/__init__.py
@@ -11,6 +11,19 @@ from .api import (
 from .compatibility import CompatibilityState, ImportReport, RenderDisposition
 from .importers import ImportedArtifact, import_artifact, import_drg, import_sbg
 from .interoperability import EngineDiscrepancy, InteroperabilityReport, inspect_with_sbagenx
+from .living_sessions import (
+    AffectSnapshot,
+    LivingSessionArchive,
+    LivingSessionPlan,
+    SessionEvent,
+    SessionMutation,
+    SessionOutcome,
+    StoredSession,
+    create_child_sleep_plan,
+    create_sleep_plan,
+    recommend_child_mode,
+    sleep_request_from_manifest,
+)
 from .sbagenx_backend import BackendCapability, SBaGenXProbe, probe_sbagenx
 from .sbagenx_native import (
     NativeDiagnostic,
@@ -24,12 +37,15 @@ from .sbgf import import_sbgf
 from .sleep import SleepLayers, SleepRecipe, SleepRequest, build_sleep_recipe
 
 __all__ = [
+    "AffectSnapshot",
     "BackendCapability",
     "CompatibilityState",
     "EngineDiscrepancy",
     "ImportReport",
     "ImportedArtifact",
     "InteroperabilityReport",
+    "LivingSessionArchive",
+    "LivingSessionPlan",
     "NativeDiagnostic",
     "NativeValidationReport",
     "RenderDisposition",
@@ -37,11 +53,17 @@ __all__ = [
     "SBaGenXNative",
     "SBaGenXNativeError",
     "SBaGenXProbe",
+    "SessionEvent",
+    "SessionMutation",
+    "SessionOutcome",
     "SleepLayers",
     "SleepRecipe",
     "SleepRequest",
+    "StoredSession",
     "UnsupportedSBaGenXAPI",
     "build_sleep_recipe",
+    "create_child_sleep_plan",
+    "create_sleep_plan",
     "import_artifact",
     "import_drg",
     "import_sbg",
@@ -49,9 +71,11 @@ __all__ = [
     "inspect_artifact",
     "inspect_with_sbagenx",
     "probe_sbagenx",
+    "recommend_child_mode",
     "render_schedule",
     "render_sleep",
     "render_specs",
+    "sleep_request_from_manifest",
     "validate_sbagenx_source",
     "write_audio",
 ]

--- a/pysbagen/__init__.py
+++ b/pysbagen/__init__.py
@@ -24,6 +24,7 @@ from .living_sessions import (
     recommend_child_mode,
     sleep_request_from_manifest,
 )
+from .living_session_policy import install_living_session_policy
 from .sbagenx_backend import BackendCapability, SBaGenXProbe, probe_sbagenx
 from .sbagenx_native import (
     NativeDiagnostic,
@@ -35,6 +36,8 @@ from .sbagenx_native import (
 )
 from .sbgf import import_sbgf
 from .sleep import SleepLayers, SleepRecipe, SleepRequest, build_sleep_recipe
+
+install_living_session_policy()
 
 __all__ = [
     "AffectSnapshot",

--- a/pysbagen/living_session_policy.py
+++ b/pysbagen/living_session_policy.py
@@ -1,0 +1,107 @@
+"""Centralized variation policy hardening for Living Sessions.
+
+The first Living Sessions model deliberately keeps its data and archive machinery
+in ``living_sessions``. This module owns the product-level mutation selection
+policy so retention behavior can evolve without coupling it to storage.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from . import living_sessions as _living
+from .living_sessions import SessionMutation
+
+
+def install_living_session_policy() -> None:
+    """Install the current explicit mutation and identity policies.
+
+    The assignment is intentional: ``create_child_sleep_plan`` resolves the
+    selector from its module globals at call time. Keeping the policy here makes
+    high-salience contrast rules independently testable and prevents storage
+    code from accumulating engagement heuristics.
+    """
+
+    _living._select_mutations = select_mutations  # type: ignore[attr-defined]
+    _living._identity = memorable_identity  # type: ignore[attr-defined]
+
+
+def select_mutations(
+    candidates: list[SessionMutation],
+    usage: dict[str, int],
+    mode: str,
+    parent_session_id: str,
+) -> list[SessionMutation]:
+    """Select disclosed changes while keeping contrast audibly meaningful."""
+
+    if not candidates:
+        raise ValueError("No valid living-session mutations are available")
+
+    eligible = candidates
+    if mode == "contrast":
+        audible = [item for item in candidates if item.key != "request.seed"]
+        eligible = audible or candidates
+
+    ranked = sorted(
+        eligible,
+        key=lambda item: (
+            usage.get(item.key, 0),
+            contrast_priority(item.key) if mode == "contrast" else 0,
+            _living._short_hash(  # type: ignore[attr-defined]
+                {"parent": parent_session_id, "mode": mode, "key": item.key},
+                16,
+            ),
+        ),
+    )
+    if mode != "wander":
+        return ranked[:1]
+
+    first = ranked[0]
+    for candidate in ranked[1:]:
+        strong_pair = {first.key, candidate.key}
+        if strong_pair in (
+            {"request.intensity", "request.layers.harmonic_box"},
+            {"request.intensity", "request.layers.isochronic"},
+        ):
+            continue
+        return [first, candidate]
+    return [first]
+
+
+def contrast_priority(key: str) -> int:
+    """Rank audible contrast dimensions ahead of subtle or temporal changes."""
+
+    if key == "request.sound_world_bundle":
+        return 0
+    if key == "request.intensity":
+        return 1
+    if key.startswith("request.layers."):
+        return 2
+    if key == "request.duration_minutes":
+        return 3
+    return 9
+
+
+def memorable_identity(recipe_sha256: str, *, generation: int) -> tuple[str, tuple[str, ...]]:
+    """Create a stable human identity and always provide three unique motifs."""
+
+    digest = hashlib.sha256(f"{recipe_sha256}:{generation}".encode("utf-8")).digest()
+    title = (
+        f"{_living._ADJECTIVES[digest[0] % len(_living._ADJECTIVES)]} "  # type: ignore[attr-defined]
+        f"{_living._NOUNS[digest[1] % len(_living._NOUNS)]}"  # type: ignore[attr-defined]
+    )
+    motifs: list[str] = []
+    for value in digest[2:]:
+        motif = _living._MOTIFS[value % len(_living._MOTIFS)]  # type: ignore[attr-defined]
+        if motif not in motifs:
+            motifs.append(motif)
+        if len(motifs) == 3:
+            break
+    if len(motifs) < 3:
+        for motif in _living._MOTIFS:  # type: ignore[attr-defined]
+            if motif not in motifs:
+                motifs.append(motif)
+            if len(motifs) == 3:
+                break
+    return title, tuple(motifs)

--- a/pysbagen/living_sessions.py
+++ b/pysbagen/living_sessions.py
@@ -1,0 +1,787 @@
+"""Local-first living-session identity, lineage, memory, and outcome tracking."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import random
+import tempfile
+from dataclasses import asdict, dataclass, field, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from .sleep import SleepLayers, SleepRequest, build_sleep_recipe, recipe_manifest
+
+SessionMode = Literal["root", "return", "branch", "contrast", "wander"]
+SessionComfort = Literal["comfortable", "neutral", "uncomfortable"]
+BackendPolicy = Literal["python", "sbagenx", "auto"]
+
+_ADJECTIVES = (
+    "Amber",
+    "Blue",
+    "Distant",
+    "Ember",
+    "Hidden",
+    "Liminal",
+    "Moonless",
+    "Moss",
+    "Quiet",
+    "Silver",
+    "Soft",
+    "Velvet",
+)
+_NOUNS = (
+    "Archive",
+    "Bridge",
+    "Cairn",
+    "Chamber",
+    "Constellation",
+    "Current",
+    "Garden",
+    "Harbor",
+    "Lantern",
+    "Signal",
+    "Threshold",
+    "Tide",
+)
+_MOTIFS = (
+    "drift",
+    "ember",
+    "hush",
+    "low-glow",
+    "rain",
+    "return",
+    "ripple",
+    "shadow",
+    "stillness",
+    "threshold",
+    "tide",
+    "warmth",
+)
+
+
+@dataclass(frozen=True)
+class AffectSnapshot:
+    """Small, non-medical emotional-state snapshot used for personal pattern recall."""
+
+    valence: float
+    arousal: float
+    agency: float
+    note: str | None = None
+
+    def __post_init__(self) -> None:
+        if not -1.0 <= float(self.valence) <= 1.0:
+            raise ValueError("valence must be between -1 and 1")
+        if not 0.0 <= float(self.arousal) <= 1.0:
+            raise ValueError("arousal must be between 0 and 1")
+        if not 0.0 <= float(self.agency) <= 1.0:
+            raise ValueError("agency must be between 0 and 1")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "AffectSnapshot | None":
+        return cls(**payload) if payload else None
+
+
+@dataclass(frozen=True)
+class SessionMutation:
+    """One disclosed change between a parent session and its child."""
+
+    key: str
+    before: Any
+    after: Any
+    reason: str
+
+
+@dataclass(frozen=True)
+class LivingSessionPlan:
+    """Reproducible identity and recipe for one session in a continuing lineage."""
+
+    session_id: str
+    lineage_id: str
+    generation: int
+    parent_session_id: str | None
+    mode: SessionMode
+    title: str
+    motif: tuple[str, ...]
+    created_at: str
+    backend_policy: BackendPolicy
+    recipe_manifest: dict[str, Any]
+    recipe_sha256: str
+    mutations: tuple[SessionMutation, ...] = ()
+    rationale: str = ""
+    experimental: bool = False
+    pre_affect: AffectSnapshot | None = None
+    schema_version: str = "pysbagen.living-session-plan.v1"
+
+    @property
+    def memory_phrase(self) -> str:
+        return f"{self.title} · {' / '.join(self.motif)}"
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["motif"] = list(self.motif)
+        payload["mutations"] = [asdict(item) for item in self.mutations]
+        payload["pre_affect"] = self.pre_affect.to_dict() if self.pre_affect else None
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "LivingSessionPlan":
+        data = dict(payload)
+        data["motif"] = tuple(data.get("motif") or ())
+        data["mutations"] = tuple(SessionMutation(**item) for item in data.get("mutations") or ())
+        data["pre_affect"] = AffectSnapshot.from_dict(data.get("pre_affect"))
+        return cls(**data)
+
+
+@dataclass(frozen=True)
+class SessionEvent:
+    """Append-only event or memorable echo attached to a session."""
+
+    event_id: str
+    session_id: str
+    kind: str
+    created_at: str
+    label: str
+    position_seconds: float | None = None
+    payload: dict[str, Any] = field(default_factory=dict)
+    schema_version: str = "pysbagen.living-session-event.v1"
+
+    def __post_init__(self) -> None:
+        if self.position_seconds is not None and float(self.position_seconds) < 0:
+            raise ValueError("position_seconds cannot be negative")
+        if not self.kind.strip():
+            raise ValueError("event kind cannot be empty")
+        if not self.label.strip():
+            raise ValueError("event label cannot be empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "SessionEvent":
+        return cls(**payload)
+
+
+@dataclass(frozen=True)
+class SessionOutcome:
+    """Optional local check-in that teaches the archive without claiming efficacy."""
+
+    session_id: str
+    completed_at: str
+    rating: int
+    would_repeat: bool
+    comfort: SessionComfort
+    post_affect: AffectSnapshot | None = None
+    note: str | None = None
+    tags: tuple[str, ...] = ()
+    schema_version: str = "pysbagen.living-session-outcome.v1"
+
+    def __post_init__(self) -> None:
+        if not 1 <= int(self.rating) <= 5:
+            raise ValueError("rating must be between 1 and 5")
+        if self.comfort not in {"comfortable", "neutral", "uncomfortable"}:
+            raise ValueError(f"unknown comfort state: {self.comfort}")
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["tags"] = list(self.tags)
+        payload["post_affect"] = self.post_affect.to_dict() if self.post_affect else None
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "SessionOutcome":
+        data = dict(payload)
+        data["tags"] = tuple(data.get("tags") or ())
+        data["post_affect"] = AffectSnapshot.from_dict(data.get("post_affect"))
+        return cls(**data)
+
+
+@dataclass(frozen=True)
+class StoredSession:
+    plan: LivingSessionPlan
+    events: tuple[SessionEvent, ...] = ()
+    outcome: SessionOutcome | None = None
+
+    @property
+    def status(self) -> str:
+        if self.outcome is not None:
+            return "completed"
+        if any(event.kind == "render" for event in self.events):
+            return "active"
+        return "planned"
+
+
+def default_living_sessions_root() -> Path:
+    if os.name == "nt":
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+        return base / "PySbagen" / "living-sessions"
+    base = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    return base / "pysbagen" / "living-sessions"
+
+
+class LivingSessionArchive:
+    """Local content-addressed archive for plans, events, echoes, and outcomes."""
+
+    def __init__(self, root: str | Path | None = None) -> None:
+        self.root = Path(root).expanduser() if root is not None else default_living_sessions_root()
+        self.sessions_root = self.root / "sessions"
+        self.sessions_root.mkdir(parents=True, exist_ok=True)
+
+    def create(self, plan: LivingSessionPlan) -> StoredSession:
+        path = self.sessions_root / plan.session_id
+        if path.exists():
+            existing = self.get(plan.session_id)
+            if existing.plan.to_dict() != plan.to_dict():
+                raise ValueError(f"Session ID collision: {plan.session_id}")
+            return existing
+        temporary = Path(tempfile.mkdtemp(prefix=f".{plan.session_id}-", dir=self.sessions_root))
+        try:
+            _write_json_atomic(temporary / "plan.json", plan.to_dict())
+            (temporary / "events.jsonl").write_text("", encoding="utf-8")
+            os.replace(temporary, path)
+        except Exception:
+            if temporary.exists():
+                import shutil
+
+                shutil.rmtree(temporary, ignore_errors=True)
+            raise
+        return self.get(plan.session_id)
+
+    def get(self, session_id: str) -> StoredSession:
+        path = self.sessions_root / session_id
+        plan_path = path / "plan.json"
+        if not plan_path.is_file():
+            raise KeyError(f"Living session not found: {session_id}")
+        plan = LivingSessionPlan.from_dict(json.loads(plan_path.read_text(encoding="utf-8")))
+        events: list[SessionEvent] = []
+        events_path = path / "events.jsonl"
+        if events_path.is_file():
+            for line in events_path.read_text(encoding="utf-8").splitlines():
+                if line.strip():
+                    events.append(SessionEvent.from_dict(json.loads(line)))
+        outcome_path = path / "outcome.json"
+        outcome = (
+            SessionOutcome.from_dict(json.loads(outcome_path.read_text(encoding="utf-8")))
+            if outcome_path.is_file()
+            else None
+        )
+        return StoredSession(plan, tuple(events), outcome)
+
+    def list_sessions(self) -> list[StoredSession]:
+        sessions: list[StoredSession] = []
+        for path in sorted(self.sessions_root.iterdir()):
+            if not path.is_dir() or path.name.startswith("."):
+                continue
+            try:
+                sessions.append(self.get(path.name))
+            except (KeyError, OSError, ValueError, json.JSONDecodeError):
+                continue
+        return sorted(sessions, key=lambda item: (item.plan.created_at, item.plan.session_id))
+
+    def lineage(self, lineage_id: str) -> list[StoredSession]:
+        return [item for item in self.list_sessions() if item.plan.lineage_id == lineage_id]
+
+    def append_event(
+        self,
+        session_id: str,
+        *,
+        kind: str,
+        label: str,
+        position_seconds: float | None = None,
+        payload: dict[str, Any] | None = None,
+        created_at: str | None = None,
+    ) -> SessionEvent:
+        self.get(session_id)
+        timestamp = created_at or _utc_now()
+        event_payload = payload or {}
+        event_id = _short_hash(
+            {
+                "session_id": session_id,
+                "kind": kind,
+                "label": label,
+                "position_seconds": position_seconds,
+                "payload": event_payload,
+                "created_at": timestamp,
+            },
+            24,
+        )
+        event = SessionEvent(
+            event_id=event_id,
+            session_id=session_id,
+            kind=kind,
+            created_at=timestamp,
+            label=label,
+            position_seconds=position_seconds,
+            payload=event_payload,
+        )
+        path = self.sessions_root / session_id / "events.jsonl"
+        existing_ids = {item.event_id for item in self.get(session_id).events}
+        if event.event_id not in existing_ids:
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(_canonical_json(event.to_dict()) + "\n")
+        return event
+
+    def finish(self, outcome: SessionOutcome) -> StoredSession:
+        current = self.get(outcome.session_id)
+        path = self.sessions_root / outcome.session_id / "outcome.json"
+        if current.outcome is not None and current.outcome.to_dict() != outcome.to_dict():
+            raise ValueError("Session already has a different outcome; outcomes are immutable")
+        _write_json_atomic(path, outcome.to_dict())
+        return self.get(outcome.session_id)
+
+    def echoes(self) -> list[dict[str, Any]]:
+        echoes: list[dict[str, Any]] = []
+        for item in self.list_sessions():
+            for event in item.events:
+                if event.kind != "echo":
+                    continue
+                echoes.append(
+                    {
+                        "session_id": item.plan.session_id,
+                        "lineage_id": item.plan.lineage_id,
+                        "title": item.plan.title,
+                        "memory_phrase": item.plan.memory_phrase,
+                        "event": event.to_dict(),
+                    }
+                )
+        return sorted(echoes, key=lambda item: item["event"]["created_at"])
+
+    def atlas(self) -> dict[str, Any]:
+        sessions = self.list_sessions()
+        completed = [item for item in sessions if item.outcome is not None]
+        ratings = [item.outcome.rating for item in completed if item.outcome is not None]
+        repeat_votes = [item.outcome.would_repeat for item in completed if item.outcome is not None]
+        affect_deltas: list[dict[str, float]] = []
+        for item in completed:
+            before = item.plan.pre_affect
+            after = item.outcome.post_affect if item.outcome else None
+            if before and after:
+                affect_deltas.append(
+                    {
+                        "valence": after.valence - before.valence,
+                        "arousal": after.arousal - before.arousal,
+                        "agency": after.agency - before.agency,
+                    }
+                )
+        lineages: dict[str, list[StoredSession]] = {}
+        for item in sessions:
+            lineages.setdefault(item.plan.lineage_id, []).append(item)
+        return {
+            "schema": "pysbagen.living-session-atlas.v1",
+            "session_count": len(sessions),
+            "planned_count": sum(item.status == "planned" for item in sessions),
+            "active_count": sum(item.status == "active" for item in sessions),
+            "completed_count": len(completed),
+            "lineage_count": len(lineages),
+            "echo_count": len(self.echoes()),
+            "average_rating": (sum(ratings) / len(ratings)) if ratings else None,
+            "would_repeat_rate": (sum(repeat_votes) / len(repeat_votes)) if repeat_votes else None,
+            "average_affect_delta": _average_deltas(affect_deltas),
+            "lineages": [
+                {
+                    "lineage_id": lineage_id,
+                    "session_count": len(items),
+                    "completed_count": sum(item.outcome is not None for item in items),
+                    "titles": [item.plan.title for item in items],
+                    "latest_session_id": max(items, key=lambda item: item.plan.created_at).plan.session_id,
+                }
+                for lineage_id, items in sorted(lineages.items())
+            ],
+            "pattern_candidates": _pattern_candidates(completed),
+        }
+
+
+def create_sleep_plan(
+    request: SleepRequest,
+    *,
+    pre_affect: AffectSnapshot | None = None,
+    backend_policy: BackendPolicy = "python",
+    created_at: str | None = None,
+) -> LivingSessionPlan:
+    """Create the root of a reproducible sleep-session lineage."""
+
+    recipe = build_sleep_recipe(request)
+    manifest = recipe_manifest(recipe)
+    recipe_sha = _short_hash(manifest, 64)
+    lineage_id = _short_hash({"kind": "sleep", "recipe_sha256": recipe_sha}, 24)
+    timestamp = created_at or _utc_now()
+    title, motif = _identity(recipe_sha, generation=0)
+    session_id = _session_id(
+        lineage_id=lineage_id,
+        parent_session_id=None,
+        generation=0,
+        mode="root",
+        recipe_sha256=recipe_sha,
+        created_at=timestamp,
+    )
+    return LivingSessionPlan(
+        session_id=session_id,
+        lineage_id=lineage_id,
+        generation=0,
+        parent_session_id=None,
+        mode="root",
+        title=title,
+        motif=motif,
+        created_at=timestamp,
+        backend_policy=backend_policy,
+        recipe_manifest=manifest,
+        recipe_sha256=recipe_sha,
+        rationale="A stable root identity for a session that can be returned to, branched, contrasted, or wandered from.",
+        pre_affect=pre_affect,
+    )
+
+
+def create_child_sleep_plan(
+    parent: LivingSessionPlan,
+    *,
+    mode: Literal["return", "branch", "contrast", "wander"] = "branch",
+    archive: LivingSessionArchive | None = None,
+    pre_affect: AffectSnapshot | None = None,
+    created_at: str | None = None,
+) -> LivingSessionPlan:
+    """Create a disclosed child variant while preserving lineage identity."""
+
+    if mode not in {"return", "branch", "contrast", "wander"}:
+        raise ValueError(f"unknown living-session mode: {mode}")
+    request = sleep_request_from_manifest(parent.recipe_manifest)
+    used = _mutation_usage(archive.lineage(parent.lineage_id) if archive else [])
+    mutations: tuple[SessionMutation, ...]
+    if mode == "return":
+        child_request = request
+        mutations = ()
+        rationale = "Return to the exact remembered recipe before introducing more novelty."
+        experimental = False
+    else:
+        candidates = _mutation_candidates(parent, request, mode)
+        selected = _select_mutations(candidates, used, mode, parent.session_id)
+        child_request = _apply_mutations(request, selected)
+        mutations = tuple(selected)
+        experimental = mode == "wander"
+        rationale = {
+            "branch": "Change one disclosed dimension so the archive can learn what mattered.",
+            "contrast": "Change one high-salience dimension to test a clearly different route.",
+            "wander": "Combine two compatible disclosed changes for exploration; treat the result as less causally interpretable.",
+        }[mode]
+
+    manifest = recipe_manifest(build_sleep_recipe(child_request))
+    recipe_sha = _short_hash(manifest, 64)
+    generation = parent.generation + 1
+    timestamp = created_at or _utc_now()
+    if mode == "return":
+        title, motif = parent.title, parent.motif
+    else:
+        title, motif = _identity(recipe_sha, generation=generation)
+    session_id = _session_id(
+        lineage_id=parent.lineage_id,
+        parent_session_id=parent.session_id,
+        generation=generation,
+        mode=mode,
+        recipe_sha256=recipe_sha,
+        created_at=timestamp,
+    )
+    return LivingSessionPlan(
+        session_id=session_id,
+        lineage_id=parent.lineage_id,
+        generation=generation,
+        parent_session_id=parent.session_id,
+        mode=mode,
+        title=title,
+        motif=motif,
+        created_at=timestamp,
+        backend_policy=parent.backend_policy,
+        recipe_manifest=manifest,
+        recipe_sha256=recipe_sha,
+        mutations=mutations,
+        rationale=rationale,
+        experimental=experimental,
+        pre_affect=pre_affect,
+    )
+
+
+def recommend_child_mode(parent: StoredSession, archive: LivingSessionArchive) -> str:
+    """Choose a transparent next mode from local feedback, never a medical claim."""
+
+    outcome = parent.outcome
+    if outcome is None:
+        return "branch"
+    lineage = archive.lineage(parent.plan.lineage_id)
+    exact_returns = sum(
+        item.plan.recipe_sha256 == parent.plan.recipe_sha256 and item.plan.mode == "return"
+        for item in lineage
+    )
+    if outcome.comfort == "uncomfortable" or outcome.rating <= 2:
+        return "contrast"
+    if outcome.rating >= 4 and outcome.would_repeat:
+        return "return" if exact_returns == 0 else "branch"
+    return "branch"
+
+
+def sleep_request_from_manifest(manifest: dict[str, Any]) -> SleepRequest:
+    """Reconstruct a validated SleepRequest from a stored exact recipe manifest."""
+
+    if manifest.get("format") != "pysbagen-sleep-recipe-v1":
+        raise ValueError("Living sleep sessions require a pysbagen-sleep-recipe-v1 manifest")
+    payload = dict(manifest.get("request") or {})
+    layers_payload = payload.get("layers")
+    if layers_payload is not None:
+        payload["layers"] = SleepLayers(**layers_payload)
+    request = SleepRequest(**payload)
+    request.validate()
+    return request
+
+
+def _mutation_candidates(
+    parent: LivingSessionPlan,
+    request: SleepRequest,
+    mode: str,
+) -> list[SessionMutation]:
+    rng = random.Random(int(_short_hash({"session": parent.session_id, "mode": mode}, 16), 16))
+    candidates: list[SessionMutation] = []
+
+    new_seed = rng.randrange(1, 2**31 - 1)
+    if new_seed == request.seed:
+        new_seed = (new_seed + 1) % (2**31 - 1)
+    candidates.append(
+        SessionMutation(
+            "request.seed",
+            request.seed,
+            new_seed,
+            "Change the generated bed/phases while preserving the selected journey structure.",
+        )
+    )
+
+    duration_options = [
+        value
+        for value in (float(request.duration_minutes) - 15.0, float(request.duration_minutes) + 15.0)
+        if 10.0 <= value <= 180.0 and value != float(request.duration_minutes)
+    ]
+    if duration_options:
+        after = rng.choice(duration_options)
+        candidates.append(
+            SessionMutation(
+                "request.duration_minutes",
+                float(request.duration_minutes),
+                after,
+                "Test whether a shorter or longer support window fits this lineage better.",
+            )
+        )
+
+    intensities = ["gentle", "balanced", "immersive"]
+    current_index = intensities.index(request.intensity)
+    if mode == "contrast":
+        intensity_after = intensities[-1 - current_index]
+        if intensity_after == request.intensity:
+            intensity_after = intensities[0 if current_index > 0 else 2]
+    else:
+        adjacent = [
+            intensities[index]
+            for index in (current_index - 1, current_index + 1)
+            if 0 <= index < len(intensities)
+        ]
+        intensity_after = rng.choice(adjacent) if adjacent else request.intensity
+    if intensity_after != request.intensity:
+        candidates.append(
+            SessionMutation(
+                "request.intensity",
+                request.intensity,
+                intensity_after,
+                "Change how present the underlying layers feel without changing the stated sleep problem.",
+            )
+        )
+
+    internal_worlds = ["warm_ambient", "slow_night_music", "rain_room", "deep_night"]
+    world_options = [world for world in internal_worlds if world != request.sound_world]
+    if world_options:
+        world_after = rng.choice(world_options)
+        candidates.append(
+            SessionMutation(
+                "request.sound_world_bundle",
+                {"sound_world": request.sound_world, "user_audio": request.user_audio},
+                {"sound_world": world_after, "user_audio": None},
+                "Move the same intent into a different remembered sound world, with any prior user-audio binding disclosed.",
+            )
+        )
+
+    layers = request.layers or SleepLayers()
+    if mode == "contrast":
+        layer_name = "harmonic_box" if layers.harmonic_box else "isochronic"
+    else:
+        layer_name = rng.choice(["harmonic_box", "isochronic"])
+    layer_after = not getattr(layers, layer_name)
+    layers_after = replace(layers, **{layer_name: layer_after})
+    if layers_after.enabled_names():
+        candidates.append(
+            SessionMutation(
+                f"request.layers.{layer_name}",
+                getattr(layers, layer_name),
+                layer_after,
+                f"{'Enable' if layer_after else 'Remove'} the {layer_name.replace('_', ' ')} layer as one disclosed test.",
+            )
+        )
+    return candidates
+
+
+def _select_mutations(
+    candidates: list[SessionMutation],
+    usage: dict[str, int],
+    mode: str,
+    parent_session_id: str,
+) -> list[SessionMutation]:
+    if not candidates:
+        raise ValueError("No valid living-session mutations are available")
+    ranked = sorted(
+        candidates,
+        key=lambda item: (
+            usage.get(item.key, 0),
+            _short_hash({"parent": parent_session_id, "mode": mode, "key": item.key}, 16),
+        ),
+    )
+    if mode != "wander":
+        return ranked[:1]
+    first = ranked[0]
+    for candidate in ranked[1:]:
+        strong_pair = {first.key, candidate.key}
+        if strong_pair == {"request.intensity", "request.layers.harmonic_box"}:
+            continue
+        if strong_pair == {"request.intensity", "request.layers.isochronic"}:
+            continue
+        return [first, candidate]
+    return [first]
+
+
+def _apply_mutations(request: SleepRequest, mutations: list[SessionMutation]) -> SleepRequest:
+    current = request
+    for mutation in mutations:
+        if mutation.key == "request.seed":
+            current = replace(current, seed=int(mutation.after))
+        elif mutation.key == "request.duration_minutes":
+            current = replace(current, duration_minutes=float(mutation.after))
+        elif mutation.key == "request.intensity":
+            current = replace(current, intensity=str(mutation.after))
+        elif mutation.key == "request.sound_world_bundle":
+            after = dict(mutation.after)
+            current = replace(
+                current,
+                sound_world=str(after["sound_world"]),
+                user_audio=after.get("user_audio"),
+            )
+        elif mutation.key.startswith("request.layers."):
+            layer_name = mutation.key.rsplit(".", 1)[-1]
+            layers = current.layers or SleepLayers()
+            current = replace(current, layers=replace(layers, **{layer_name: bool(mutation.after)}))
+        else:
+            raise ValueError(f"Unsupported living-session mutation: {mutation.key}")
+    current.validate()
+    return current
+
+
+def _mutation_usage(sessions: list[StoredSession]) -> dict[str, int]:
+    usage: dict[str, int] = {}
+    for item in sessions:
+        for mutation in item.plan.mutations:
+            usage[mutation.key] = usage.get(mutation.key, 0) + 1
+    return usage
+
+
+def _identity(recipe_sha256: str, *, generation: int) -> tuple[str, tuple[str, ...]]:
+    digest = hashlib.sha256(f"{recipe_sha256}:{generation}".encode("utf-8")).digest()
+    title = f"{_ADJECTIVES[digest[0] % len(_ADJECTIVES)]} {_NOUNS[digest[1] % len(_NOUNS)]}"
+    motifs: list[str] = []
+    for value in digest[2:]:
+        motif = _MOTIFS[value % len(_MOTIFS)]
+        if motif not in motifs:
+            motifs.append(motif)
+        if len(motifs) == 3:
+            break
+    return title, tuple(motifs)
+
+
+def _session_id(
+    *,
+    lineage_id: str,
+    parent_session_id: str | None,
+    generation: int,
+    mode: str,
+    recipe_sha256: str,
+    created_at: str,
+) -> str:
+    return _short_hash(
+        {
+            "lineage_id": lineage_id,
+            "parent_session_id": parent_session_id,
+            "generation": generation,
+            "mode": mode,
+            "recipe_sha256": recipe_sha256,
+            "created_at": created_at,
+        },
+        24,
+    )
+
+
+def _pattern_candidates(completed: list[StoredSession]) -> list[dict[str, Any]]:
+    patterns: list[dict[str, Any]] = []
+    by_world: dict[str, list[int]] = {}
+    by_mode: dict[str, list[int]] = {}
+    for item in completed:
+        if item.outcome is None:
+            continue
+        request = item.plan.recipe_manifest.get("request") or {}
+        world = str(request.get("sound_world", "unknown"))
+        by_world.setdefault(world, []).append(item.outcome.rating)
+        by_mode.setdefault(item.plan.mode, []).append(item.outcome.rating)
+    for label, values in sorted(by_world.items()):
+        if len(values) >= 2:
+            patterns.append(
+                {
+                    "kind": "sound-world",
+                    "label": label,
+                    "observations": len(values),
+                    "average_rating": sum(values) / len(values),
+                    "claim": "descriptive local pattern only",
+                }
+            )
+    for label, values in sorted(by_mode.items()):
+        if len(values) >= 2:
+            patterns.append(
+                {
+                    "kind": "mode",
+                    "label": label,
+                    "observations": len(values),
+                    "average_rating": sum(values) / len(values),
+                    "claim": "descriptive local pattern only",
+                }
+            )
+    return sorted(patterns, key=lambda item: (-item["average_rating"], item["kind"], item["label"]))
+
+
+def _average_deltas(values: list[dict[str, float]]) -> dict[str, float] | None:
+    if not values:
+        return None
+    return {
+        key: sum(item[key] for item in values) / len(values)
+        for key in ("valence", "arousal", "agency")
+    }
+
+
+def _canonical_json(payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _short_hash(payload: Any, length: int) -> str:
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:length]
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/pysbagen/session_cli.py
+++ b/pysbagen/session_cli.py
@@ -205,6 +205,11 @@ def main(argv: list[str] | None = None) -> int:
 
         if args.command == "render":
             stored = archive.get(args.session_id)
+            if stored.plan.backend_policy == "sbagenx":
+                raise ValueError(
+                    "This plan requires SBaGenX, but native rendering is not qualified yet; "
+                    "use a Python plan or wait for the typed native-render receipt train."
+                )
             request = sleep_request_from_manifest(stored.plan.recipe_manifest)
             outfile = Path(args.outfile or f"{_slug(stored.plan.title)}-{stored.plan.session_id[:8]}.wav")
             result = write_audio(render_sleep(request), outfile)
@@ -224,6 +229,11 @@ def main(argv: list[str] | None = None) -> int:
                     "recipe_sha256": stored.plan.recipe_sha256,
                     "backend_policy": stored.plan.backend_policy,
                     "actual_backend": "python",
+                    "backend_reason": (
+                        "explicit Python policy"
+                        if stored.plan.backend_policy == "python"
+                        else "auto policy selected the qualified portable Python backend; native rendering is not enabled"
+                    ),
                 },
             )
             print(f"Rendered {stored.plan.memory_phrase}")

--- a/pysbagen/session_cli.py
+++ b/pysbagen/session_cli.py
@@ -1,0 +1,362 @@
+"""Command-line loop for memorable, evolving, local-first PySbagen sessions."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+
+from .api import render_sleep, write_audio
+from .living_sessions import (
+    AffectSnapshot,
+    LivingSessionArchive,
+    SessionOutcome,
+    create_child_sleep_plan,
+    create_sleep_plan,
+    recommend_child_mode,
+    sleep_request_from_manifest,
+)
+from .sleep import (
+    INTENSITY_LABELS,
+    PROBLEM_LABELS,
+    SOUND_WORLD_LABELS,
+    SleepRequest,
+    build_sleep_recipe,
+    write_recipe_manifest,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sbgpy-session",
+        description="Create living session lineages, echoes, outcomes, and a local personal atlas.",
+    )
+    parser.add_argument("--root", help="Living-session archive root")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    new_parser = subparsers.add_parser("new-sleep", help="Create a memorable root sleep session")
+    new_parser.add_argument("--problem", choices=sorted(PROBLEM_LABELS), required=True)
+    new_parser.add_argument("--sound-world", choices=sorted(SOUND_WORLD_LABELS), required=True)
+    new_parser.add_argument("--intensity", choices=sorted(INTENSITY_LABELS), default="balanced")
+    new_parser.add_argument("--duration", type=float, default=45.0)
+    new_parser.add_argument("--user-audio")
+    new_parser.add_argument("--seed", type=int, default=0)
+    new_parser.add_argument("--backend-policy", choices=["python", "sbagenx", "auto"], default="python")
+    _add_affect_arguments(new_parser, "pre")
+    new_parser.add_argument("--json", action="store_true", dest="as_json")
+
+    next_parser = subparsers.add_parser("next", help="Create the next return, branch, contrast, or wander")
+    next_parser.add_argument("session_id")
+    next_parser.add_argument("--mode", choices=["auto", "return", "branch", "contrast", "wander"], default="auto")
+    _add_affect_arguments(next_parser, "pre")
+    next_parser.add_argument("--json", action="store_true", dest="as_json")
+
+    show_parser = subparsers.add_parser("show", help="Show one plan, its echoes/events, and outcome")
+    show_parser.add_argument("session_id")
+    show_parser.add_argument("--json", action="store_true", dest="as_json")
+
+    list_parser = subparsers.add_parser("list", help="List the local session atlas chronologically")
+    list_parser.add_argument("--json", action="store_true", dest="as_json")
+
+    mark_parser = subparsers.add_parser("mark", help="Attach a memorable echo or event")
+    mark_parser.add_argument("session_id")
+    mark_parser.add_argument("--kind", choices=["echo", "shift", "insight", "discomfort", "custom"], default="echo")
+    mark_parser.add_argument("--label", required=True)
+    mark_parser.add_argument("--at", type=float, dest="position_seconds")
+    mark_parser.add_argument("--payload", help="Optional JSON object with extra local details")
+
+    finish_parser = subparsers.add_parser("finish", help="Record an optional non-medical outcome check-in")
+    finish_parser.add_argument("session_id")
+    finish_parser.add_argument("--rating", type=int, choices=range(1, 6), required=True)
+    finish_parser.add_argument("--would-repeat", choices=["yes", "no"], required=True)
+    finish_parser.add_argument("--comfort", choices=["comfortable", "neutral", "uncomfortable"], required=True)
+    finish_parser.add_argument("--note")
+    finish_parser.add_argument("--tag", action="append", default=[])
+    _add_affect_arguments(finish_parser, "post")
+
+    render_parser = subparsers.add_parser("render", help="Render the exact stored sleep recipe")
+    render_parser.add_argument("session_id")
+    render_parser.add_argument("-o", "--outfile")
+
+    atlas_parser = subparsers.add_parser("atlas", help="Summarize lineages, echoes, and descriptive local patterns")
+    atlas_parser.add_argument("--json", action="store_true", dest="as_json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    archive = LivingSessionArchive(args.root)
+    try:
+        if args.command == "new-sleep":
+            request = SleepRequest(
+                problem=args.problem,
+                sound_world=args.sound_world,
+                intensity=args.intensity,
+                duration_minutes=args.duration,
+                user_audio=args.user_audio,
+                seed=args.seed,
+            )
+            plan = create_sleep_plan(
+                request,
+                pre_affect=_affect_from_args(args, "pre"),
+                backend_policy=args.backend_policy,
+            )
+            archive.create(plan)
+            _print_plan(plan, args.as_json)
+            return 0
+
+        if args.command == "next":
+            parent = archive.get(args.session_id)
+            mode = recommend_child_mode(parent, archive) if args.mode == "auto" else args.mode
+            plan = create_child_sleep_plan(
+                parent.plan,
+                mode=mode,
+                archive=archive,
+                pre_affect=_affect_from_args(args, "pre"),
+            )
+            archive.create(plan)
+            _print_plan(plan, args.as_json)
+            return 0
+
+        if args.command == "show":
+            stored = archive.get(args.session_id)
+            if args.as_json:
+                print(
+                    json.dumps(
+                        {
+                            "plan": stored.plan.to_dict(),
+                            "status": stored.status,
+                            "events": [event.to_dict() for event in stored.events],
+                            "outcome": stored.outcome.to_dict() if stored.outcome else None,
+                        },
+                        indent=2,
+                        sort_keys=True,
+                    )
+                )
+            else:
+                _print_stored(stored)
+            return 0
+
+        if args.command == "list":
+            sessions = archive.list_sessions()
+            if args.as_json:
+                print(
+                    json.dumps(
+                        [
+                            {
+                                "session_id": item.plan.session_id,
+                                "lineage_id": item.plan.lineage_id,
+                                "title": item.plan.title,
+                                "memory_phrase": item.plan.memory_phrase,
+                                "mode": item.plan.mode,
+                                "generation": item.plan.generation,
+                                "status": item.status,
+                                "rating": item.outcome.rating if item.outcome else None,
+                            }
+                            for item in sessions
+                        ],
+                        indent=2,
+                        sort_keys=True,
+                    )
+                )
+            else:
+                for item in sessions:
+                    rating = f" rating={item.outcome.rating}" if item.outcome else ""
+                    print(
+                        f"{item.plan.session_id}  {item.status:9}  "
+                        f"g{item.plan.generation} {item.plan.mode:8}  {item.plan.memory_phrase}{rating}"
+                    )
+            return 0
+
+        if args.command == "mark":
+            payload = json.loads(args.payload) if args.payload else {}
+            if not isinstance(payload, dict):
+                raise ValueError("--payload must decode to a JSON object")
+            event = archive.append_event(
+                args.session_id,
+                kind=args.kind,
+                label=args.label,
+                position_seconds=args.position_seconds,
+                payload=payload,
+            )
+            print(f"Recorded {event.kind} {event.event_id}: {event.label}")
+            return 0
+
+        if args.command == "finish":
+            outcome = SessionOutcome(
+                session_id=args.session_id,
+                completed_at=_utc_now(),
+                rating=args.rating,
+                would_repeat=args.would_repeat == "yes",
+                comfort=args.comfort,
+                post_affect=_affect_from_args(args, "post"),
+                note=args.note,
+                tags=tuple(sorted(set(args.tag))),
+            )
+            stored = archive.finish(outcome)
+            print(
+                f"Completed {stored.plan.memory_phrase}: rating {outcome.rating}/5, "
+                f"would repeat={'yes' if outcome.would_repeat else 'no'}"
+            )
+            print("Use `sbgpy-session next SESSION_ID --mode auto` for a transparent next step.")
+            return 0
+
+        if args.command == "render":
+            stored = archive.get(args.session_id)
+            request = sleep_request_from_manifest(stored.plan.recipe_manifest)
+            outfile = Path(args.outfile or f"{_slug(stored.plan.title)}-{stored.plan.session_id[:8]}.wav")
+            result = write_audio(render_sleep(request), outfile)
+            recipe_path = write_recipe_manifest(build_sleep_recipe(request), result.outfile)
+            archive.append_event(
+                args.session_id,
+                kind="render",
+                label="Rendered exact living-session recipe",
+                payload={
+                    "output_path": str(result.outfile),
+                    "output_sha256": _sha256_file(result.outfile),
+                    "frames": result.frames,
+                    "sample_rate": result.sample_rate,
+                    "duration": result.duration,
+                    "peak": result.peak,
+                    "recipe_manifest_path": str(recipe_path.resolve()),
+                    "recipe_sha256": stored.plan.recipe_sha256,
+                    "backend_policy": stored.plan.backend_policy,
+                    "actual_backend": "python",
+                },
+            )
+            print(f"Rendered {stored.plan.memory_phrase}")
+            print(f"Audio: {result.outfile}")
+            print(f"Recipe: {recipe_path}")
+            return 0
+
+        if args.command == "atlas":
+            atlas = archive.atlas()
+            if args.as_json:
+                print(json.dumps(atlas, indent=2, sort_keys=True))
+            else:
+                _print_atlas(atlas)
+            return 0
+    except (KeyError, OSError, RuntimeError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"sbgpy-session: {exc}") from exc
+    raise AssertionError(f"Unhandled command: {args.command}")
+
+
+def _add_affect_arguments(parser: argparse.ArgumentParser, prefix: str) -> None:
+    parser.add_argument(f"--{prefix}-valence", type=float)
+    parser.add_argument(f"--{prefix}-arousal", type=float)
+    parser.add_argument(f"--{prefix}-agency", type=float)
+    parser.add_argument(f"--{prefix}-note")
+
+
+def _affect_from_args(args: argparse.Namespace, prefix: str) -> AffectSnapshot | None:
+    values = [
+        getattr(args, f"{prefix}_valence"),
+        getattr(args, f"{prefix}_arousal"),
+        getattr(args, f"{prefix}_agency"),
+    ]
+    if all(value is None for value in values):
+        return None
+    if any(value is None for value in values):
+        raise ValueError(f"Supply all three --{prefix}-valence/--{prefix}-arousal/--{prefix}-agency values")
+    return AffectSnapshot(
+        valence=float(values[0]),
+        arousal=float(values[1]),
+        agency=float(values[2]),
+        note=getattr(args, f"{prefix}_note"),
+    )
+
+
+def _print_plan(plan, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(plan.to_dict(), indent=2, sort_keys=True))
+        return
+    print(plan.memory_phrase)
+    print(f"Session: {plan.session_id}")
+    print(f"Lineage: {plan.lineage_id} · generation {plan.generation} · mode {plan.mode}")
+    print(f"Recipe SHA-256: {plan.recipe_sha256}")
+    print(plan.rationale)
+    if plan.mutations:
+        print("Disclosed changes:")
+        for mutation in plan.mutations:
+            print(f"  {mutation.key}: {mutation.before!r} -> {mutation.after!r}")
+            print(f"    {mutation.reason}")
+    else:
+        print("Disclosed changes: none")
+    if plan.experimental:
+        print("Exploration note: this wander combines changes and is less causally interpretable.")
+
+
+def _print_stored(stored) -> None:
+    _print_plan(stored.plan, False)
+    print(f"Status: {stored.status}")
+    if stored.events:
+        print("Events:")
+        for event in stored.events:
+            at = f" @ {event.position_seconds:.2f}s" if event.position_seconds is not None else ""
+            print(f"  {event.kind}{at}: {event.label}")
+    else:
+        print("Events: none")
+    if stored.outcome:
+        print(
+            f"Outcome: {stored.outcome.rating}/5, comfort={stored.outcome.comfort}, "
+            f"would-repeat={'yes' if stored.outcome.would_repeat else 'no'}"
+        )
+    else:
+        print("Outcome: not recorded")
+
+
+def _print_atlas(atlas: dict) -> None:
+    print("PySbagen Living Session Atlas")
+    print(
+        f"Sessions: {atlas['session_count']} · completed: {atlas['completed_count']} · "
+        f"lineages: {atlas['lineage_count']} · echoes: {atlas['echo_count']}"
+    )
+    if atlas["average_rating"] is not None:
+        print(f"Average local rating: {atlas['average_rating']:.2f}/5")
+    if atlas["would_repeat_rate"] is not None:
+        print(f"Would-repeat rate: {atlas['would_repeat_rate']:.0%}")
+    if atlas["average_affect_delta"]:
+        delta = atlas["average_affect_delta"]
+        print(
+            "Average recorded state delta: "
+            f"valence {delta['valence']:+.2f}, arousal {delta['arousal']:+.2f}, agency {delta['agency']:+.2f}"
+        )
+    if atlas["lineages"]:
+        print("Lineages:")
+        for lineage in atlas["lineages"]:
+            print(
+                f"  {lineage['lineage_id']}: {lineage['session_count']} session(s), "
+                f"{lineage['completed_count']} completed · {' -> '.join(lineage['titles'])}"
+            )
+    if atlas["pattern_candidates"]:
+        print("Descriptive local pattern candidates:")
+        for pattern in atlas["pattern_candidates"]:
+            print(
+                f"  {pattern['kind']}={pattern['label']}: {pattern['average_rating']:.2f}/5 "
+                f"across {pattern['observations']} observations"
+            )
+    print("These are personal descriptive records, not medical-efficacy conclusions.")
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-") or "living-session"
+
+
+def _utc_now() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pysbagen/tests/test_living_sessions.py
+++ b/pysbagen/tests/test_living_sessions.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pysbagen.living_sessions import (
+    AffectSnapshot,
+    LivingSessionArchive,
+    SessionOutcome,
+    create_child_sleep_plan,
+    create_sleep_plan,
+    recommend_child_mode,
+    sleep_request_from_manifest,
+)
+from pysbagen.sleep import SleepRequest
+
+
+def _request() -> SleepRequest:
+    return SleepRequest(
+        problem="racing_mind",
+        sound_world="rain_room",
+        intensity="balanced",
+        duration_minutes=45,
+        seed=17,
+    )
+
+
+def test_root_identity_is_memorable_and_reproducible():
+    before = AffectSnapshot(valence=-0.4, arousal=0.8, agency=0.3)
+    first = create_sleep_plan(_request(), pre_affect=before, created_at="2026-07-31T19:00:00+00:00")
+    second = create_sleep_plan(_request(), pre_affect=before, created_at="2026-07-31T19:00:00+00:00")
+
+    assert first == second
+    assert len(first.title.split()) == 2
+    assert len(first.motif) == 3
+    assert first.memory_phrase.startswith(first.title)
+    assert len(first.recipe_sha256) == 64
+    assert first.mode == "root"
+
+
+def test_branch_changes_exactly_one_disclosed_dimension():
+    root = create_sleep_plan(_request(), created_at="2026-07-31T19:00:00+00:00")
+    child = create_child_sleep_plan(
+        root,
+        mode="branch",
+        created_at="2026-07-31T19:01:00+00:00",
+    )
+
+    assert child.parent_session_id == root.session_id
+    assert child.lineage_id == root.lineage_id
+    assert child.generation == 1
+    assert len(child.mutations) == 1
+    assert child.recipe_sha256 != root.recipe_sha256
+    sleep_request_from_manifest(child.recipe_manifest).validate()
+
+
+def test_return_preserves_recipe_and_identity():
+    root = create_sleep_plan(_request(), created_at="2026-07-31T19:00:00+00:00")
+    returned = create_child_sleep_plan(
+        root,
+        mode="return",
+        created_at="2026-07-31T19:02:00+00:00",
+    )
+
+    assert returned.recipe_sha256 == root.recipe_sha256
+    assert returned.title == root.title
+    assert returned.motif == root.motif
+    assert returned.mutations == ()
+    assert returned.session_id != root.session_id
+
+
+def test_wander_combines_no_more_than_two_disclosed_changes():
+    root = create_sleep_plan(_request(), created_at="2026-07-31T19:00:00+00:00")
+    child = create_child_sleep_plan(
+        root,
+        mode="wander",
+        created_at="2026-07-31T19:03:00+00:00",
+    )
+
+    assert child.experimental
+    assert 1 <= len(child.mutations) <= 2
+    assert len({item.key for item in child.mutations}) == len(child.mutations)
+    sleep_request_from_manifest(child.recipe_manifest).validate()
+
+
+def test_archive_keeps_echoes_outcomes_and_descriptive_atlas(tmp_path: Path):
+    archive = LivingSessionArchive(tmp_path / "living")
+    root = create_sleep_plan(
+        _request(),
+        pre_affect=AffectSnapshot(valence=-0.5, arousal=0.9, agency=0.2),
+        created_at="2026-07-31T19:00:00+00:00",
+    )
+    archive.create(root)
+    archive.append_event(
+        root.session_id,
+        kind="echo",
+        label="The rain became a room",
+        position_seconds=123.5,
+        created_at="2026-07-31T19:02:00+00:00",
+    )
+    outcome = SessionOutcome(
+        session_id=root.session_id,
+        completed_at="2026-07-31T20:00:00+00:00",
+        rating=5,
+        would_repeat=True,
+        comfort="comfortable",
+        post_affect=AffectSnapshot(valence=0.4, arousal=0.2, agency=0.7),
+        tags=("rain", "settled"),
+    )
+    stored = archive.finish(outcome)
+    atlas = archive.atlas()
+
+    assert stored.status == "completed"
+    assert archive.echoes()[0]["event"]["label"] == "The rain became a room"
+    assert atlas["session_count"] == 1
+    assert atlas["completed_count"] == 1
+    assert atlas["echo_count"] == 1
+    assert atlas["average_rating"] == 5
+    assert atlas["average_affect_delta"]["valence"] == pytest.approx(0.9)
+
+
+def test_auto_mode_returns_after_a_strong_first_outcome_then_branches(tmp_path: Path):
+    archive = LivingSessionArchive(tmp_path / "living")
+    root = create_sleep_plan(_request(), created_at="2026-07-31T19:00:00+00:00")
+    archive.create(root)
+    archive.finish(
+        SessionOutcome(
+            session_id=root.session_id,
+            completed_at="2026-07-31T20:00:00+00:00",
+            rating=5,
+            would_repeat=True,
+            comfort="comfortable",
+        )
+    )
+    stored_root = archive.get(root.session_id)
+    assert recommend_child_mode(stored_root, archive) == "return"
+
+    returned = create_child_sleep_plan(
+        root,
+        mode="return",
+        archive=archive,
+        created_at="2026-07-31T21:00:00+00:00",
+    )
+    archive.create(returned)
+    archive.finish(
+        SessionOutcome(
+            session_id=returned.session_id,
+            completed_at="2026-07-31T22:00:00+00:00",
+            rating=5,
+            would_repeat=True,
+            comfort="comfortable",
+        )
+    )
+    assert recommend_child_mode(archive.get(returned.session_id), archive) == "branch"
+
+
+def test_outcome_is_immutable(tmp_path: Path):
+    archive = LivingSessionArchive(tmp_path / "living")
+    root = create_sleep_plan(_request(), created_at="2026-07-31T19:00:00+00:00")
+    archive.create(root)
+    archive.finish(
+        SessionOutcome(
+            session_id=root.session_id,
+            completed_at="2026-07-31T20:00:00+00:00",
+            rating=4,
+            would_repeat=True,
+            comfort="comfortable",
+        )
+    )
+    with pytest.raises(ValueError, match="immutable"):
+        archive.finish(
+            SessionOutcome(
+                session_id=root.session_id,
+                completed_at="2026-07-31T20:00:00+00:00",
+                rating=1,
+                would_repeat=False,
+                comfort="uncomfortable",
+            )
+        )

--- a/pysbagen/tests/test_living_sessions.py
+++ b/pysbagen/tests/test_living_sessions.py
@@ -13,6 +13,7 @@ from pysbagen.living_sessions import (
     recommend_child_mode,
     sleep_request_from_manifest,
 )
+from pysbagen.session_cli import main as session_main
 from pysbagen.sleep import SleepRequest
 
 
@@ -81,6 +82,19 @@ def test_wander_combines_no_more_than_two_disclosed_changes():
     assert child.experimental
     assert 1 <= len(child.mutations) <= 2
     assert len({item.key for item in child.mutations}) == len(child.mutations)
+    sleep_request_from_manifest(child.recipe_manifest).validate()
+
+
+def test_contrast_uses_one_audible_product_dimension():
+    root = create_sleep_plan(_request(), created_at="2026-07-31T19:00:00+00:00")
+    child = create_child_sleep_plan(
+        root,
+        mode="contrast",
+        created_at="2026-07-31T19:04:00+00:00",
+    )
+
+    assert len(child.mutations) == 1
+    assert child.mutations[0].key != "request.seed"
     sleep_request_from_manifest(child.recipe_manifest).validate()
 
 
@@ -178,3 +192,17 @@ def test_outcome_is_immutable(tmp_path: Path):
                 comfort="uncomfortable",
             )
         )
+
+
+def test_native_required_plan_refuses_python_render(tmp_path: Path):
+    archive_root = tmp_path / "living"
+    archive = LivingSessionArchive(archive_root)
+    root = create_sleep_plan(
+        _request(),
+        backend_policy="sbagenx",
+        created_at="2026-07-31T19:00:00+00:00",
+    )
+    archive.create(root)
+
+    with pytest.raises(SystemExit, match="requires SBaGenX"):
+        session_main(["--root", str(archive_root), "render", root.session_id])


### PR DESCRIPTION
## What changed

- adds a PySbagen-owned Living Sessions product layer above either renderer;
- derives memorable two-word titles and three-word motifs from exact recipe identity;
- preserves recipe SHA-256, lineage ID, parent session, generation, and unique occurrence ID;
- adds four transparent return routes:
  - `return` — exact remembered recipe;
  - `branch` — exactly one disclosed change;
  - `contrast` — exactly one high-salience audible change;
  - `wander` — at most two compatible disclosed changes, marked less causally interpretable;
- adds a local append-only archive for plans, events, echoes, and immutable outcomes;
- adds optional pre/post valence, arousal, and agency context;
- adds transparent next-mode recommendations with no hidden model;
- adds a personal atlas with lineage, echo, rating, repeat, affect-delta, and descriptive local-pattern summaries;
- adds `sbgpy-session` with new-sleep, render, mark, finish, next, show, list, and atlas commands;
- reconstructs and validates exact stored SleepRequests before rendering;
- records actual backend, backend-selection reason, recipe identity, output identity, and output SHA-256;
- refuses to render an `sbagenx`-required plan through Python while native rendering remains unqualified;
- separates retention/variation policy from archive storage;
- modernizes `project.license` to an SPDX string;
- records the project-owner supplied HTE-Newest/InvisiSynth reasoning pass without vendoring its runtime code.

## Product boundary

SBaGenX remains responsible for advanced native SBG/SBGF DSP, authoring, plotting, export, and future qualified native rendering.

PySbagen owns the continuing human/session layer: identity, provenance, lineages, echoes, outcomes, local learning, and backend-independent orchestration.

This PR deliberately adds no duplicate native DSP.

## Anti-drawer design

Continued use creates new value through:

- exact return;
- understandable variation;
- remembered moments;
- honest local outcome history;
- lineages and an accumulating atlas.

It does not use points, badges, streak coercion, leaderboards, cloud accounts, opaque recommendations, or undisclosed random changes.

## Product paths

```bash
sbgpy-session new-sleep --problem racing_mind --sound-world rain_room
sbgpy-session render SESSION_ID -o tonight.wav
sbgpy-session mark SESSION_ID --kind echo --at 123.5 --label "The rain became a room"
sbgpy-session finish SESSION_ID --rating 5 --would-repeat yes --comfort comfortable
sbgpy-session next SESSION_ID --mode auto
sbgpy-session atlas
```

## Qualification

GitHub Actions Python qualification run #57 passed the hardened implementation head:

- Python 3.10 — passed;
- Python 3.11 — passed;
- Python 3.12 — passed;
- Python 3.13 — passed;
- complete repository result — **68 tests passed**;
- source distribution and wheel build — passed;
- wheel contains `living_sessions.py`, `living_session_policy.py`, and `session_cli.py`;
- updated SPDX license metadata builds without the former license-table deprecation warning.

Self-review caught and fixed two product-policy errors before qualification:

1. contrast could select seed-only novelty instead of an audible product change;
2. an SBaGenX-required plan could silently render through Python.

Bugbot is not enabled. CodeRabbit automatic review skipped the non-default stacked base. A manual review was requested; CodeRabbit reports success but has produced no submitted review or inline thread.

## Stack

Base: `agent/sbagenx-interoperability-train-20260731` / PR #11

Head: `agent/living-sessions-train-20260731`

## Receipts and docs

- `docs/research/HTE_LIVING_SESSIONS_GAP_SYNTHESIS_2026_07_31.md`
- `.beads/pysbagen_living_sessions_train_2026_07_31.md`
- `.beads/pysbagen_living_sessions_train_2026_07_31_WAVE1_COMPLETION.md`
- `docs/product/LIVING_SESSIONS_GUIDE.md`

## Next product train

LIV-011 — Constellation view: an offline, useful lineage navigation surface showing branches, mutations, echoes, outcomes, backends, and provenance. Do not reopen Wave 1 as an audit loop unless a real regression appears.
