### PR TITLE
Build offline Living Sessions constellation navigator

### DIFF
--- a/.beads/pysbagen_living_sessions_confluence_train_2026_08_07.md
+++ b/.beads/pysbagen_living_sessions_confluence_train_2026_08_07.md
@@ -1,0 +1,152 @@
+# PySbagen LIV-012 — Living Sessions Confluence Train
+
+Date: 2026-08-07
+Product: PySbagen
+Stack base: `agent/living-sessions-constellation-20260805`
+Train branch: `agent/living-sessions-confluence-20260807`
+
+## Product objective
+
+Make two remembered Living Sessions capable of producing a third experience that is recognizably descended from both, while remaining understandable and reusable.
+
+This train is successful when the listener can say:
+
+> I remember those two sessions. This new one carries something from each of them, adds something of its own, and I can see and hear how it became this experience.
+
+## Beads
+
+### LIV-012.1 — Dual remembered ancestors
+
+Create a Confluence from two distinct stored Living Sessions rather than from detached recipe dictionaries.
+
+Acceptance:
+
+- both ancestors remain named and addressable;
+- both parent recipe identities remain visible in Confluence metadata;
+- same-session self-Confluence is rejected;
+- a Confluence can later be used as an ancestor.
+
+### LIV-012.2 — Experiential inheritance
+
+Represent inherited dimensions as `A`, `B`, `both`, or `new`.
+
+Initial dimensions:
+
+- intent / problem;
+- sound world;
+- intensity;
+- duration;
+- layer blend.
+
+Acceptance:
+
+- explicit inheritance choices are supported;
+- conflicting explicit A/B choices for the same trait fail clearly;
+- differences remain visible as creative tensions.
+
+### LIV-012.3 — Memory-guided suggestion
+
+Use existing local memory to suggest understandable inheritance.
+
+Signals may include:
+
+- outcome rating;
+- would-repeat choice;
+- echoes;
+- shared dimensions;
+- available bridge values.
+
+Acceptance:
+
+- no hidden model;
+- no efficacy claim;
+- the suggestion explains each choice;
+- both ancestors contribute when the source material permits a meaningful distinction.
+
+### LIV-012.4 — Newness created by the meeting
+
+Create dimensions that belong to neither parent exactly when a meaningful bridge exists.
+
+Initial bridges:
+
+- intensity midpoint;
+- duration midpoint;
+- compatible layer union;
+- always-new deterministic generation seed.
+
+Acceptance:
+
+- `new` means a real value not copied from either parent;
+- child recipe identity differs when the experience differs;
+- the result remains reproducible.
+
+### LIV-012.5 — Memorable hybrid identity
+
+Give the Confluence its own title, motif, session ID, lineage ID, generation, and recipe identity.
+
+Acceptance:
+
+- identity carries recognizable material from both parents when possible;
+- identity is not merely `ParentA+ParentB` or a hash dump;
+- the child can be remembered and referred to on its own.
+
+### LIV-012.6 — Normal Living Session life
+
+After creation, a Confluence is a normal Living Session for rendering, echoes, and outcomes.
+
+Acceptance:
+
+- existing `sbgpy-session render` accepts the stored sleep recipe under existing backend policy;
+- existing `mark` and `finish` paths apply;
+- no parallel Confluence-only outcome store is created.
+
+### LIV-012.7 — Dual-parent constellation
+
+Add the second ancestor as a real constellation edge.
+
+Acceptance:
+
+- Parent A keeps the existing primary-parent compatibility path;
+- Parent B receives a second graph edge;
+- intentional cross-lineage ancestry is not mislabeled as a broken lineage;
+- the existing offline HTML renderer can display the enriched graph.
+
+### LIV-012.8 — Product command surface
+
+Expose `sbgpy-confluence` with:
+
+- `suggest`;
+- `create`;
+- `show`;
+- `constellation`.
+
+Acceptance:
+
+- JSON forms remain scriptable;
+- ordinary output emphasizes experience and inheritance rather than internal bookkeeping.
+
+### LIV-012.9 — Product guide
+
+Document the experience, inheritance vocabulary, CLI journey, dual-parent graph, renderer boundary, and anti-audit boundary.
+
+### LIV-012.10 — Qualification
+
+Run the repository's supported Python qualification and packaging checks on the exact final train head.
+
+## Hard boundaries
+
+Do not build:
+
+- audit machinery;
+- audit-of-audit machinery;
+- provenance quality scoring;
+- causality tribunal machinery;
+- duplicate SBaGenX DSP;
+- HTE runtime integration;
+- Cycloside integration.
+
+Existing identity hashes, parent identities, and structural visibility exist because a person needs to understand and return to the experience.
+
+## Product rule
+
+Repeated use must create new value through memory, recognizable variation, lineage, and creativity—not through engagement pressure.

--- a/.beads/pysbagen_living_sessions_constellation_train_2026_08_05.md
+++ b/.beads/pysbagen_living_sessions_constellation_train_2026_08_05.md
@@ -1,0 +1,112 @@
+# PySbagen Living Sessions — Constellation Train
+
+**Date:** August 5, 2026  
+**Branch:** `agent/living-sessions-constellation-20260805`  
+**Pull request:** `#14` — Build offline Living Sessions constellation navigator  
+**Stack base:** `agent/living-sessions-train-20260731` / PR #12  
+**Status:** complete and qualified
+
+## Product intent
+
+Turn Living Sessions ancestry into an offline navigation surface that helps someone return, compare, understand, and continue—not a graph exported once and forgotten.
+
+## Hard boundaries
+
+- Do not duplicate SBaGenX DSP, authoring, plotting, or curve features.
+- Do not mutate the archive while viewing it.
+- Do not hide recipe hashes or backend receipts behind human-facing names.
+- Do not infer missing ancestry.
+- Do not introduce remote assets, analytics, cloud accounts, badges, streaks, or leaderboards.
+- Do not build or explore the permission-gated Cycloside path.
+
+## HTE / InvisiSynth synthesis
+
+The train uses:
+
+- Memory Engine: episodes + continuity + uncertainty;
+- Learning Engine: change → outcome → mismatch visibility;
+- Affect Engine: emotional tags stay attached to their episode;
+- Dependency Grapher: directed ancestry and critical relationships;
+- Parallel Oracle and Synthesis: human memory and technical provenance coexist;
+- InvisiSynth: missing parents, lineage breaks, and suspicious absences remain visible.
+
+## Delivered beads
+
+### LIV-011A — Deterministic constellation graph — complete
+
+- nodes for stored sessions;
+- directed parent/child edges;
+- deterministic layout;
+- snapshot SHA-256;
+- lineage filtering and focus validation;
+- read-only graph generation.
+
+### LIV-011B — Evidence-rich node and edge model — complete
+
+- recipe summaries and full recipe hashes;
+- before/after mutation values;
+- causal-interpretability labels;
+- echoes and event anchors;
+- outcomes and optional affect delta;
+- backend policy, actual backend, and output hash;
+- structural warnings without auto-repair.
+
+### LIV-011C — Self-contained offline navigator — complete
+
+- no remote assets;
+- searchable nodes;
+- lineage, status, and mode filters;
+- selectable session details;
+- centered focus session;
+- responsive layout;
+- safe JSON embedding for arbitrary local labels.
+
+### LIV-011D — Terminal and JSON surfaces — complete
+
+- useful terminal map without a browser;
+- complete graph JSON;
+- HTML path, HTML hash, and snapshot-hash receipts;
+- explicit errors for missing scope and focus.
+
+### LIV-011E — Product integration — complete
+
+- `sbgpy-session constellation`;
+- public Python API exports;
+- package inclusion;
+- focused tests;
+- operator guide and completion receipt.
+
+## Acceptance result
+
+The train satisfies its product acceptance:
+
+- the view reveals why two sessions differ;
+- an exact return is visibly exact;
+- echoes and outcomes are inspectable from their session;
+- actual backend/output identity remains visible;
+- incomplete ancestry stays incomplete rather than invented;
+- hostile local labels cannot break the HTML document;
+- the generated file works offline without remote assets;
+- graph generation appends no session or archive event;
+- Python 3.10–3.13 tests and the distributable package pass;
+- the next product wave is handed off without reopening Wave 1 or creating audit machinery.
+
+## Qualification
+
+GitHub Actions Python qualification run `#67` passed implementation head `8ff3a2892f3b57f38cfe7cc7a25dbfe171ffb2c8`:
+
+- Python 3.10 — passed;
+- Python 3.11 — passed;
+- Python 3.12 — passed;
+- Python 3.13 — passed;
+- complete repository result — **73 tests passed**;
+- source distribution and wheel build — passed;
+- wheel includes `pysbagen/constellation.py` and the updated session CLI.
+
+The first qualification run exposed one wording-order mismatch in a test after **72 tests passed**. The regression was corrected to lock the actual user-facing interpretation language; no product or safety assertion was weakened.
+
+## Next product wave
+
+**LIV-012 — Confluence Sessions** is the next original product train: explicitly combine selected dimensions from two known lineages while preserving both parent identities, inherited-dimension receipts, conflicts, and causal uncertainty.
+
+This is queued only inside PySbagen. The Cycloside cross-project possibility remains parked behind its explicit permission gate.

--- a/.beads/pysbagen_living_sessions_constellation_train_2026_08_05_COMPLETION.md
+++ b/.beads/pysbagen_living_sessions_constellation_train_2026_08_05_COMPLETION.md
@@ -1,0 +1,131 @@
+# PySbagen Living Sessions — Constellation Completion Receipt
+
+**Date:** August 5, 2026  
+**Status:** complete and qualified  
+**Branch:** `agent/living-sessions-constellation-20260805`  
+**Pull request:** `#14` — Build offline Living Sessions constellation navigator  
+**Stack base:** PR `#12` / `agent/living-sessions-train-20260731`
+
+## Product delivered
+
+Constellation turns the local Living Sessions archive into a continuing navigation surface with:
+
+- deterministic session nodes and directed ancestry;
+- exact recipe, lineage, parent, generation, and occurrence identity;
+- visible return, branch, contrast, and wander relationships;
+- before/after mutation values and recorded reasons;
+- causal-interpretability labels;
+- echoes, shifts, insights, and discomfort anchors;
+- optional outcomes and affect deltas;
+- backend policy, actual renderer, output path, and output SHA-256 receipts;
+- structural warnings for incomplete or contradictory ancestry;
+- terminal, JSON, and self-contained offline HTML views;
+- search plus lineage, status, and mode filters;
+- graph snapshot and HTML-file SHA-256 receipts.
+
+## Product boundary retained
+
+Constellation adds no duplicate native DSP.
+
+- SBaGenX remains the optional advanced SBG/SBGF engine and authoring/runtime layer.
+- PySbagen owns the continuing human/session memory and provenance surface above qualified renderers.
+- The navigator reads existing session records and does not append viewing events.
+- The Cycloside cross-project possibility remains permission-gated and untouched.
+
+## HTE / InvisiSynth use
+
+The project-owner supplied `HTE-Newest.zip` was used as a reasoning corpus:
+
+- Memory Engine for episode continuity and uncertainty;
+- Learning Engine for change/outcome/mismatch visibility;
+- Affect Engine for state-tagged episodes;
+- Dependency Grapher for directed ancestry;
+- Parallel Oracle and Synthesis for simultaneous human and technical truth;
+- InvisiSynth for visible missing parents and broken relationships.
+
+No HTE runtime code, private configuration, or dependency was copied into PySbagen.
+
+## User paths
+
+```bash
+sbgpy-session constellation
+sbgpy-session constellation --json
+sbgpy-session constellation --html
+sbgpy-session constellation --lineage LINEAGE_ID --html lineage.html
+sbgpy-session constellation --focus SESSION_ID --html focused.html
+```
+
+## Files delivered
+
+Runtime:
+
+- `pysbagen/constellation.py`
+- constellation integration in `pysbagen/session_cli.py`
+- public exports in `pysbagen/__init__.py`
+
+Tests:
+
+- `pysbagen/tests/test_constellation.py`
+
+Documentation:
+
+- `docs/product/LIVING_SESSIONS_CONSTELLATION_GUIDE.md`
+- `.beads/pysbagen_living_sessions_constellation_train_2026_08_05.md`
+- this completion receipt
+
+## Qualification
+
+GitHub Actions Python qualification run `#67` passed implementation head `8ff3a2892f3b57f38cfe7cc7a25dbfe171ffb2c8`, and final-head run `#72` passed completion-receipt head `4071dbfb7072d2f137275247fa8a90eae851d7ee`:
+
+- Python 3.10 product-path tests — passed;
+- Python 3.11 product-path tests — passed;
+- Python 3.12 product-path tests — passed;
+- Python 3.13 product-path tests — passed;
+- complete repository result — **73 tests passed**;
+- Python 3.12 source distribution — passed;
+- Python 3.12 wheel build — passed;
+- the wheel includes `pysbagen/constellation.py` and updated public/CLI surfaces.
+
+Focused coverage includes:
+
+- deterministic graph and snapshot identity;
+- parent/child ancestry and exact-return labeling;
+- mutation and causal-interpretability receipts;
+- echoes, outcomes, affect deltas, backend identities, and output hashes;
+- lineage and focus fail-closed behavior;
+- missing-parent warnings without invented edges;
+- hostile `</script>` labels remaining inert;
+- no external script or stylesheet dependency;
+- atomic offline HTML writing;
+- CLI export and hash receipts.
+
+The first run failed only because the regression expected the phrase `personal descriptive records` while the product emitted `descriptive personal records`; **72 tests had passed**. The test was aligned with the actual user-facing language, and all 73 tests then passed. No functional, provenance, safety, or scope assertion was removed.
+
+## Review state
+
+- PR is open and mergeable.
+- Bugbot is not enabled and performed no review.
+- CodeRabbit automatic review skipped the non-default stacked base.
+- A manual `@coderabbitai review` request was posted.
+- CodeRabbit acknowledged the requested scope but reported that the review was rate-limited; it performed no submitted review and created no actionable inline findings.
+- This limitation is recorded rather than represented as a completed review.
+
+## Anti-drawer acceptance
+
+Constellation creates repeat value because the user can:
+
+- navigate a growing personal history rather than search filenames;
+- return to an exact known session;
+- understand one-change and bounded-exploration descendants;
+- revisit remembered moments in context;
+- compare outcomes without discarding provenance;
+- see which renderer and exact output produced an experience;
+- notice missing or contradictory history rather than being shown a falsely complete map.
+
+It uses no points, badges, streak pressure, social ranking, analytics, cloud account, or hidden recommendation model.
+
+## Next queued wave
+
+**LIV-012 — Confluence Sessions**: combine explicitly selected dimensions from two known lineages while retaining both parents, inherited-dimension receipts, conflict disclosures, and causal uncertainty.
+
+The Cycloside integration idea remains parked and may not be explored or built without Justin's explicit permission.

--- a/docs/product/LIVING_SESSIONS_CONFLUENCE_GUIDE.md
+++ b/docs/product/LIVING_SESSIONS_CONFLUENCE_GUIDE.md
@@ -1,0 +1,151 @@
+# Living Sessions Confluence
+
+Confluence Sessions let two remembered Living Sessions become the ancestors of a new experience.
+
+The product idea is deliberately **not** “merge two configuration files.” A Confluence starts from two experiences that already have identities, echoes, outcomes, and history. It then makes a new session by choosing what should remain recognizable from Parent A, what should remain recognizable from Parent B, and where the meeting itself should create something new.
+
+## The experience
+
+A Confluence can:
+
+- inherit a recognizable dimension from Parent A;
+- inherit another dimension from Parent B;
+- preserve a dimension both parents already share;
+- create a deliberate bridge where two parent choices differ;
+- create a fresh deterministic generation seed so the child is its own reproducible experience;
+- retain both ancestors;
+- become an ancestor of later Confluences;
+- use the ordinary Living Sessions render, echo, outcome, and return paths after creation.
+
+Each inheritance item is labeled as one of:
+
+- `A` — inherited from Parent A;
+- `B` — inherited from Parent B;
+- `both` — already shared by both parents;
+- `new` — created by the meeting itself.
+
+That vocabulary is there to make the hybrid understandable, not to create a verification tribunal.
+
+## What can be inherited today
+
+The first Confluence implementation works with Living Sessions backed by PySbagen sleep recipe manifests and considers these experiential dimensions:
+
+- intent / sleep problem;
+- sound world;
+- presence / intensity;
+- duration;
+- layer blend.
+
+The generation seed is always new and is derived deterministically from both parent recipe identities plus the selected blend. It is never silently copied from one parent.
+
+## Suggested inheritance
+
+PySbagen can suggest a blend instead of making the listener manually decide every dimension.
+
+The suggestion is intentionally simple and visible. It can use:
+
+- recorded outcome rating;
+- whether the listener marked the experience worth repeating;
+- remembered echoes;
+- whether a dimension is already shared;
+- whether two different values have a meaningful middle or combined form.
+
+Examples of a genuinely new bridge include:
+
+- `gentle` + `immersive` presence becoming `balanced`;
+- 30 minutes + 90 minutes becoming a 60-minute bridge;
+- two compatible layer blends becoming a union that neither parent used exactly.
+
+A suggestion is not a claim that one parent caused an outcome or that the hybrid will have a particular effect. It is a transparent product choice based on the local memory already present in Living Sessions.
+
+## CLI
+
+Preview a meeting without creating it:
+
+```bash
+sbgpy-confluence suggest SESSION_A SESSION_B
+```
+
+Force selected dimensions to come from specific parents while leaving the rest available for suggestion:
+
+```bash
+sbgpy-confluence suggest SESSION_A SESSION_B \
+  --from-a sound_world \
+  --from-b problem
+```
+
+Multiple dimensions can be comma-separated:
+
+```bash
+sbgpy-confluence create SESSION_A SESSION_B \
+  --from-a sound_world,layers \
+  --from-b problem
+```
+
+Inspect a created Confluence:
+
+```bash
+sbgpy-confluence show CONFLUENCE_SESSION_ID
+```
+
+Then use the normal Living Sessions workflow:
+
+```bash
+sbgpy-session render CONFLUENCE_SESSION_ID -o confluence.wav
+sbgpy-session mark CONFLUENCE_SESSION_ID --kind echo --at 180 --label "The two worlds finally met"
+sbgpy-session finish CONFLUENCE_SESSION_ID --rating 5 --would-repeat yes --comfort comfortable
+```
+
+A completed Confluence can be supplied as either parent in a later `sbgpy-confluence create` command.
+
+## Dual-parent constellation
+
+The ordinary Living Sessions plan keeps Parent A in the existing primary-parent field so existing session storage and rendering remain compatible.
+
+The Confluence event stores the second ancestor and the inheritance story. The Confluence constellation view uses that information to add a real second edge:
+
+```bash
+sbgpy-confluence constellation
+sbgpy-confluence constellation --focus CONFLUENCE_SESSION_ID
+sbgpy-confluence constellation --html confluence-family.html
+```
+
+The resulting graph shows both ancestral routes without pretending that intentional cross-lineage ancestry is a broken single-parent lineage.
+
+## Identity
+
+A Confluence receives:
+
+- a new session ID;
+- a new lineage ID derived from both parent lineages and the new recipe;
+- a new recipe SHA-256;
+- a hybrid title assembled from recognizable pieces of the parent identities when possible;
+- a motif that carries memories from both parents plus a meeting motif;
+- a generation one greater than the older of its two parents.
+
+The goal is that the child feels related to both parents while still being something the listener can remember by itself.
+
+## Renderer boundary
+
+Confluence lives above the renderer.
+
+It does not add DSP, duplicate SBaGenX, or qualify native rendering. If both parents use the same backend policy, the child keeps it. If the parents disagree, the child uses `auto` rather than silently preferring one ancestor's renderer policy.
+
+The existing Living Sessions rendering rules still apply. Native SBaGenX rendering remains gated on the separate typed-render qualification work.
+
+## Product boundary
+
+Confluence exists to make repeated use create more interesting things to return to.
+
+It does **not** add:
+
+- an audit engine;
+- provenance scoring;
+- recursive verification layers;
+- causality adjudication;
+- engagement points, streaks, or leaderboards;
+- cloud accounts or hidden recommendation models.
+
+HTE, InvisiSynth, memory, affect, and synthesis ideas were used as design reasoning. Their runtime machinery is not vendored into PySbagen.
+
+The permission-gated Cycloside idea remains parked and untouched.

--- a/docs/product/LIVING_SESSIONS_CONSTELLATION_GUIDE.md
+++ b/docs/product/LIVING_SESSIONS_CONSTELLATION_GUIDE.md
@@ -1,0 +1,128 @@
+# PySbagen Living Sessions — Constellation Guide
+
+**Status:** Wave 2 product surface  
+**Command:** `sbgpy-session constellation`  
+**Network requirement:** none  
+**Archive mutation:** none
+
+## Why this exists
+
+A lineage should not become a pile of session IDs and WAV filenames. The Constellation turns the local Living Sessions archive into a navigable map of:
+
+- where a session came from;
+- what changed;
+- what stayed identical;
+- which moments were remembered;
+- what outcome was recorded;
+- which backend actually rendered it;
+- which recipe and output hashes prove its identity.
+
+This is not a decorative diagram. Selecting a node exposes the evidence behind it.
+
+## Open the full local constellation
+
+```bash
+sbgpy-session constellation --html
+```
+
+This writes `living-session-constellation.html`. The file is self-contained. It loads no CDN, analytics script, font, image, remote stylesheet, or network API.
+
+Choose another destination:
+
+```bash
+sbgpy-session constellation --html ./atlas/tonight.html
+```
+
+## Restrict the view
+
+One lineage:
+
+```bash
+sbgpy-session constellation --lineage LINEAGE_ID --html lineage.html
+```
+
+Open with one session selected and centered:
+
+```bash
+sbgpy-session constellation --focus SESSION_ID --html focused.html
+```
+
+A focus session must be inside the selected snapshot. Missing lineages and out-of-scope focus IDs fail closed.
+
+## Terminal and JSON views
+
+```bash
+sbgpy-session constellation
+sbgpy-session constellation --json
+sbgpy-session constellation --html map.html --json
+```
+
+The export receipt includes the exact graph snapshot SHA-256, HTML path, and HTML SHA-256. Generating a constellation never appends an archive event or modifies a session. It is a read-only snapshot.
+
+## What a node shows
+
+Each node contains or exposes:
+
+- title and motif;
+- session, lineage, parent, and generation IDs;
+- mode and status;
+- exact recipe SHA-256;
+- stated problem, sound world, intensity, duration, seed, and layers;
+- disclosed mutations;
+- echoes, shifts, insights, and discomfort markers;
+- optional rating, comfort, repeat intent, tags, and affect delta;
+- backend policy;
+- actual renderer identities found in render receipts;
+- latest output SHA-256;
+- causal-interpretability label;
+- structural warnings.
+
+## What an edge means
+
+- `exact return` — parent and child preserve recipe identity;
+- `branch` — one disclosed dimension changed;
+- `contrast` — one audible high-salience dimension changed;
+- `wander` — one or two disclosed changes, marked bounded exploration.
+
+The edge label names the changed recipe dimensions. The details panel preserves before/after values and the recorded reason.
+
+## Search and filters
+
+The offline navigator supports full-text search across titles, motifs, echoes, IDs, and hashes; lineage, status, and mode filters; click and keyboard selection; and scrolling to a focused session.
+
+## Structural truth
+
+The map does not invent missing ancestry. It reports:
+
+- a parent absent from the selected snapshot;
+- parent/child lineage mismatch;
+- generation gaps;
+- a return whose recipe hash changed;
+- a parentless session claiming a non-zero generation.
+
+These warnings describe archive structure. They do not rewrite or repair history.
+
+## HTE / InvisiSynth design use
+
+The design applies the project-owner supplied HTE-Newest reasoning corpus:
+
+- **Memory:** show episodes and continuity, but treat patterns as guidance rather than destiny;
+- **Learning:** keep prediction, change, outcome, and mismatch connected;
+- **Affect:** expose optional emotional tags beside the episode they belong to;
+- **Dependency Grapher:** make ancestry and dependency direction legible;
+- **Parallel Oracle / Synthesis:** keep technical provenance and human memory visible at the same time;
+- **InvisiSynth:** surface absences and broken relationships rather than drawing a falsely complete graph.
+
+No HTE runtime code or private configuration is copied into the product.
+
+## Product boundary
+
+Constellation is a PySbagen session-intelligence surface. It adds no synthesis engine, curve language, mix effect, native editor, or SBaGenX DSP duplicate.
+
+SBaGenX remains the optional advanced native SBG/SBGF engine. PySbagen maps the continuing human and provenance history above whichever qualified renderer was actually used.
+
+The possible Cycloside cross-project path remains permission-gated and is not part of this train.
+
+## Interpretation boundary
+
+The navigator shows personal descriptive history. A high rating, affect change, or repeated preference is not proof of medical efficacy or causation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ sbgpy-inspect-gui = "inspect_gui:main"
 sbgpy-sleep = "pysbagen.sleep_cli:main"
 sbgpy-sleep-gui = "sleep_gui:main"
 sbgpy-session = "pysbagen.session_cli:main"
+sbgpy-confluence = "pysbagen.confluence_cli:main"
 
 [project.entry-points."pysbagen.generators"]
 # Third parties can register generator plugins in this group.

--- a/pysbagen/__init__.py
+++ b/pysbagen/__init__.py
@@ -9,6 +9,13 @@ from .api import (
     write_audio,
 )
 from .compatibility import CompatibilityState, ImportReport, RenderDisposition
+from .constellation import (
+    ConstellationWarning,
+    build_constellation,
+    constellation_to_text,
+    render_constellation_html,
+    write_constellation_html,
+)
 from .importers import ImportedArtifact, import_artifact, import_drg, import_sbg
 from .interoperability import EngineDiscrepancy, InteroperabilityReport, inspect_with_sbagenx
 from .living_sessions import (
@@ -43,6 +50,7 @@ __all__ = [
     "AffectSnapshot",
     "BackendCapability",
     "CompatibilityState",
+    "ConstellationWarning",
     "EngineDiscrepancy",
     "ImportReport",
     "ImportedArtifact",
@@ -64,7 +72,9 @@ __all__ = [
     "SleepRequest",
     "StoredSession",
     "UnsupportedSBaGenXAPI",
+    "build_constellation",
     "build_sleep_recipe",
+    "constellation_to_text",
     "create_child_sleep_plan",
     "create_sleep_plan",
     "import_artifact",
@@ -75,11 +85,13 @@ __all__ = [
     "inspect_with_sbagenx",
     "probe_sbagenx",
     "recommend_child_mode",
+    "render_constellation_html",
     "render_schedule",
     "render_sleep",
     "render_specs",
     "sleep_request_from_manifest",
     "validate_sbagenx_source",
     "write_audio",
+    "write_constellation_html",
 ]
 __version__ = "0.4.0"

--- a/pysbagen/confluence.py
+++ b/pysbagen/confluence.py
@@ -1,0 +1,719 @@
+"""Dual-ancestor Living Session synthesis for memorable hybrid experiences."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Literal
+
+from .constellation import build_constellation
+from .living_sessions import AffectSnapshot, LivingSessionArchive, LivingSessionPlan, StoredSession
+from .sleep import SleepLayers, SleepRequest, build_sleep_recipe, recipe_manifest
+
+InheritanceSource = Literal["A", "B", "both", "new"]
+
+TRAIT_KEYS = ("problem", "sound_world", "intensity", "duration_minutes", "layers")
+_TRAIT_LABELS = {
+    "problem": "intent",
+    "sound_world": "sound world",
+    "intensity": "presence",
+    "duration_minutes": "duration",
+    "layers": "layer blend",
+}
+
+
+@dataclass(frozen=True)
+class ConfluenceInheritance:
+    """One experiential dimension carried into a Confluence session."""
+
+    trait: str
+    source: InheritanceSource
+    value: Any
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ConfluenceSuggestion:
+    """Transparent suggestion for how two remembered sessions might meet."""
+
+    parent_a_session_id: str
+    parent_b_session_id: str
+    assignments: tuple[ConfluenceInheritance, ...]
+    tensions: tuple[str, ...]
+    rationale: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "parent_a_session_id": self.parent_a_session_id,
+            "parent_b_session_id": self.parent_b_session_id,
+            "assignments": [item.to_dict() for item in self.assignments],
+            "tensions": list(self.tensions),
+            "rationale": self.rationale,
+        }
+
+
+def suggest_confluence(
+    parent_a: StoredSession,
+    parent_b: StoredSession,
+    *,
+    from_a: Iterable[str] = (),
+    from_b: Iterable[str] = (),
+) -> ConfluenceSuggestion:
+    """Suggest a comprehensible blend using memory, outcome, and audible difference."""
+
+    _validate_parents(parent_a, parent_b)
+    request_a = _request_from_plan(parent_a.plan)
+    request_b = _request_from_plan(parent_b.plan)
+    explicit_a = _normalize_trait_set(from_a)
+    explicit_b = _normalize_trait_set(from_b)
+    overlap = explicit_a & explicit_b
+    if overlap:
+        raise ValueError(
+            "A trait cannot be explicitly inherited from both parents: "
+            + ", ".join(sorted(overlap))
+        )
+
+    values_a = _trait_values(request_a)
+    values_b = _trait_values(request_b)
+    score_a = _memory_score(parent_a)
+    score_b = _memory_score(parent_b)
+    preferred = "A" if score_a >= score_b else "B"
+    assignments: list[ConfluenceInheritance] = []
+    tensions: list[str] = []
+
+    for trait in TRAIT_KEYS:
+        value_a = values_a[trait]
+        value_b = values_b[trait]
+        if value_a == value_b:
+            assignments.append(
+                ConfluenceInheritance(
+                    trait,
+                    "both",
+                    value_a,
+                    f"Both memories already share this {_TRAIT_LABELS[trait]}.",
+                )
+            )
+            continue
+
+        tensions.append(
+            f"{_TRAIT_LABELS[trait]} differs: A={_display(value_a)} · B={_display(value_b)}"
+        )
+
+        if trait in explicit_a:
+            assignments.append(
+                ConfluenceInheritance(
+                    trait,
+                    "A",
+                    value_a,
+                    f"Explicitly keep Parent A's {_TRAIT_LABELS[trait]}.",
+                )
+            )
+            continue
+        if trait in explicit_b:
+            assignments.append(
+                ConfluenceInheritance(
+                    trait,
+                    "B",
+                    value_b,
+                    f"Explicitly keep Parent B's {_TRAIT_LABELS[trait]}.",
+                )
+            )
+            continue
+
+        bridge = _bridge_value(trait, value_a, value_b)
+        if bridge is not None:
+            assignments.append(
+                ConfluenceInheritance(
+                    trait,
+                    "new",
+                    bridge,
+                    f"Create a bridge between the two remembered {_TRAIT_LABELS[trait]} choices.",
+                )
+            )
+            continue
+
+        source = _suggest_source(
+            trait,
+            preferred=preferred,
+            parent_a=parent_a,
+            parent_b=parent_b,
+            existing=assignments,
+        )
+        value = value_a if source == "A" else value_b
+        assignments.append(
+            ConfluenceInheritance(
+                trait,
+                source,
+                value,
+                _inheritance_reason(trait, source, parent_a, parent_b),
+            )
+        )
+
+    assignments = _ensure_both_parents_are_present(
+        assignments,
+        values_a=values_a,
+        values_b=values_b,
+        parent_a=parent_a,
+        parent_b=parent_b,
+        protected_a=explicit_a,
+        protected_b=explicit_b,
+    )
+    inherited_a = [_TRAIT_LABELS[x.trait] for x in assignments if x.source == "A"]
+    inherited_b = [_TRAIT_LABELS[x.trait] for x in assignments if x.source == "B"]
+    newly_bridged = [_TRAIT_LABELS[x.trait] for x in assignments if x.source == "new"]
+    shared = [_TRAIT_LABELS[x.trait] for x in assignments if x.source == "both"]
+    parts = []
+    if inherited_a:
+        parts.append("A carries " + ", ".join(inherited_a))
+    if inherited_b:
+        parts.append("B carries " + ", ".join(inherited_b))
+    if newly_bridged:
+        parts.append("the meeting creates " + ", ".join(newly_bridged))
+    if shared:
+        parts.append("both already share " + ", ".join(shared))
+    parts.append("the generation seed is new so the result is its own reproducible experience")
+    return ConfluenceSuggestion(
+        parent_a_session_id=parent_a.plan.session_id,
+        parent_b_session_id=parent_b.plan.session_id,
+        assignments=tuple(assignments),
+        tensions=tuple(tensions),
+        rationale="; ".join(parts) + ".",
+    )
+
+
+def create_confluence_plan(
+    parent_a: StoredSession,
+    parent_b: StoredSession,
+    *,
+    suggestion: ConfluenceSuggestion | None = None,
+    from_a: Iterable[str] = (),
+    from_b: Iterable[str] = (),
+    pre_affect: AffectSnapshot | None = None,
+    created_at: str | None = None,
+) -> tuple[LivingSessionPlan, ConfluenceSuggestion]:
+    """Create a dual-ancestor plan without writing it to an archive."""
+
+    _validate_parents(parent_a, parent_b)
+    suggestion = suggestion or suggest_confluence(
+        parent_a,
+        parent_b,
+        from_a=from_a,
+        from_b=from_b,
+    )
+    if suggestion.parent_a_session_id != parent_a.plan.session_id:
+        raise ValueError("Confluence suggestion does not belong to Parent A")
+    if suggestion.parent_b_session_id != parent_b.plan.session_id:
+        raise ValueError("Confluence suggestion does not belong to Parent B")
+
+    request_a = _request_from_plan(parent_a.plan)
+    request_b = _request_from_plan(parent_b.plan)
+    values_a = _trait_values(request_a)
+    values_b = _trait_values(request_b)
+    selected: dict[str, Any] = {}
+    for item in suggestion.assignments:
+        if item.trait not in TRAIT_KEYS:
+            raise ValueError(f"Unsupported Confluence trait: {item.trait}")
+        if item.source == "A":
+            selected[item.trait] = values_a[item.trait]
+        elif item.source == "B":
+            selected[item.trait] = values_b[item.trait]
+        elif item.source == "both":
+            if values_a[item.trait] != values_b[item.trait]:
+                raise ValueError(f"Trait {item.trait} is not shared by both parents")
+            selected[item.trait] = values_a[item.trait]
+        elif item.source == "new":
+            selected[item.trait] = item.value
+        else:
+            raise ValueError(f"Unknown Confluence source: {item.source}")
+
+    missing = [trait for trait in TRAIT_KEYS if trait not in selected]
+    if missing:
+        raise ValueError("Confluence suggestion is incomplete: " + ", ".join(missing))
+
+    seed = _new_seed(parent_a.plan, parent_b.plan, selected)
+    request = SleepRequest(
+        problem=str(selected["problem"]),
+        sound_world=str(selected["sound_world"]),
+        intensity=str(selected["intensity"]),
+        duration_minutes=float(selected["duration_minutes"]),
+        user_audio=_selected_user_audio(
+            selected["sound_world"],
+            request_a=request_a,
+            request_b=request_b,
+            assignments=suggestion.assignments,
+        ),
+        layers=_layers_from_value(selected["layers"]),
+        seed=seed,
+    )
+    request.validate()
+    manifest = recipe_manifest(build_sleep_recipe(request))
+    recipe_sha = _hash(manifest)
+    timestamp = created_at or _utc_now()
+    generation = max(parent_a.plan.generation, parent_b.plan.generation) + 1
+    lineage_id = _hash(
+        {
+            "kind": "confluence",
+            "parent_a_lineage": parent_a.plan.lineage_id,
+            "parent_b_lineage": parent_b.plan.lineage_id,
+            "recipe_sha256": recipe_sha,
+        },
+        24,
+    )
+    title, motif = _hybrid_identity(parent_a.plan, parent_b.plan, recipe_sha)
+    session_id = _hash(
+        {
+            "kind": "confluence-session",
+            "lineage_id": lineage_id,
+            "parent_a": parent_a.plan.session_id,
+            "parent_b": parent_b.plan.session_id,
+            "generation": generation,
+            "recipe_sha256": recipe_sha,
+            "created_at": timestamp,
+        },
+        24,
+    )
+    backend_policy = (
+        parent_a.plan.backend_policy
+        if parent_a.plan.backend_policy == parent_b.plan.backend_policy
+        else "auto"
+    )
+    plan = LivingSessionPlan(
+        session_id=session_id,
+        lineage_id=lineage_id,
+        generation=generation,
+        parent_session_id=parent_a.plan.session_id,
+        mode="confluence",
+        title=title,
+        motif=motif,
+        created_at=timestamp,
+        backend_policy=backend_policy,
+        recipe_manifest=manifest,
+        recipe_sha256=recipe_sha,
+        mutations=(),
+        rationale=suggestion.rationale,
+        experimental=True,
+        pre_affect=pre_affect,
+    )
+    return plan, suggestion
+
+
+def create_confluence_session(
+    archive: LivingSessionArchive,
+    parent_a_session_id: str,
+    parent_b_session_id: str,
+    *,
+    from_a: Iterable[str] = (),
+    from_b: Iterable[str] = (),
+    pre_affect: AffectSnapshot | None = None,
+    created_at: str | None = None,
+) -> StoredSession:
+    """Create and persist a new session that remembers both ancestors."""
+
+    parent_a = archive.get(parent_a_session_id)
+    parent_b = archive.get(parent_b_session_id)
+    plan, suggestion = create_confluence_plan(
+        parent_a,
+        parent_b,
+        from_a=from_a,
+        from_b=from_b,
+        pre_affect=pre_affect,
+        created_at=created_at,
+    )
+    archive.create(plan)
+    archive.append_event(
+        plan.session_id,
+        kind="confluence",
+        label=f"{parent_a.plan.title} × {parent_b.plan.title}",
+        payload={
+            "schema": "pysbagen.living-session-confluence.v1",
+            "parent_a": _parent_summary(parent_a),
+            "parent_b": _parent_summary(parent_b),
+            "inheritance": [item.to_dict() for item in suggestion.assignments],
+            "tensions": list(suggestion.tensions),
+            "rationale": suggestion.rationale,
+            "new_seed": plan.recipe_manifest["request"]["seed"],
+            "backend_policy_resolution": (
+                "parents agree"
+                if parent_a.plan.backend_policy == parent_b.plan.backend_policy
+                else "parents differ; Confluence uses auto rather than silently preferring either renderer policy"
+            ),
+        },
+    )
+    return archive.get(plan.session_id)
+
+
+def confluence_metadata(stored: StoredSession) -> dict[str, Any] | None:
+    """Return the persisted Confluence event payload for a session, if present."""
+
+    events = [event for event in stored.events if event.kind == "confluence"]
+    if not events:
+        return None
+    return max(events, key=lambda event: (event.created_at, event.event_id)).payload
+
+
+def build_confluence_constellation(
+    archive: LivingSessionArchive,
+    *,
+    focus_session_id: str | None = None,
+) -> dict[str, Any]:
+    """Enrich the ordinary constellation with second-parent Confluence edges."""
+
+    graph = build_constellation(archive, focus_session_id=focus_session_id)
+    visible_ids = {node["session_id"] for node in graph["nodes"]}
+    edges = list(graph["edges"])
+    existing = {edge["edge_id"] for edge in edges}
+    confluence_count = 0
+    for stored in archive.list_sessions():
+        if stored.plan.session_id not in visible_ids:
+            continue
+        metadata = confluence_metadata(stored)
+        if not metadata:
+            continue
+        parent_b = str((metadata.get("parent_b") or {}).get("session_id") or "")
+        if not parent_b or parent_b not in visible_ids:
+            continue
+        edge_id = f"{parent_b}->{stored.plan.session_id}:confluence-b"
+        if edge_id in existing:
+            continue
+        edges.append(
+            {
+                "edge_id": edge_id,
+                "source": parent_b,
+                "target": stored.plan.session_id,
+                "mode": "confluence-b",
+                "short_label": "confluence · B",
+                "mutations": [],
+                "change_count": 0,
+                "experimental": True,
+                "recipe_identity_preserved": False,
+                "causal_interpretability": "multi-ancestor",
+            }
+        )
+        existing.add(edge_id)
+        confluence_count += 1
+
+    confluence_ids = {
+        stored.plan.session_id
+        for stored in archive.list_sessions()
+        if confluence_metadata(stored) is not None
+    }
+    expected_cross_lineage_codes = {"parent-lineage-mismatch", "generation-gap"}
+    graph["warnings"] = [
+        warning
+        for warning in graph["warnings"]
+        if not (
+            warning["session_id"] in confluence_ids
+            and warning["code"] in expected_cross_lineage_codes
+        )
+    ]
+    for node in graph["nodes"]:
+        if node["session_id"] in confluence_ids:
+            node["warnings"] = [
+                warning
+                for warning in node["warnings"]
+                if warning["code"] not in expected_cross_lineage_codes
+            ]
+
+    graph["edges"] = sorted(edges, key=lambda edge: (edge["source"], edge["target"], edge["edge_id"]))
+    graph["counts"]["edges"] = len(graph["edges"])
+    graph["counts"]["warnings"] = len(graph["warnings"])
+    graph["counts"]["confluence_second_parent_edges"] = confluence_count
+    graph["schema"] = "pysbagen.living-session-constellation.confluence.v1"
+    snapshot_payload = {
+        "nodes": graph["nodes"],
+        "edges": graph["edges"],
+        "warnings": graph["warnings"],
+        "lineages": graph["lineages"],
+    }
+    graph["snapshot_sha256"] = hashlib.sha256(
+        json.dumps(snapshot_payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+    return graph
+
+
+def describe_confluence(stored: StoredSession) -> dict[str, Any]:
+    """Return a user-facing hybrid identity and inheritance summary."""
+
+    metadata = confluence_metadata(stored)
+    if metadata is None:
+        raise ValueError(f"Session {stored.plan.session_id} is not a Confluence session")
+    return {
+        "session_id": stored.plan.session_id,
+        "title": stored.plan.title,
+        "memory_phrase": stored.plan.memory_phrase,
+        "lineage_id": stored.plan.lineage_id,
+        "generation": stored.plan.generation,
+        "recipe_sha256": stored.plan.recipe_sha256,
+        "status": stored.status,
+        "parent_a": metadata["parent_a"],
+        "parent_b": metadata["parent_b"],
+        "inheritance": metadata["inheritance"],
+        "tensions": metadata["tensions"],
+        "rationale": metadata["rationale"],
+        "backend_policy": stored.plan.backend_policy,
+        "outcome": stored.outcome.to_dict() if stored.outcome else None,
+    }
+
+
+def _validate_parents(parent_a: StoredSession, parent_b: StoredSession) -> None:
+    if parent_a.plan.session_id == parent_b.plan.session_id:
+        raise ValueError("Confluence requires two distinct remembered sessions")
+    _request_from_plan(parent_a.plan)
+    _request_from_plan(parent_b.plan)
+
+
+def _request_from_plan(plan: LivingSessionPlan) -> SleepRequest:
+    manifest = plan.recipe_manifest
+    if manifest.get("format") != "pysbagen-sleep-recipe-v1":
+        raise ValueError("Confluence currently supports Living Sessions with sleep recipe manifests")
+    payload = dict(manifest.get("request") or {})
+    layers = payload.get("layers")
+    if layers is not None:
+        payload["layers"] = SleepLayers(**layers)
+    request = SleepRequest(**payload)
+    request.validate()
+    return request
+
+
+def _trait_values(request: SleepRequest) -> dict[str, Any]:
+    layers = request.layers or SleepLayers()
+    return {
+        "problem": request.problem,
+        "sound_world": request.sound_world,
+        "intensity": request.intensity,
+        "duration_minutes": float(request.duration_minutes),
+        "layers": asdict(layers),
+    }
+
+
+def _normalize_trait_set(values: Iterable[str]) -> set[str]:
+    result = {value.strip() for value in values if value and value.strip()}
+    unknown = result - set(TRAIT_KEYS)
+    if unknown:
+        raise ValueError(
+            "Unknown Confluence trait(s): "
+            + ", ".join(sorted(unknown))
+            + ". Choose from: "
+            + ", ".join(TRAIT_KEYS)
+        )
+    return result
+
+
+def _bridge_value(trait: str, value_a: Any, value_b: Any) -> Any | None:
+    if trait == "intensity":
+        order = ["gentle", "balanced", "immersive"]
+        left, right = order.index(str(value_a)), order.index(str(value_b))
+        midpoint = order[(left + right) // 2]
+        if midpoint not in {value_a, value_b}:
+            return midpoint
+    if trait == "duration_minutes":
+        midpoint = round((float(value_a) + float(value_b)) / 2.0 / 5.0) * 5.0
+        if 10.0 <= midpoint <= 180.0 and midpoint not in {float(value_a), float(value_b)}:
+            return midpoint
+    if trait == "layers":
+        a = dict(value_a)
+        b = dict(value_b)
+        union = {key: bool(a.get(key) or b.get(key)) for key in sorted(set(a) | set(b))}
+        if union != a and union != b and any(union.values()):
+            return union
+    return None
+
+
+def _suggest_source(
+    trait: str,
+    *,
+    preferred: str,
+    parent_a: StoredSession,
+    parent_b: StoredSession,
+    existing: list[ConfluenceInheritance],
+) -> Literal["A", "B"]:
+    used = {item.source for item in existing}
+    if trait == "sound_world":
+        echoes_a = sum(event.kind == "echo" for event in parent_a.events)
+        echoes_b = sum(event.kind == "echo" for event in parent_b.events)
+        if echoes_a != echoes_b:
+            return "A" if echoes_a > echoes_b else "B"
+    if "A" not in used:
+        return "A"
+    if "B" not in used:
+        return "B"
+    if trait in {"problem", "intensity"}:
+        return preferred
+    return "B" if preferred == "A" else "A"
+
+
+def _ensure_both_parents_are_present(
+    assignments: list[ConfluenceInheritance],
+    *,
+    values_a: dict[str, Any],
+    values_b: dict[str, Any],
+    parent_a: StoredSession,
+    parent_b: StoredSession,
+    protected_a: set[str],
+    protected_b: set[str],
+) -> list[ConfluenceInheritance]:
+    sources = {item.source for item in assignments}
+    if "A" in sources and "B" in sources:
+        return assignments
+
+    mutable = list(assignments)
+    missing = "A" if "A" not in sources else "B"
+    protected_other = protected_b if missing == "A" else protected_a
+    for index, item in enumerate(mutable):
+        if item.source not in {"A", "B"}:
+            continue
+        if item.trait in protected_other:
+            continue
+        a, b = values_a[item.trait], values_b[item.trait]
+        if a == b:
+            continue
+        value = a if missing == "A" else b
+        mutable[index] = ConfluenceInheritance(
+            item.trait,
+            missing,
+            value,
+            _inheritance_reason(item.trait, missing, parent_a, parent_b)
+            + " This also keeps the Confluence genuinely dual-parent.",
+        )
+        return mutable
+    return mutable
+
+
+def _inheritance_reason(
+    trait: str,
+    source: str,
+    parent_a: StoredSession,
+    parent_b: StoredSession,
+) -> str:
+    parent = parent_a if source == "A" else parent_b
+    echo_count = sum(event.kind == "echo" for event in parent.events)
+    outcome = parent.outcome
+    memory_bits = []
+    if echo_count:
+        memory_bits.append(f"{echo_count} remembered echo{'es' if echo_count != 1 else ''}")
+    if outcome is not None:
+        memory_bits.append(f"{outcome.rating}/5 outcome")
+        if outcome.would_repeat:
+            memory_bits.append("marked worth repeating")
+    memory = ", ".join(memory_bits) if memory_bits else "its recognizable recipe identity"
+    return f"Carry Parent {source}'s {_TRAIT_LABELS[trait]} because this memory contributes {memory}."
+
+
+def _memory_score(stored: StoredSession) -> tuple[int, int, int, str]:
+    outcome = stored.outcome
+    rating = outcome.rating if outcome else 0
+    repeat = int(bool(outcome and outcome.would_repeat))
+    echoes = sum(event.kind == "echo" for event in stored.events)
+    return rating, repeat, echoes, stored.plan.session_id
+
+
+def _selected_user_audio(
+    sound_world: Any,
+    *,
+    request_a: SleepRequest,
+    request_b: SleepRequest,
+    assignments: tuple[ConfluenceInheritance, ...],
+) -> str | None:
+    if sound_world != "user_audio":
+        return None
+    sound_assignment = next(item for item in assignments if item.trait == "sound_world")
+    if sound_assignment.source == "A":
+        return request_a.user_audio
+    if sound_assignment.source == "B":
+        return request_b.user_audio
+    if request_a.user_audio and request_b.user_audio and request_a.user_audio == request_b.user_audio:
+        return request_a.user_audio
+    raise ValueError(
+        "A new/shared user_audio Confluence requires both parents to reference the same available audio file"
+    )
+
+
+def _layers_from_value(value: Any) -> SleepLayers:
+    if isinstance(value, SleepLayers):
+        return value
+    payload = dict(value)
+    layers = SleepLayers(**payload)
+    if not layers.enabled_names():
+        raise ValueError("Confluence cannot disable every audio layer")
+    return layers
+
+
+def _new_seed(parent_a: LivingSessionPlan, parent_b: LivingSessionPlan, selected: dict[str, Any]) -> int:
+    digest = _hash(
+        {
+            "kind": "confluence-seed",
+            "parent_a_recipe": parent_a.recipe_sha256,
+            "parent_b_recipe": parent_b.recipe_sha256,
+            "selected": selected,
+        }
+    )
+    return int(digest[:8], 16) % (2**31 - 2) + 1
+
+
+def _hybrid_identity(
+    parent_a: LivingSessionPlan,
+    parent_b: LivingSessionPlan,
+    recipe_sha256: str,
+) -> tuple[str, tuple[str, ...]]:
+    a_words = parent_a.title.split()
+    b_words = parent_b.title.split()
+    adjective = a_words[0] if a_words else "Meeting"
+    noun = b_words[-1] if b_words else "Current"
+    title = f"{adjective} {noun}"
+    if title in {parent_a.title, parent_b.title}:
+        adjective = b_words[0] if b_words else "Braided"
+        noun = a_words[-1] if a_words else "Tide"
+        title = f"{adjective} {noun}"
+    if title in {parent_a.title, parent_b.title}:
+        title = f"Confluence {recipe_sha256[:6]}"
+
+    motifs: list[str] = []
+    for motif in (*parent_a.motif, *parent_b.motif):
+        if motif not in motifs:
+            motifs.append(motif)
+        if len(motifs) == 2:
+            break
+    bridge_motifs = ("meeting", "braid", "crossing", "confluence", "weave", "delta")
+    bridge = bridge_motifs[int(recipe_sha256[:8], 16) % len(bridge_motifs)]
+    if bridge not in motifs:
+        motifs.append(bridge)
+    while len(motifs) < 3:
+        fallback = bridge_motifs[(int(recipe_sha256[len(motifs):len(motifs)+8], 16) + len(motifs)) % len(bridge_motifs)]
+        if fallback not in motifs:
+            motifs.append(fallback)
+    return title, tuple(motifs[:3])
+
+
+def _parent_summary(stored: StoredSession) -> dict[str, Any]:
+    return {
+        "session_id": stored.plan.session_id,
+        "lineage_id": stored.plan.lineage_id,
+        "title": stored.plan.title,
+        "memory_phrase": stored.plan.memory_phrase,
+        "recipe_sha256": stored.plan.recipe_sha256,
+        "generation": stored.plan.generation,
+        "rating": stored.outcome.rating if stored.outcome else None,
+        "would_repeat": stored.outcome.would_repeat if stored.outcome else None,
+        "echo_count": sum(event.kind == "echo" for event in stored.events),
+    }
+
+
+def _display(value: Any) -> str:
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value, sort_keys=True, ensure_ascii=False)
+    return str(value)
+
+
+def _hash(payload: Any, length: int = 64) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:length]
+
+
+def _utc_now() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat()

--- a/pysbagen/confluence_cli.py
+++ b/pysbagen/confluence_cli.py
@@ -1,0 +1,141 @@
+"""CLI for Living Sessions Confluence experiences."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from .confluence import (
+    TRAIT_KEYS,
+    build_confluence_constellation,
+    create_confluence_session,
+    describe_confluence,
+    suggest_confluence,
+)
+from .constellation import constellation_to_text, render_constellation_html
+from .living_sessions import LivingSessionArchive
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sbgpy-confluence",
+        description="Combine two remembered Living Sessions into a new reproducible experience.",
+    )
+    parser.add_argument("--root", help="Living-session archive root")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    for name, help_text in (
+        ("suggest", "Preview inheritance without writing a session"),
+        ("create", "Create and remember a Confluence session"),
+    ):
+        cmd = commands.add_parser(name, help=help_text)
+        cmd.add_argument("parent_a")
+        cmd.add_argument("parent_b")
+        cmd.add_argument("--from-a", default="", help=f"Comma-separated: {', '.join(TRAIT_KEYS)}")
+        cmd.add_argument("--from-b", default="", help=f"Comma-separated: {', '.join(TRAIT_KEYS)}")
+        cmd.add_argument("--json", action="store_true", dest="as_json")
+
+    show = commands.add_parser("show", help="Show both ancestors and inheritance")
+    show.add_argument("session_id")
+    show.add_argument("--json", action="store_true", dest="as_json")
+
+    graph = commands.add_parser("constellation", help="Show dual-parent ancestry")
+    graph.add_argument("--focus")
+    graph.add_argument("--html", nargs="?", const="living-session-confluence-constellation.html")
+    graph.add_argument("--json", action="store_true", dest="as_json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    archive = LivingSessionArchive(args.root)
+    try:
+        if args.command == "suggest":
+            a, b = archive.get(args.parent_a), archive.get(args.parent_b)
+            suggestion = suggest_confluence(
+                a, b, from_a=_traits(args.from_a), from_b=_traits(args.from_b)
+            )
+            payload = suggestion.to_dict()
+            _emit(payload, args.as_json, header=f"{a.plan.memory_phrase} x {b.plan.memory_phrase}")
+            return 0
+
+        if args.command == "create":
+            stored = create_confluence_session(
+                archive,
+                args.parent_a,
+                args.parent_b,
+                from_a=_traits(args.from_a),
+                from_b=_traits(args.from_b),
+            )
+            payload = describe_confluence(stored)
+            _emit(payload, args.as_json, header=f"Created {payload['memory_phrase']}")
+            if not args.as_json:
+                print("Use sbgpy-session render/mark/finish with this session ID, or reuse it as a later ancestor.")
+            return 0
+
+        if args.command == "show":
+            payload = describe_confluence(archive.get(args.session_id))
+            _emit(payload, args.as_json, header=payload["memory_phrase"])
+            return 0
+
+        graph = build_confluence_constellation(archive, focus_session_id=args.focus)
+        html_export = None
+        if args.html:
+            path = Path(args.html).expanduser()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(render_constellation_html(graph), encoding="utf-8")
+            html_export = {"path": str(path.resolve()), "sha256": _sha256(path)}
+        if args.as_json:
+            payload = {"constellation": graph}
+            if html_export:
+                payload["html_export"] = html_export
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(constellation_to_text(graph))
+            print(
+                "Confluence second-parent connections: "
+                f"{graph['counts'].get('confluence_second_parent_edges', 0)}"
+            )
+            for edge in graph["edges"]:
+                if edge["mode"] == "confluence-b":
+                    print(f"  B {edge['source'][:8]} -> {edge['target'][:8]}")
+            if html_export:
+                print(f"Offline navigator: {html_export['path']}")
+                print(f"HTML SHA-256: {html_export['sha256']}")
+        return 0
+    except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"sbgpy-confluence: {exc}") from exc
+
+
+def _traits(value: str) -> tuple[str, ...]:
+    return tuple(part.strip() for part in value.split(",") if part.strip())
+
+
+def _emit(payload: dict, as_json: bool, *, header: str) -> None:
+    if as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    print(header)
+    if "session_id" in payload:
+        print(f"Session: {payload['session_id']}")
+    for item in payload.get("assignments", payload.get("inheritance", [])):
+        print(f"  {item['trait']} <- {item['source']}: {json.dumps(item['value'], sort_keys=True)}")
+        print(f"    {item['reason']}")
+    for tension in payload.get("tensions", []):
+        print(f"  tension: {tension}")
+    if payload.get("rationale"):
+        print(payload["rationale"])
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pysbagen/constellation.py
+++ b/pysbagen/constellation.py
@@ -1,0 +1,306 @@
+"""Read-only Living Sessions constellation snapshots and offline navigation."""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from .living_sessions import LivingSessionArchive, StoredSession
+
+NODE_W, NODE_H, X_GAP, Y_GAP, MARGIN = 232, 108, 292, 138, 64
+
+
+@dataclass(frozen=True)
+class ConstellationWarning:
+    code: str
+    session_id: str
+    detail: str
+
+
+def build_constellation(
+    archive: LivingSessionArchive,
+    *,
+    lineage_id: str | None = None,
+    focus_session_id: str | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic graph without modifying the archive."""
+    sessions = archive.list_sessions()
+    if lineage_id is not None:
+        sessions = [s for s in sessions if s.plan.lineage_id == lineage_id]
+        if not sessions:
+            raise KeyError(f"Living-session lineage not found: {lineage_id}")
+    by_id = {s.plan.session_id: s for s in sessions}
+    if focus_session_id is not None and focus_session_id not in by_id:
+        raise KeyError(f"Living session is not present in this constellation: {focus_session_id}")
+
+    warnings = _warnings(sessions, by_id)
+    layout, canvas = _layout(sessions)
+    ordered = sorted(sessions, key=_sort_key)
+    nodes = [_node(s, layout[s.plan.session_id], warnings) for s in ordered]
+    edges = [
+        _edge(s, by_id[s.plan.parent_session_id])
+        for s in ordered
+        if s.plan.parent_session_id in by_id
+    ]
+    lineages = _lineages(sessions)
+    snapshot_payload = {
+        "nodes": nodes,
+        "edges": edges,
+        "warnings": [asdict(w) for w in warnings],
+        "lineages": lineages,
+    }
+    snapshot = hashlib.sha256(_canonical(snapshot_payload).encode()).hexdigest()
+    return {
+        "schema": "pysbagen.living-session-constellation.v1",
+        "snapshot_sha256": snapshot,
+        "scope": {
+            "archive_root": str(archive.root.resolve()),
+            "lineage_id": lineage_id,
+            "focus_session_id": focus_session_id,
+        },
+        "counts": {
+            "sessions": len(nodes),
+            "edges": len(edges),
+            "lineages": len(lineages),
+            "completed": sum(n["status"] == "completed" for n in nodes),
+            "echoes": sum(n["echo_count"] for n in nodes),
+            "warnings": len(warnings),
+        },
+        "canvas": canvas,
+        "lineages": lineages,
+        "nodes": nodes,
+        "edges": edges,
+        "warnings": [asdict(w) for w in warnings],
+        "interpretation_note": (
+            "The constellation is a local navigation and provenance surface. "
+            "Outcome patterns are descriptive personal records, not medical-efficacy conclusions."
+        ),
+    }
+
+
+def constellation_to_text(graph: dict[str, Any]) -> str:
+    counts = graph["counts"]
+    lines = [
+        "PySbagen Living Sessions Constellation",
+        f"Snapshot: {graph['snapshot_sha256']}",
+        f"Sessions: {counts['sessions']} · lineages: {counts['lineages']} · connections: {counts['edges']} · echoes: {counts['echoes']}",
+    ]
+    if counts["warnings"]:
+        lines.append(f"Structural warnings: {counts['warnings']}")
+    for lineage in graph["lineages"]:
+        lines.extend(["", f"Lineage {lineage['lineage_id']} · {lineage['session_count']} session(s) · latest {lineage['latest_session_id']}"])
+        items = [n for n in graph["nodes"] if n["lineage_id"] == lineage["lineage_id"]]
+        for n in sorted(items, key=lambda x: (x["generation"], x["created_at"], x["session_id"])):
+            parent = "ROOT" if n["parent_session_id"] is None else f"↳ {n['parent_session_id'][:8]}"
+            rating = f" · {n['outcome']['rating']}/5" if n["outcome"] else ""
+            echoes = f" · {n['echo_count']} echo(es)" if n["echo_count"] else ""
+            lines.append(f"  g{n['generation']} {parent:10} {n['mode']:8} {n['memory_phrase']} [{n['status']}]{rating}{echoes}")
+            for mutation in n["mutations"]:
+                lines.append(f"      {mutation['key']}: {_display(mutation['before'])} → {_display(mutation['after'])}")
+    lines.extend(["", graph["interpretation_note"]])
+    return "\n".join(lines)
+
+
+def render_constellation_html(
+    graph: dict[str, Any],
+    *,
+    title: str = "PySbagen Living Sessions Constellation",
+) -> str:
+    """Render a self-contained HTML navigator with no remote resources."""
+    data = _html_json(graph)
+    template = """<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>__TITLE__</title><style>
+:root{color-scheme:dark;--bg:#101318;--panel:#1a2028;--text:#eef3f8;--muted:#aab6c4;--line:#637287;--accent:#8dd3ff;--good:#8ce99a;--warn:#ffd166}*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font:14px/1.45 system-ui,sans-serif}header{padding:14px 18px;border-bottom:1px solid #303947;display:flex;gap:16px;justify-content:space-between;align-items:flex-start}h1{font-size:20px;margin:0}.meta,.note{color:var(--muted)}.controls{display:flex;gap:8px;flex-wrap:wrap}.controls input,.controls select{background:#202733;color:var(--text);border:1px solid #435064;border-radius:7px;padding:7px}main{display:grid;grid-template-columns:minmax(0,1fr) 350px;height:calc(100vh - 76px)}#view{overflow:auto;position:relative;background:radial-gradient(circle at 1px 1px,#29323e 1px,transparent 0);background-size:24px 24px}#canvas{position:relative}svg{position:absolute;inset:0;pointer-events:none}.edge{fill:none;stroke:var(--line);stroke-width:2}.edge.return{stroke-dasharray:7 6}.edge.wander{stroke:var(--warn)}.edge-label{fill:var(--muted);font-size:11px;text-anchor:middle;paint-order:stroke;stroke:var(--bg);stroke-width:5px}.node{position:absolute;width:232px;min-height:108px;text-align:left;padding:10px;border:1px solid #47556a;border-left:5px solid #95a2b2;border-radius:11px;background:#1b222c;color:var(--text);cursor:pointer;box-shadow:0 8px 22px #0007}.node.active{border-left-color:var(--accent)}.node.completed{border-left-color:var(--good)}.node.wander{background:#29251d}.node.warning:after{content:'!';position:absolute;right:8px;top:6px;color:var(--warn);font-weight:800}.node:hover,.node:focus-visible,.node.selected{outline:none;border-color:var(--accent);box-shadow:0 0 0 2px #8dd3ff44}.title{font-weight:750;font-size:15px}.sub{font-size:11px;color:var(--muted)}.chips{display:flex;gap:4px;flex-wrap:wrap;margin-top:8px}.chip{border:1px solid #435064;border-radius:999px;padding:1px 6px;font-size:10px}#details{overflow:auto;border-left:1px solid #303947;background:var(--panel);padding:16px}#details h2{margin:0}#details h3{font-size:12px;color:var(--accent);letter-spacing:.08em;text-transform:uppercase;margin:18px 0 6px}.kv{display:grid;grid-template-columns:112px minmax(0,1fr);gap:4px 8px}.kv dt{color:var(--muted)}.kv dd{margin:0;overflow-wrap:anywhere}.empty{padding:24px;color:var(--muted)}.warning-text{color:var(--warn)}@media(max-width:850px){main{grid-template-columns:1fr;grid-template-rows:60vh auto;height:auto}#details{border-left:0;border-top:1px solid #303947}}
+</style></head><body><header><div><h1>__TITLE__</h1><div id="summary" class="meta"></div></div><div class="controls"><input id="search" type="search" placeholder="Search title, motif, echo, hash…"><select id="lineage" aria-label="Filter lineage"></select><select id="status"><option value="">All statuses</option><option>planned</option><option>active</option><option>completed</option></select><select id="mode"><option value="">All modes</option><option>root</option><option>return</option><option>branch</option><option>contrast</option><option>wander</option></select></div></header>
+<main><section id="view"><div id="canvas"><svg id="edges"></svg><div id="nodes"></div></div></section><aside id="details"><div class="empty">Select a session to inspect changes, memory, outcome, backend, and provenance.</div></aside></main>
+<script id="constellation-data" type="application/json">__DATA__</script><script>
+'use strict';const d=JSON.parse(document.getElementById('constellation-data').textContent),map=new Map(d.nodes.map(n=>[n.session_id,n]));let selected=null;const canvas=document.getElementById('canvas'),svg=document.getElementById('edges'),layer=document.getElementById('nodes'),details=document.getElementById('details'),search=document.getElementById('search'),lineage=document.getElementById('lineage'),status=document.getElementById('status'),mode=document.getElementById('mode');canvas.style.width=d.canvas.width+'px';canvas.style.height=d.canvas.height+'px';svg.setAttribute('width',d.canvas.width);svg.setAttribute('height',d.canvas.height);document.getElementById('summary').textContent=`${d.counts.sessions} sessions · ${d.counts.lineages} lineages · ${d.counts.echoes} echoes · ${d.snapshot_sha256}`;
+const esc=v=>String(v??'—').replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));lineage.innerHTML='<option value="">All lineages</option>'+d.lineages.map(x=>`<option value="${esc(x.lineage_id)}">${esc(x.lineage_id)} · ${x.session_count}</option>`).join('');const shown=n=>{const q=search.value.trim().toLowerCase();return(!q||JSON.stringify(n).toLowerCase().includes(q))&&(!lineage.value||n.lineage_id===lineage.value)&&(!status.value||n.status===status.value)&&(!mode.value||n.mode===mode.value)};const path=(a,b)=>{const x1=a.layout.x+232,y1=a.layout.y+54,x2=b.layout.x,y2=b.layout.y+54,k=Math.max(70,(x2-x1)*.48);return`M ${x1} ${y1} C ${x1+k} ${y1}, ${x2-k} ${y2}, ${x2} ${y2}`};
+function render(){layer.innerHTML='';svg.innerHTML='';const ids=new Set(d.nodes.filter(shown).map(n=>n.session_id));for(const e of d.edges){if(!ids.has(e.source)||!ids.has(e.target))continue;const a=map.get(e.source),b=map.get(e.target),p=document.createElementNS('http://www.w3.org/2000/svg','path'),t=document.createElementNS('http://www.w3.org/2000/svg','text');p.setAttribute('d',path(a,b));p.setAttribute('class','edge '+e.mode);t.setAttribute('x',(a.layout.x+232+b.layout.x)/2);t.setAttribute('y',(a.layout.y+b.layout.y)/2+46);t.setAttribute('class','edge-label');t.textContent=e.short_label;svg.append(p,t)}for(const n of d.nodes){if(!ids.has(n.session_id))continue;const b=document.createElement('button');b.className=`node ${n.status} ${n.mode} ${n.warnings.length?'warning':''} ${selected===n.session_id?'selected':''}`;b.style.left=n.layout.x+'px';b.style.top=n.layout.y+'px';b.dataset.id=n.session_id;b.innerHTML=`<div class="title">${esc(n.title)}</div><div class="sub">g${n.generation} · ${esc(n.mode)} · ${esc(n.session_id.slice(0,8))}</div><div class="chips"><span class="chip">${esc(n.status)}</span><span class="chip">${n.echo_count} echo</span>${n.outcome?`<span class="chip">${n.outcome.rating}/5</span>`:''}<span class="chip">${esc(n.backend.policy)}</span></div>`;b.onclick=()=>select(n.session_id,true);layer.appendChild(b)}if(!ids.size)layer.innerHTML='<div class="empty">No sessions match the filters.</div>'}
+const row=(k,v)=>`<dt>${esc(k)}</dt><dd>${esc(v)}</dd>`,list=(xs,f)=>xs.length?`<ul>${xs.map(x=>`<li>${f(x)}</li>`).join('')}</ul>`:'<div class="note">None recorded.</div>';function select(id,scroll){selected=id;const n=map.get(id);render();details.innerHTML=`<h2>${esc(n.title)}</h2><div class="note">${esc(n.motif.join(' / '))}</div><h3>Identity</h3><dl class="kv">${row('Session',n.session_id)}${row('Lineage',n.lineage_id)}${row('Parent',n.parent_session_id)}${row('Generation',n.generation)}${row('Mode',n.mode)}${row('Status',n.status)}</dl><h3>Recipe</h3><dl class="kv">${row('SHA-256',n.recipe_sha256)}${row('Problem',n.recipe.problem)}${row('Sound world',n.recipe.sound_world)}${row('Intensity',n.recipe.intensity)}${row('Duration',n.recipe.duration_minutes+' min')}${row('Layers',n.recipe.layers.join(', ')||'default')}</dl><h3>Changes</h3>${list(n.mutations,m=>`${esc(m.key)}: <b>${esc(JSON.stringify(m.before))}</b> → <b>${esc(JSON.stringify(m.after))}</b><br><span class="note">${esc(m.reason)}</span>`)}<h3>Echoes and events</h3>${list(n.echoes,e=>`${esc(e.label)}${e.position_seconds==null?'':` @ ${e.position_seconds}s`}`)}<h3>Outcome</h3>${n.outcome?`<dl class="kv">${row('Rating',n.outcome.rating+'/5')}${row('Comfort',n.outcome.comfort)}${row('Would repeat',n.outcome.would_repeat?'yes':'no')}${row('Tags',n.outcome.tags.join(', '))}${row('Affect delta',n.outcome.affect_delta?JSON.stringify(n.outcome.affect_delta):'not recorded')}</dl>`:'<div class="note">Not recorded.</div>'}<h3>Backend and provenance</h3><dl class="kv">${row('Policy',n.backend.policy)}${row('Actual',n.backend.actual_backends.join(', ')||'not rendered')}${row('Output SHA',n.backend.latest_output_sha256)}${row('Interpretability',n.causal_interpretability)}</dl>${n.warnings.length?`<h3>Structural warnings</h3>${list(n.warnings,w=>`<span class="warning-text">${esc(w.detail)}</span>`)}`:''}<p class="note">${esc(d.interpretation_note)}</p>`;if(scroll)[...document.querySelectorAll('.node')].find(x=>x.dataset.id===id)?.scrollIntoView({behavior:'smooth',block:'center',inline:'center'})}for(const x of[search,lineage,status,mode])x.addEventListener('input',render);render();if(d.scope.focus_session_id)select(d.scope.focus_session_id,true);else if(d.nodes.length)select(d.nodes[0].session_id,false);
+</script></body></html>"""
+    return template.replace("__TITLE__", html.escape(title, quote=True)).replace("__DATA__", data)
+
+
+def write_constellation_html(
+    archive: LivingSessionArchive,
+    path: str | Path,
+    *,
+    lineage_id: str | None = None,
+    focus_session_id: str | None = None,
+    title: str = "PySbagen Living Sessions Constellation",
+) -> tuple[Path, dict[str, Any]]:
+    graph = build_constellation(archive, lineage_id=lineage_id, focus_session_id=focus_session_id)
+    destination = Path(path).expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{destination.name}-", suffix=".tmp", dir=destination.parent)
+    os.close(fd)
+    temporary = Path(temporary_name)
+    try:
+        temporary.write_text(render_constellation_html(graph, title=title), encoding="utf-8")
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return destination.resolve(), graph
+
+
+def _sort_key(s: StoredSession) -> tuple[Any, ...]:
+    return s.plan.lineage_id, s.plan.generation, s.plan.created_at, s.plan.session_id
+
+
+def _layout(sessions: list[StoredSession]) -> tuple[dict[str, dict[str, int]], dict[str, int]]:
+    grouped: dict[str, list[StoredSession]] = {}
+    for s in sessions:
+        grouped.setdefault(s.plan.lineage_id, []).append(s)
+    positions: dict[str, dict[str, int]] = {}
+    top, max_generation = MARGIN, 0
+    for lineage_id in sorted(grouped):
+        generations: dict[int, list[StoredSession]] = {}
+        for s in grouped[lineage_id]:
+            generations.setdefault(s.plan.generation, []).append(s)
+            max_generation = max(max_generation, s.plan.generation)
+        rows = max((len(v) for v in generations.values()), default=1)
+        for generation, items in sorted(generations.items()):
+            ordered = sorted(items, key=lambda s: (s.plan.created_at, s.plan.session_id))
+            offset = (rows - len(ordered)) * Y_GAP // 2
+            for index, s in enumerate(ordered):
+                positions[s.plan.session_id] = {"x": MARGIN + generation * X_GAP, "y": top + offset + index * Y_GAP}
+        top += max(NODE_H + 58, rows * Y_GAP) + 82
+    width = max(760, MARGIN * 2 + (max_generation + 1) * X_GAP + NODE_W)
+    return positions, {"width": width, "height": max(450, top + MARGIN - 82)}
+
+
+def _node(s: StoredSession, layout: dict[str, int], warnings: list[ConstellationWarning]) -> dict[str, Any]:
+    plan, request = s.plan, s.plan.recipe_manifest.get("request") or {}
+    layer_data = request.get("layers") or {}
+    echoes = [
+        {"event_id": e.event_id, "kind": e.kind, "label": e.label, "position_seconds": e.position_seconds, "created_at": e.created_at, "payload": e.payload}
+        for e in s.events if e.kind in {"echo", "shift", "insight", "discomfort"}
+    ]
+    renders = [e for e in s.events if e.kind == "render"]
+    latest = max(renders, key=lambda e: e.created_at) if renders else None
+    return {
+        "session_id": plan.session_id, "lineage_id": plan.lineage_id,
+        "parent_session_id": plan.parent_session_id, "generation": plan.generation,
+        "mode": plan.mode, "title": plan.title, "motif": list(plan.motif),
+        "memory_phrase": plan.memory_phrase, "created_at": plan.created_at,
+        "status": s.status, "experimental": plan.experimental, "rationale": plan.rationale,
+        "recipe_sha256": plan.recipe_sha256,
+        "recipe": {
+            "problem": request.get("problem"), "sound_world": request.get("sound_world"),
+            "intensity": request.get("intensity"), "duration_minutes": request.get("duration_minutes"),
+            "seed": request.get("seed"), "layers": sorted(k for k, v in layer_data.items() if v),
+            "user_audio_bound": bool(request.get("user_audio")),
+        },
+        "mutations": [asdict(m) for m in plan.mutations],
+        "echo_count": sum(e.kind == "echo" for e in s.events), "echoes": echoes,
+        "event_count": len(s.events), "outcome": _outcome(s),
+        "backend": {
+            "policy": plan.backend_policy,
+            "actual_backends": sorted({str(e.payload.get("actual_backend")) for e in renders if e.payload.get("actual_backend")}),
+            "latest_output_sha256": latest.payload.get("output_sha256") if latest else None,
+            "latest_output_path": latest.payload.get("output_path") if latest else None,
+            "latest_backend_reason": latest.payload.get("backend_reason") if latest else None,
+        },
+        "causal_interpretability": _interpretability(plan.mode, len(plan.mutations)),
+        "warnings": [asdict(w) for w in warnings if w.session_id == plan.session_id],
+        "layout": layout,
+    }
+
+
+def _outcome(s: StoredSession) -> dict[str, Any] | None:
+    if s.outcome is None:
+        return None
+    before, after = s.plan.pre_affect, s.outcome.post_affect
+    delta = None if before is None or after is None else {
+        "valence": after.valence - before.valence,
+        "arousal": after.arousal - before.arousal,
+        "agency": after.agency - before.agency,
+    }
+    return {
+        "completed_at": s.outcome.completed_at, "rating": s.outcome.rating,
+        "would_repeat": s.outcome.would_repeat, "comfort": s.outcome.comfort,
+        "note": s.outcome.note, "tags": list(s.outcome.tags), "affect_delta": delta,
+    }
+
+
+def _edge(child: StoredSession, parent: StoredSession) -> dict[str, Any]:
+    mutations = [asdict(m) for m in child.plan.mutations]
+    keys = [m.key.removeprefix("request.") for m in child.plan.mutations]
+    label = "exact return" if child.plan.mode == "return" else child.plan.mode if not keys else f"{child.plan.mode} · {' + '.join(keys)}"
+    return {
+        "edge_id": f"{parent.plan.session_id}->{child.plan.session_id}",
+        "source": parent.plan.session_id, "target": child.plan.session_id,
+        "mode": child.plan.mode, "short_label": label, "mutations": mutations,
+        "change_count": len(mutations), "experimental": child.plan.experimental,
+        "recipe_identity_preserved": parent.plan.recipe_sha256 == child.plan.recipe_sha256,
+        "causal_interpretability": _interpretability(child.plan.mode, len(mutations)),
+    }
+
+
+def _lineages(sessions: list[StoredSession]) -> list[dict[str, Any]]:
+    grouped: dict[str, list[StoredSession]] = {}
+    for s in sessions:
+        grouped.setdefault(s.plan.lineage_id, []).append(s)
+    result = []
+    for lineage_id, items in sorted(grouped.items()):
+        ordered = sorted(items, key=_sort_key)
+        latest = max(ordered, key=lambda s: (s.plan.created_at, s.plan.session_id))
+        result.append({
+            "lineage_id": lineage_id, "session_count": len(ordered),
+            "completed_count": sum(s.outcome is not None for s in ordered),
+            "echo_count": sum(e.kind == "echo" for s in ordered for e in s.events),
+            "root_session_ids": [s.plan.session_id for s in ordered if s.plan.parent_session_id is None],
+            "latest_session_id": latest.plan.session_id,
+            "max_generation": max(s.plan.generation for s in ordered),
+            "titles": [s.plan.title for s in ordered],
+        })
+    return result
+
+
+def _warnings(sessions: list[StoredSession], by_id: dict[str, StoredSession]) -> list[ConstellationWarning]:
+    result: list[ConstellationWarning] = []
+    for s in sessions:
+        p, parent_id = s.plan, s.plan.parent_session_id
+        if parent_id is None:
+            if p.generation != 0:
+                result.append(ConstellationWarning("root-generation-mismatch", p.session_id, f"Session has no parent but reports generation {p.generation}."))
+            continue
+        parent = by_id.get(parent_id)
+        if parent is None:
+            result.append(ConstellationWarning("parent-not-in-snapshot", p.session_id, f"Parent {parent_id} is absent from the selected constellation snapshot."))
+            continue
+        if parent.plan.lineage_id != p.lineage_id:
+            result.append(ConstellationWarning("parent-lineage-mismatch", p.session_id, "Parent and child report different lineage identities."))
+        if p.generation != parent.plan.generation + 1:
+            result.append(ConstellationWarning("generation-gap", p.session_id, f"Child generation {p.generation} does not directly follow parent generation {parent.plan.generation}."))
+        if p.mode == "return" and p.recipe_sha256 != parent.plan.recipe_sha256:
+            result.append(ConstellationWarning("return-recipe-mismatch", p.session_id, "A return edge does not preserve the parent recipe SHA-256."))
+    return sorted(result, key=lambda w: (w.session_id, w.code, w.detail))
+
+
+def _interpretability(mode: str, changes: int) -> str:
+    if mode == "root": return "baseline"
+    if mode == "return" and changes == 0: return "exact-repeat"
+    if mode in {"branch", "contrast"} and changes == 1: return "high"
+    if mode == "wander" and 1 <= changes <= 2: return "bounded-exploration"
+    return "uncertain"
+
+
+def _display(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=False) if isinstance(value, (dict, list, tuple)) else str(value)
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _html_json(value: Any) -> str:
+    return _canonical(value).replace("&", "\\u0026").replace("<", "\\u003c").replace(">", "\\u003e").replace("\u2028", "\\u2028").replace("\u2029", "\\u2029")

--- a/pysbagen/constellation_cli.py
+++ b/pysbagen/constellation_cli.py
@@ -1,0 +1,120 @@
+"""CLI for exporting and opening offline Living Session constellations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import webbrowser
+from pathlib import Path
+
+from .constellation import (
+    build_constellation,
+    write_constellation_html,
+    write_constellation_json,
+)
+from .living_sessions import LivingSessionArchive
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sbgpy-constellation",
+        description=(
+            "Build a self-contained offline navigator for Living Session lineages, "
+            "mutations, echoes, outcomes, backends, and provenance."
+        ),
+    )
+    parser.add_argument("--root", help="Living-session archive root")
+    parser.add_argument("--lineage", help="Restrict the snapshot to one lineage ID")
+    parser.add_argument(
+        "--session",
+        dest="focus_session_id",
+        help="Focus one session and automatically restrict to its lineage",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["html", "json"],
+        default="html",
+        help="Snapshot format (default: html)",
+    )
+    parser.add_argument("-o", "--outfile", help="Destination path")
+    parser.add_argument(
+        "--redact-notes",
+        action="store_true",
+        help="Remove free-text notes, event labels/payloads, and user-audio paths",
+    )
+    parser.add_argument(
+        "--open",
+        action="store_true",
+        dest="open_after",
+        help="Open the generated HTML in the default browser",
+    )
+    parser.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="Print the snapshot summary and identity as JSON",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.open_after and args.format != "html":
+        raise SystemExit("sbgpy-constellation: --open requires --format html")
+
+    archive = LivingSessionArchive(args.root)
+    try:
+        graph = build_constellation(
+            archive,
+            lineage_id=args.lineage,
+            focus_session_id=args.focus_session_id,
+        )
+        default_name = (
+            f"living-constellation-{args.focus_session_id[:8]}.html"
+            if args.focus_session_id and args.format == "html"
+            else f"living-constellation.{args.format}"
+        )
+        destination = Path(args.outfile or default_name)
+        if args.format == "html":
+            written = write_constellation_html(
+                graph,
+                destination,
+                redact_notes=args.redact_notes,
+            )
+        else:
+            written = write_constellation_json(
+                graph,
+                destination,
+                redact_notes=args.redact_notes,
+            )
+    except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"sbgpy-constellation: {exc}") from exc
+
+    summary = graph.to_dict(redact_notes=args.redact_notes)["summary"]
+    receipt = {
+        "schema": "pysbagen.constellation-export-receipt.v1",
+        "path": str(written),
+        "format": args.format,
+        "graph_sha256": graph.graph_sha256,
+        "focus_session_id": graph.focus_session_id,
+        "lineage_filter": args.lineage,
+        "notes_redacted": args.redact_notes,
+        **summary,
+    }
+    if args.summary_json:
+        print(json.dumps(receipt, indent=2, sort_keys=True))
+    else:
+        print(
+            f"Wrote {summary['session_count']} session(s), {summary['edge_count']} relationship(s), "
+            f"and {summary['echo_count']} echo(es) to {written}"
+        )
+        print(f"Snapshot SHA-256: {graph.graph_sha256}")
+        if summary["warning_count"]:
+            print(f"Integrity warnings preserved: {summary['warning_count']}")
+
+    if args.open_after:
+        webbrowser.open(written.as_uri())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pysbagen/constellation_model.py
+++ b/pysbagen/constellation_model.py
@@ -1,0 +1,396 @@
+"""Truth-derived graph model for PySbagen Living Session constellations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from .living_sessions import LivingSessionArchive, StoredSession
+
+
+@dataclass(frozen=True)
+class ConstellationNode:
+    """One preserved Living Session represented as a navigable constellation node."""
+
+    session_id: str
+    lineage_id: str
+    parent_session_id: str | None
+    generation: int
+    mode: str
+    title: str
+    memory_phrase: str
+    motif: tuple[str, ...]
+    status: str
+    created_at: str
+    backend_policy: str
+    recipe_sha256: str
+    experimental: bool
+    rationale: str
+    mutations: tuple[dict[str, Any], ...]
+    events: tuple[dict[str, Any], ...]
+    outcome: dict[str, Any] | None
+    pre_affect: dict[str, Any] | None
+    request_summary: dict[str, Any]
+    x: int = 0
+    y: int = 0
+
+    @property
+    def echo_count(self) -> int:
+        return sum(event.get("kind") == "echo" for event in self.events)
+
+    @property
+    def render_count(self) -> int:
+        return sum(event.get("kind") == "render" for event in self.events)
+
+    @property
+    def rating(self) -> int | None:
+        if not self.outcome or self.outcome.get("rating") is None:
+            return None
+        return int(self.outcome["rating"])
+
+    def to_dict(self, *, redact_notes: bool = False) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["echo_count"] = self.echo_count
+        payload["render_count"] = self.render_count
+        payload["rating"] = self.rating
+        if redact_notes:
+            payload["rationale"] = ""
+            payload["events"] = [
+                {**event, "label": "[redacted]", "payload": {}}
+                for event in payload["events"]
+            ]
+            payload["pre_affect"] = _redact_affect_note(payload.get("pre_affect"))
+            if payload["outcome"]:
+                payload["outcome"]["note"] = None
+                payload["outcome"]["post_affect"] = _redact_affect_note(
+                    payload["outcome"].get("post_affect")
+                )
+            payload["request_summary"] = {
+                key: value
+                for key, value in payload["request_summary"].items()
+                if key != "user_audio"
+            }
+        return payload
+
+
+@dataclass(frozen=True)
+class ConstellationEdge:
+    """A parent-to-child relationship with disclosed mutation context."""
+
+    source_session_id: str
+    target_session_id: str
+    mode: str
+    label: str
+    experimental: bool
+    mutations: tuple[dict[str, Any], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ConstellationGraph:
+    """Deterministic snapshot of one or more local Living Session lineages."""
+
+    nodes: list[ConstellationNode]
+    edges: list[ConstellationEdge]
+    lineages: list[dict[str, Any]]
+    integrity_warnings: list[str] = field(default_factory=list)
+    focus_session_id: str | None = None
+    generated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    schema_version: str = "pysbagen.living-session-constellation.v1"
+
+    @property
+    def graph_sha256(self) -> str:
+        identity = {
+            "schema_version": self.schema_version,
+            "nodes": [node.to_dict(redact_notes=False) for node in self.nodes],
+            "edges": [edge.to_dict() for edge in self.edges],
+            "lineages": self.lineages,
+            "integrity_warnings": self.integrity_warnings,
+            "focus_session_id": self.focus_session_id,
+        }
+        encoded = json.dumps(
+            identity,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def to_dict(self, *, redact_notes: bool = False) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "generated_at": self.generated_at,
+            "graph_sha256": self.graph_sha256,
+            "focus_session_id": self.focus_session_id,
+            "summary": {
+                "session_count": len(self.nodes),
+                "edge_count": len(self.edges),
+                "lineage_count": len(self.lineages),
+                "completed_count": sum(node.status == "completed" for node in self.nodes),
+                "echo_count": sum(node.echo_count for node in self.nodes),
+                "warning_count": len(self.integrity_warnings),
+            },
+            "lineages": self.lineages,
+            "nodes": [node.to_dict(redact_notes=redact_notes) for node in self.nodes],
+            "edges": [edge.to_dict() for edge in self.edges],
+            "integrity_warnings": list(self.integrity_warnings),
+            "privacy": {
+                "notes_redacted": redact_notes,
+                "scope": "local archive snapshot",
+            },
+        }
+
+
+def build_constellation(
+    archive: LivingSessionArchive,
+    *,
+    lineage_id: str | None = None,
+    focus_session_id: str | None = None,
+) -> ConstellationGraph:
+    """Build a deterministic graph from the archive without inventing relationships."""
+
+    sessions = archive.list_sessions()
+    focus: StoredSession | None = None
+    if focus_session_id is not None:
+        focus = archive.get(focus_session_id)
+        if lineage_id is not None and lineage_id != focus.plan.lineage_id:
+            raise ValueError(
+                f"focus session belongs to lineage {focus.plan.lineage_id}, not {lineage_id}"
+            )
+        lineage_id = focus.plan.lineage_id
+
+    if lineage_id is not None:
+        sessions = [item for item in sessions if item.plan.lineage_id == lineage_id]
+        if not sessions:
+            raise KeyError(f"Living-session lineage not found: {lineage_id}")
+
+    nodes = [_node_from_session(item) for item in sessions]
+    _apply_layout(nodes)
+    by_id = {node.session_id: node for node in nodes}
+    edges: list[ConstellationEdge] = []
+    warnings: list[str] = []
+
+    for node in nodes:
+        parent_id = node.parent_session_id
+        if parent_id is None:
+            if node.generation != 0:
+                warnings.append(
+                    f"{node.session_id}: generation {node.generation} has no parent"
+                )
+            continue
+        parent = by_id.get(parent_id)
+        if parent is None:
+            warnings.append(
+                f"{node.session_id}: parent {parent_id} is outside this snapshot or missing"
+            )
+            continue
+        if parent.lineage_id != node.lineage_id:
+            warnings.append(f"{node.session_id}: parent belongs to a different lineage")
+        if node.generation != parent.generation + 1:
+            warnings.append(
+                f"{node.session_id}: generation {node.generation} does not follow parent generation {parent.generation}"
+            )
+        edges.append(
+            ConstellationEdge(
+                source_session_id=parent.session_id,
+                target_session_id=node.session_id,
+                mode=node.mode,
+                label=_edge_label(node),
+                experimental=node.experimental,
+                mutations=node.mutations,
+            )
+        )
+
+    _detect_cycles(nodes, edges, warnings)
+    return ConstellationGraph(
+        nodes=sorted(
+            nodes,
+            key=lambda node: (
+                node.lineage_id,
+                node.generation,
+                node.created_at,
+                node.session_id,
+            ),
+        ),
+        edges=sorted(
+            edges,
+            key=lambda edge: (edge.source_session_id, edge.target_session_id),
+        ),
+        lineages=_lineage_summaries(nodes),
+        integrity_warnings=sorted(set(warnings)),
+        focus_session_id=focus.plan.session_id if focus else None,
+    )
+
+
+def write_constellation_json(
+    graph: ConstellationGraph,
+    destination: str | Path,
+    *,
+    redact_notes: bool = False,
+) -> Path:
+    """Atomically write the machine-readable graph snapshot."""
+
+    path = Path(destination).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}-",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        temporary.write_text(
+            json.dumps(
+                graph.to_dict(redact_notes=redact_notes),
+                indent=2,
+                sort_keys=True,
+                ensure_ascii=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return path.resolve()
+
+
+def _node_from_session(item: StoredSession) -> ConstellationNode:
+    request = dict(item.plan.recipe_manifest.get("request") or {})
+    return ConstellationNode(
+        session_id=item.plan.session_id,
+        lineage_id=item.plan.lineage_id,
+        parent_session_id=item.plan.parent_session_id,
+        generation=item.plan.generation,
+        mode=item.plan.mode,
+        title=item.plan.title,
+        memory_phrase=item.plan.memory_phrase,
+        motif=item.plan.motif,
+        status=item.status,
+        created_at=item.plan.created_at,
+        backend_policy=item.plan.backend_policy,
+        recipe_sha256=item.plan.recipe_sha256,
+        experimental=item.plan.experimental,
+        rationale=item.plan.rationale,
+        mutations=tuple(asdict(mutation) for mutation in item.plan.mutations),
+        events=tuple(event.to_dict() for event in item.events),
+        outcome=item.outcome.to_dict() if item.outcome else None,
+        pre_affect=item.plan.pre_affect.to_dict() if item.plan.pre_affect else None,
+        request_summary={
+            "problem": request.get("problem"),
+            "sound_world": request.get("sound_world"),
+            "intensity": request.get("intensity"),
+            "duration_minutes": request.get("duration_minutes"),
+            "seed": request.get("seed"),
+            "layers": request.get("layers"),
+            "user_audio": request.get("user_audio"),
+        },
+    )
+
+
+def _apply_layout(nodes: list[ConstellationNode]) -> None:
+    lineages: dict[str, list[ConstellationNode]] = {}
+    for node in nodes:
+        lineages.setdefault(node.lineage_id, []).append(node)
+
+    lineage_offset = 0
+    for lineage_id in sorted(lineages):
+        items = sorted(
+            lineages[lineage_id],
+            key=lambda node: (node.generation, node.created_at, node.session_id),
+        )
+        by_generation: dict[int, list[ConstellationNode]] = {}
+        for node in items:
+            by_generation.setdefault(node.generation, []).append(node)
+        max_rows = max((len(group) for group in by_generation.values()), default=1)
+        for generation, group in sorted(by_generation.items()):
+            for row, node in enumerate(group):
+                object.__setattr__(node, "x", 70 + generation * 300)
+                object.__setattr__(node, "y", 70 + lineage_offset + row * 125)
+        lineage_offset += max(180, max_rows * 125 + 90)
+
+
+def _edge_label(node: ConstellationNode) -> str:
+    if not node.mutations:
+        return node.mode
+    keys = ", ".join(
+        mutation["key"].removeprefix("request.") for mutation in node.mutations
+    )
+    return f"{node.mode}: {keys}"
+
+
+def _lineage_summaries(nodes: Iterable[ConstellationNode]) -> list[dict[str, Any]]:
+    grouped: dict[str, list[ConstellationNode]] = {}
+    for node in nodes:
+        grouped.setdefault(node.lineage_id, []).append(node)
+
+    summaries: list[dict[str, Any]] = []
+    for lineage_id, items in sorted(grouped.items()):
+        ordered = sorted(
+            items,
+            key=lambda node: (node.generation, node.created_at, node.session_id),
+        )
+        roots = [node for node in ordered if node.parent_session_id is None]
+        summaries.append(
+            {
+                "lineage_id": lineage_id,
+                "session_count": len(ordered),
+                "completed_count": sum(node.status == "completed" for node in ordered),
+                "echo_count": sum(node.echo_count for node in ordered),
+                "max_generation": max(
+                    (node.generation for node in ordered), default=0
+                ),
+                "root_session_ids": [node.session_id for node in roots],
+                "root_title": roots[0].title if roots else None,
+                "latest_session_id": max(
+                    ordered,
+                    key=lambda node: (node.created_at, node.session_id),
+                ).session_id,
+            }
+        )
+    return summaries
+
+
+def _detect_cycles(
+    nodes: list[ConstellationNode],
+    edges: list[ConstellationEdge],
+    warnings: list[str],
+) -> None:
+    children: dict[str, list[str]] = {node.session_id: [] for node in nodes}
+    for edge in edges:
+        children.setdefault(edge.source_session_id, []).append(
+            edge.target_session_id
+        )
+
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(session_id: str) -> None:
+        if session_id in visiting:
+            warnings.append(f"{session_id}: cycle detected in parent relationships")
+            return
+        if session_id in visited:
+            return
+        visiting.add(session_id)
+        for child in children.get(session_id, []):
+            visit(child)
+        visiting.remove(session_id)
+        visited.add(session_id)
+
+    for node in nodes:
+        visit(node.session_id)
+
+
+def _redact_affect_note(payload: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not payload:
+        return payload
+    return {**payload, "note": None}

--- a/pysbagen/constellation_render.py
+++ b/pysbagen/constellation_render.py
@@ -1,0 +1,77 @@
+"""Safe packaged-template renderer for Living Session constellations."""
+
+from __future__ import annotations
+
+import html
+import json
+import os
+import tempfile
+from importlib.resources import files
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .constellation import ConstellationGraph
+
+
+def render_constellation_html(
+    graph: "ConstellationGraph",
+    *,
+    redact_notes: bool = False,
+) -> str:
+    """Render one self-contained offline HTML navigator from a packaged template."""
+
+    payload = graph.to_dict(redact_notes=redact_notes)
+    data_json = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).replace(
+        "</", "<\\/"
+    )
+    template = (
+        files("pysbagen")
+        .joinpath("data")
+        .joinpath("constellation_template.html")
+        .read_text(encoding="utf-8")
+    )
+    title = "PySbagen Living Session Constellation"
+    return (
+        template.replace("__TITLE__", html.escape(title))
+        .replace("__GRAPH_SHORT__", payload["graph_sha256"][:16])
+        .replace("__REDACTED__", str(redact_notes).lower())
+        .replace("__DATA_JSON__", data_json)
+    )
+
+
+def write_constellation_html(
+    graph: "ConstellationGraph",
+    destination: str | Path,
+    *,
+    redact_notes: bool = False,
+) -> Path:
+    """Atomically write a self-contained HTML constellation snapshot."""
+
+    path = Path(destination).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}-",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        temporary.write_text(
+            render_constellation_html(graph, redact_notes=redact_notes),
+            encoding="utf-8",
+        )
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return path.resolve()
+
+
+def install_constellation_renderer() -> None:
+    """Replace the embedded prototype renderer with the packaged-template implementation."""
+
+    from . import constellation
+
+    constellation.render_constellation_html = render_constellation_html
+    constellation.write_constellation_html = write_constellation_html

--- a/pysbagen/data/constellation_template.html
+++ b/pysbagen/data/constellation_template.html
@@ -1,0 +1,256 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>__TITLE__</title>
+<style>
+:root {
+  color-scheme: dark;
+  --bg: #090b12;
+  --panel: #111625;
+  --panel2: #171e31;
+  --text: #eef2ff;
+  --muted: #9ba8c7;
+  --line: #435174;
+  --focus: #f4d27a;
+  --warn: #f6a96b;
+  --root: #9cc5ff;
+  --return: #b7a5ff;
+  --branch: #7ee0d6;
+  --contrast: #ff9eab;
+  --wander: #f3c56b;
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--text); font: 14px/1.45 system-ui, sans-serif; }
+header { padding: 18px 22px; border-bottom: 1px solid #232c43; background: #0c101b; }
+header h1 { margin: 0 0 4px; font-size: 22px; }
+header p { margin: 0; color: var(--muted); }
+.toolbar { display: grid; grid-template-columns: minmax(180px, 1fr) repeat(3, minmax(120px, 180px)); gap: 10px; padding: 12px 18px; background: var(--panel); border-bottom: 1px solid #232c43; }
+input, select, button { width: 100%; border: 1px solid #35415f; border-radius: 7px; background: #0c1120; color: var(--text); padding: 9px 10px; }
+button { cursor: pointer; }
+main { display: grid; grid-template-columns: minmax(0, 1fr) 360px; height: calc(100vh - 132px); }
+.stage { overflow: auto; position: relative; }
+svg { min-width: 100%; min-height: 100%; }
+.edge { stroke: var(--line); stroke-width: 2; fill: none; opacity: .8; }
+.edge.experimental { stroke-dasharray: 8 6; }
+.node { cursor: pointer; }
+.node rect { fill: var(--panel2); stroke-width: 2; rx: 10; }
+.node[data-mode="root"] rect { stroke: var(--root); }
+.node[data-mode="return"] rect { stroke: var(--return); }
+.node[data-mode="branch"] rect { stroke: var(--branch); }
+.node[data-mode="contrast"] rect { stroke: var(--contrast); }
+.node[data-mode="wander"] rect { stroke: var(--wander); }
+.node.focus rect, .node.selected rect { stroke: var(--focus); stroke-width: 4; }
+.node.dim { opacity: .15; }
+.node text { fill: var(--text); pointer-events: none; }
+.node .sub { fill: var(--muted); font-size: 11px; }
+aside { border-left: 1px solid #232c43; background: var(--panel); overflow: auto; padding: 16px; }
+aside h2 { margin-top: 0; }
+.meta { display: grid; grid-template-columns: 110px 1fr; gap: 6px 10px; }
+.meta dt { color: var(--muted); }
+.meta dd { margin: 0; overflow-wrap: anywhere; }
+.card { background: var(--panel2); border: 1px solid #2c3651; border-radius: 8px; padding: 10px; margin: 10px 0; }
+.badge { display: inline-block; border: 1px solid #4b5a7d; border-radius: 999px; padding: 2px 7px; margin: 2px; color: var(--muted); }
+.warnings { color: var(--warn); }
+footer { color: var(--muted); font-size: 12px; margin-top: 18px; }
+pre { white-space: pre-wrap; overflow-wrap: anywhere; }
+@media (max-width: 900px) {
+  .toolbar { grid-template-columns: 1fr 1fr; }
+  main { grid-template-columns: 1fr; height: auto; }
+  .stage { height: 68vh; }
+  aside { border-left: 0; border-top: 1px solid #232c43; }
+}
+</style>
+</head>
+<body>
+<header>
+  <h1>__TITLE__</h1>
+  <p><span id="summary"></span> · snapshot <code>__GRAPH_SHORT__</code> · local/offline</p>
+</header>
+<section class="toolbar" aria-label="Constellation filters">
+  <input id="search" type="search" placeholder="Search title, motif, session, mutation, event">
+  <select id="lineage"><option value="">All lineages</option></select>
+  <select id="mode"><option value="">All modes</option><option>root</option><option>return</option><option>branch</option><option>contrast</option><option>wander</option></select>
+  <select id="status"><option value="">All states</option><option>planned</option><option>active</option><option>completed</option></select>
+</section>
+<main>
+  <section class="stage" aria-label="Session lineage graph">
+    <svg id="graph" role="img" aria-label="Living Session constellation"></svg>
+  </section>
+  <aside id="detail">
+    <h2>Select a session</h2>
+    <p>Click a node to inspect its exact recipe identity, ancestry, disclosed mutations, echoes, outcome, backend policy, and provenance.</p>
+    <div class="warnings" id="warnings"></div>
+    <footer>This file contains a selected local archive snapshot. Notes redacted: __REDACTED__.</footer>
+  </aside>
+</main>
+<script id="constellation-data" type="application/json">__DATA_JSON__</script>
+<script>
+const data = JSON.parse(document.getElementById("constellation-data").textContent);
+const svg = document.getElementById("graph");
+const detail = document.getElementById("detail");
+const search = document.getElementById("search");
+const lineage = document.getElementById("lineage");
+const mode = document.getElementById("mode");
+const status = document.getElementById("status");
+const byId = new Map(data.nodes.map(n => [n.session_id, n]));
+const focusId = data.focus_session_id || "";
+const nodeEls = new Map();
+const edgeEls = [];
+const ns = "http://www.w3.org/2000/svg";
+
+document.getElementById("summary").textContent =
+  `${data.summary.session_count} sessions · ${data.summary.lineage_count} lineages · ${data.summary.echo_count} echoes`;
+
+for (const item of data.lineages) {
+  const option = document.createElement("option");
+  option.value = item.lineage_id;
+  option.textContent = `${item.root_title || item.lineage_id} (${item.session_count})`;
+  lineage.appendChild(option);
+}
+
+const maxX = Math.max(900, ...data.nodes.map(n => n.x + 300));
+const maxY = Math.max(600, ...data.nodes.map(n => n.y + 180));
+svg.setAttribute("viewBox", `0 0 ${maxX} ${maxY}`);
+svg.setAttribute("width", maxX);
+svg.setAttribute("height", maxY);
+
+for (const edge of data.edges) {
+  const source = byId.get(edge.source_session_id);
+  const target = byId.get(edge.target_session_id);
+  if (!source || !target) continue;
+  const path = document.createElementNS(ns, "path");
+  const sx = source.x + 220, sy = source.y + 44;
+  const tx = target.x, ty = target.y + 44;
+  const mid = (sx + tx) / 2;
+  path.setAttribute("d", `M ${sx} ${sy} C ${mid} ${sy}, ${mid} ${ty}, ${tx} ${ty}`);
+  path.setAttribute("class", `edge ${edge.experimental ? "experimental" : ""}`);
+  path.dataset.source = edge.source_session_id;
+  path.dataset.target = edge.target_session_id;
+  path.dataset.label = edge.label;
+  svg.appendChild(path);
+  edgeEls.push(path);
+}
+
+for (const node of data.nodes) {
+  const group = document.createElementNS(ns, "g");
+  group.setAttribute("class", `node ${node.session_id === focusId ? "focus" : ""}`);
+  group.setAttribute("transform", `translate(${node.x},${node.y})`);
+  group.dataset.id = node.session_id;
+  group.dataset.mode = node.mode;
+  const rect = document.createElementNS(ns, "rect");
+  rect.setAttribute("width", "220");
+  rect.setAttribute("height", "88");
+  const titleText = document.createElementNS(ns, "text");
+  titleText.setAttribute("x", "12");
+  titleText.setAttribute("y", "25");
+  titleText.textContent = node.title;
+  const metaText = document.createElementNS(ns, "text");
+  metaText.setAttribute("x", "12");
+  metaText.setAttribute("y", "47");
+  metaText.setAttribute("class", "sub");
+  metaText.textContent = `g${node.generation} · ${node.mode} · ${node.status}`;
+  const countText = document.createElementNS(ns, "text");
+  countText.setAttribute("x", "12");
+  countText.setAttribute("y", "68");
+  countText.setAttribute("class", "sub");
+  countText.textContent = `${node.echo_count} echoes · ${node.render_count} renders${node.rating ? ` · ${node.rating}/5` : ""}`;
+  group.append(rect, titleText, metaText, countText);
+  group.addEventListener("click", () => selectNode(node.session_id));
+  svg.appendChild(group);
+  nodeEls.set(node.session_id, group);
+}
+
+function searchable(node) {
+  return JSON.stringify({
+    title: node.title,
+    motif: node.motif,
+    id: node.session_id,
+    lineage: node.lineage_id,
+    mutations: node.mutations,
+    events: node.events,
+    tags: node.outcome?.tags || []
+  }).toLowerCase();
+}
+
+function applyFilters() {
+  const q = search.value.trim().toLowerCase();
+  for (const node of data.nodes) {
+    const visible =
+      (!lineage.value || node.lineage_id === lineage.value) &&
+      (!mode.value || node.mode === mode.value) &&
+      (!status.value || node.status === status.value) &&
+      (!q || searchable(node).includes(q));
+    nodeEls.get(node.session_id).style.display = visible ? "" : "none";
+    node._visible = visible;
+  }
+  for (const edgeEl of edgeEls) {
+    edgeEl.style.display =
+      byId.get(edgeEl.dataset.source)._visible && byId.get(edgeEl.dataset.target)._visible ? "" : "none";
+  }
+}
+search.addEventListener("input", applyFilters);
+lineage.addEventListener("change", applyFilters);
+mode.addEventListener("change", applyFilters);
+status.addEventListener("change", applyFilters);
+
+function esc(value) {
+  return String(value ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+}
+function pretty(value) { return esc(typeof value === "string" ? value : JSON.stringify(value)); }
+
+function selectNode(id) {
+  const node = byId.get(id);
+  for (const [nodeId, el] of nodeEls) {
+    el.classList.toggle("selected", nodeId === id);
+    el.classList.toggle("dim", nodeId !== id && nodeId !== node.parent_session_id && !data.edges.some(e => e.source_session_id === id && e.target_session_id === nodeId));
+  }
+  const mutations = node.mutations.length
+    ? node.mutations.map(m => `<div class="card"><strong>${esc(m.key)}</strong><br>${pretty(m.before)} → ${pretty(m.after)}<br><small>${esc(m.reason)}</small></div>`).join("")
+    : "<p>No recipe mutation; this is an exact root/return relationship.</p>";
+  const events = node.events.length
+    ? node.events.map(e => `<div class="card"><strong>${esc(e.kind)}</strong>${e.position_seconds == null ? "" : ` @ ${e.position_seconds}s`}<br>${esc(e.label)}${Object.keys(e.payload || {}).length ? `<pre>${esc(JSON.stringify(e.payload, null, 2))}</pre>` : ""}</div>`).join("")
+    : "<p>No events recorded.</p>";
+  const outcome = node.outcome
+    ? `<div class="card"><strong>${node.outcome.rating}/5</strong> · ${esc(node.outcome.comfort)} · repeat ${node.outcome.would_repeat ? "yes" : "no"}<br>${esc(node.outcome.note || "")}<br>${(node.outcome.tags || []).map(t => `<span class="badge">${esc(t)}</span>`).join("")}</div>`
+    : "<p>No outcome recorded.</p>";
+  detail.innerHTML = `
+    <h2>${esc(node.memory_phrase)}</h2>
+    <dl class="meta">
+      <dt>Session</dt><dd><code>${esc(node.session_id)}</code></dd>
+      <dt>Lineage</dt><dd><code>${esc(node.lineage_id)}</code></dd>
+      <dt>Parent</dt><dd>${node.parent_session_id ? `<code>${esc(node.parent_session_id)}</code>` : "root"}</dd>
+      <dt>Generation</dt><dd>${node.generation}</dd>
+      <dt>Mode</dt><dd>${esc(node.mode)}${node.experimental ? " · experimental" : ""}</dd>
+      <dt>Status</dt><dd>${esc(node.status)}</dd>
+      <dt>Backend</dt><dd>${esc(node.backend_policy)}</dd>
+      <dt>Recipe</dt><dd><code>${esc(node.recipe_sha256)}</code></dd>
+      <dt>Created</dt><dd>${esc(node.created_at)}</dd>
+    </dl>
+    <h3>Journey</h3>
+    <div class="card">${Object.entries(node.request_summary).map(([k,v]) => `<span class="badge">${esc(k)}=${pretty(v)}</span>`).join("")}</div>
+    <p>${esc(node.rationale)}</p>
+    <h3>Disclosed changes</h3>${mutations}
+    <h3>Echoes and events</h3>${events}
+    <h3>Outcome</h3>${outcome}
+    <button id="copy-id">Copy session ID</button>
+    ${data.integrity_warnings.length ? `<div class="warnings"><h3>Snapshot warnings</h3><ul>${data.integrity_warnings.map(w => `<li>${esc(w)}</li>`).join("")}</ul></div>` : ""}
+    <footer>Snapshot hash: <code>${data.graph_sha256}</code><br>Notes redacted: ${data.privacy.notes_redacted}.</footer>`;
+  document.getElementById("copy-id").addEventListener("click", async () => {
+    try { await navigator.clipboard.writeText(node.session_id); }
+    catch (_) { /* clipboard may be unavailable for file://; ID remains visible */ }
+  });
+}
+
+applyFilters();
+if (focusId && byId.has(focusId)) selectNode(focusId);
+else if (data.nodes.length) selectNode(data.nodes[0].session_id);
+
+if (data.integrity_warnings.length) {
+  document.getElementById("warnings").innerHTML =
+    `<h3>Snapshot warnings</h3><ul>${data.integrity_warnings.map(w => `<li>${esc(w)}</li>`).join("")}</ul>`;
+}
+</script>
+</body>
+</html>

--- a/pysbagen/session_cli.py
+++ b/pysbagen/session_cli.py
@@ -9,6 +9,11 @@ import re
 from pathlib import Path
 
 from .api import render_sleep, write_audio
+from .constellation import (
+    build_constellation,
+    constellation_to_text,
+    write_constellation_html,
+)
 from .living_sessions import (
     AffectSnapshot,
     LivingSessionArchive,
@@ -82,6 +87,21 @@ def build_parser() -> argparse.ArgumentParser:
 
     atlas_parser = subparsers.add_parser("atlas", help="Summarize lineages, echoes, and descriptive local patterns")
     atlas_parser.add_argument("--json", action="store_true", dest="as_json")
+
+    constellation_parser = subparsers.add_parser(
+        "constellation",
+        help="Navigate session ancestry, changes, echoes, outcomes, backends, and provenance",
+    )
+    constellation_parser.add_argument("--lineage", help="Limit the snapshot to one lineage ID")
+    constellation_parser.add_argument("--focus", help="Select and center one session when the HTML opens")
+    constellation_parser.add_argument(
+        "--html",
+        nargs="?",
+        const="living-session-constellation.html",
+        metavar="PATH",
+        help="Write a self-contained offline HTML navigator (default filename when omitted)",
+    )
+    constellation_parser.add_argument("--json", action="store_true", dest="as_json")
     return parser
 
 
@@ -247,6 +267,40 @@ def main(argv: list[str] | None = None) -> int:
                 print(json.dumps(atlas, indent=2, sort_keys=True))
             else:
                 _print_atlas(atlas)
+            return 0
+
+        if args.command == "constellation":
+            html_export = None
+            if args.html:
+                html_path, graph = write_constellation_html(
+                    archive,
+                    args.html,
+                    lineage_id=args.lineage,
+                    focus_session_id=args.focus,
+                )
+                html_export = {
+                    "path": str(html_path),
+                    "sha256": _sha256_file(html_path),
+                    "snapshot_sha256": graph["snapshot_sha256"],
+                }
+            else:
+                graph = build_constellation(
+                    archive,
+                    lineage_id=args.lineage,
+                    focus_session_id=args.focus,
+                )
+            if args.as_json:
+                payload = (
+                    {"constellation": graph, "html_export": html_export}
+                    if html_export is not None
+                    else graph
+                )
+                print(json.dumps(payload, indent=2, sort_keys=True))
+            else:
+                print(constellation_to_text(graph))
+                if html_export is not None:
+                    print(f"Offline navigator: {html_export['path']}")
+                    print(f"HTML SHA-256: {html_export['sha256']}")
             return 0
     except (KeyError, OSError, RuntimeError, TypeError, ValueError, json.JSONDecodeError) as exc:
         raise SystemExit(f"sbgpy-session: {exc}") from exc

--- a/pysbagen/tests/test_confluence.py
+++ b/pysbagen/tests/test_confluence.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import pytest
+
+from pysbagen.confluence import (
+    build_confluence_constellation,
+    confluence_metadata,
+    create_confluence_plan,
+    create_confluence_session,
+    describe_confluence,
+    suggest_confluence,
+)
+from pysbagen.living_sessions import LivingSessionArchive, SessionOutcome, create_sleep_plan
+from pysbagen.sleep import SleepLayers, SleepRequest
+
+
+def _parents(tmp_path):
+    archive = LivingSessionArchive(tmp_path / "living")
+    plan_a = create_sleep_plan(
+        SleepRequest(
+            problem="racing_mind",
+            sound_world="rain_room",
+            intensity="gentle",
+            duration_minutes=30,
+            layers=SleepLayers(binaural=True, monaural=False, isochronic=False, harmonic_box=False),
+            seed=11,
+        ),
+        created_at="2026-08-07T10:00:00+00:00",
+    )
+    plan_b = create_sleep_plan(
+        SleepRequest(
+            problem="cannot_cross",
+            sound_world="deep_night",
+            intensity="immersive",
+            duration_minutes=90,
+            layers=SleepLayers(binaural=False, monaural=True, isochronic=True, harmonic_box=False),
+            seed=22,
+        ),
+        created_at="2026-08-07T10:01:00+00:00",
+    )
+    archive.create(plan_a)
+    archive.create(plan_b)
+    archive.append_event(plan_a.session_id, kind="echo", label="Rain became a room", position_seconds=120.0, created_at="2026-08-07T10:02:00+00:00")
+    archive.append_event(plan_b.session_id, kind="echo", label="Deep low opening", position_seconds=60.0, created_at="2026-08-07T10:03:00+00:00")
+    archive.append_event(plan_b.session_id, kind="echo", label="Threshold softened", position_seconds=240.0, created_at="2026-08-07T10:04:00+00:00")
+    archive.finish(SessionOutcome(session_id=plan_a.session_id, completed_at="2026-08-07T11:00:00+00:00", rating=5, would_repeat=True, comfort="comfortable"))
+    archive.finish(SessionOutcome(session_id=plan_b.session_id, completed_at="2026-08-07T11:01:00+00:00", rating=4, would_repeat=True, comfort="comfortable"))
+    return archive, archive.get(plan_a.session_id), archive.get(plan_b.session_id)
+
+
+def test_suggestion_is_dual_parent_and_creates_real_bridge_traits(tmp_path):
+    _, parent_a, parent_b = _parents(tmp_path)
+    suggestion = suggest_confluence(parent_a, parent_b)
+    sources = {item.source for item in suggestion.assignments}
+    assert {"A", "B", "new"} <= sources
+    by_trait = {item.trait: item for item in suggestion.assignments}
+    assert by_trait["intensity"].source == "new"
+    assert by_trait["intensity"].value == "balanced"
+    assert by_trait["duration_minutes"].source == "new"
+    assert by_trait["duration_minutes"].value == 60.0
+    assert "generation seed is new" in suggestion.rationale
+
+
+def test_explicit_inheritance_overrides_suggestion_without_hiding_conflicts(tmp_path):
+    _, parent_a, parent_b = _parents(tmp_path)
+    suggestion = suggest_confluence(parent_a, parent_b, from_a=("sound_world",), from_b=("problem",))
+    by_trait = {item.trait: item for item in suggestion.assignments}
+    assert by_trait["sound_world"].source == "A"
+    assert by_trait["sound_world"].value == "rain_room"
+    assert by_trait["problem"].source == "B"
+    assert by_trait["problem"].value == "cannot_cross"
+    assert any("sound world differs" in item for item in suggestion.tensions)
+    assert any("intent differs" in item for item in suggestion.tensions)
+
+
+def test_same_trait_cannot_be_forced_from_both_parents(tmp_path):
+    _, parent_a, parent_b = _parents(tmp_path)
+    with pytest.raises(ValueError, match="cannot be explicitly inherited from both"):
+        suggest_confluence(parent_a, parent_b, from_a=("sound_world",), from_b=("sound_world",))
+
+
+def test_create_plan_has_new_identity_and_new_seed(tmp_path):
+    _, parent_a, parent_b = _parents(tmp_path)
+    plan, suggestion = create_confluence_plan(parent_a, parent_b, created_at="2026-08-07T12:00:00+00:00")
+    assert plan.mode == "confluence"
+    assert plan.parent_session_id == parent_a.plan.session_id
+    assert plan.lineage_id not in {parent_a.plan.lineage_id, parent_b.plan.lineage_id}
+    assert plan.title not in {parent_a.plan.title, parent_b.plan.title}
+    assert plan.recipe_manifest["request"]["seed"] not in {
+        parent_a.plan.recipe_manifest["request"]["seed"],
+        parent_b.plan.recipe_manifest["request"]["seed"],
+    }
+    assert plan.recipe_sha256 not in {parent_a.plan.recipe_sha256, parent_b.plan.recipe_sha256}
+    assert suggestion.parent_b_session_id == parent_b.plan.session_id
+
+
+def test_persisted_confluence_remembers_both_ancestors_and_inheritance(tmp_path):
+    archive, parent_a, parent_b = _parents(tmp_path)
+    stored = create_confluence_session(archive, parent_a.plan.session_id, parent_b.plan.session_id, created_at="2026-08-07T12:00:00+00:00")
+    metadata = confluence_metadata(stored)
+    assert metadata is not None
+    assert metadata["parent_a"]["session_id"] == parent_a.plan.session_id
+    assert metadata["parent_b"]["session_id"] == parent_b.plan.session_id
+    assert metadata["schema"] == "pysbagen.living-session-confluence.v1"
+    assert {item["source"] for item in metadata["inheritance"]} >= {"A", "B", "new"}
+    description = describe_confluence(stored)
+    assert description["parent_a"]["title"] == parent_a.plan.title
+    assert description["parent_b"]["title"] == parent_b.plan.title
+
+
+def test_confluence_can_become_a_future_ancestor(tmp_path):
+    archive, parent_a, parent_b = _parents(tmp_path)
+    first = create_confluence_session(archive, parent_a.plan.session_id, parent_b.plan.session_id, created_at="2026-08-07T12:00:00+00:00")
+    second = create_confluence_session(archive, first.plan.session_id, parent_a.plan.session_id, created_at="2026-08-07T13:00:00+00:00")
+    metadata = confluence_metadata(second)
+    assert metadata is not None
+    assert metadata["parent_a"]["session_id"] == first.plan.session_id
+    assert second.plan.generation == max(first.plan.generation, parent_a.plan.generation) + 1
+
+
+def test_constellation_contains_second_parent_edge_without_false_lineage_warning(tmp_path):
+    archive, parent_a, parent_b = _parents(tmp_path)
+    confluence = create_confluence_session(archive, parent_a.plan.session_id, parent_b.plan.session_id, created_at="2026-08-07T12:00:00+00:00")
+    graph = build_confluence_constellation(archive, focus_session_id=confluence.plan.session_id)
+    second_edges = [edge for edge in graph["edges"] if edge["mode"] == "confluence-b" and edge["source"] == parent_b.plan.session_id and edge["target"] == confluence.plan.session_id]
+    assert len(second_edges) == 1
+    assert graph["counts"]["confluence_second_parent_edges"] == 1
+    warning_codes = {warning["code"] for warning in graph["warnings"] if warning["session_id"] == confluence.plan.session_id}
+    assert "parent-lineage-mismatch" not in warning_codes
+    assert "generation-gap" not in warning_codes
+
+
+def test_confluence_rejects_using_the_same_session_twice(tmp_path):
+    _, parent_a, _ = _parents(tmp_path)
+    with pytest.raises(ValueError, match="two distinct remembered sessions"):
+        suggest_confluence(parent_a, parent_a)

--- a/pysbagen/tests/test_constellation.py
+++ b/pysbagen/tests/test_constellation.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pysbagen.constellation import (
+    build_constellation,
+    constellation_to_text,
+    render_constellation_html,
+)
+from pysbagen.living_sessions import (
+    AffectSnapshot,
+    LivingSessionArchive,
+    SessionOutcome,
+    create_child_sleep_plan,
+    create_sleep_plan,
+)
+from pysbagen.session_cli import main as session_main
+from pysbagen.sleep import SleepRequest
+
+
+def _request() -> SleepRequest:
+    return SleepRequest(
+        problem="racing_mind",
+        sound_world="rain_room",
+        intensity="balanced",
+        duration_minutes=45,
+        seed=17,
+    )
+
+
+def _lineage(archive: LivingSessionArchive):
+    root = create_sleep_plan(
+        _request(),
+        pre_affect=AffectSnapshot(valence=-0.5, arousal=0.9, agency=0.2),
+        created_at="2026-08-05T20:00:00+00:00",
+    )
+    archive.create(root)
+    archive.append_event(
+        root.session_id,
+        kind="render",
+        label="Rendered exact living-session recipe",
+        payload={
+            "actual_backend": "python",
+            "output_path": "/tmp/root.wav",
+            "output_sha256": "f" * 64,
+            "backend_reason": "explicit Python policy",
+        },
+        created_at="2026-08-05T20:01:00+00:00",
+    )
+    archive.finish(
+        SessionOutcome(
+            session_id=root.session_id,
+            completed_at="2026-08-05T21:00:00+00:00",
+            rating=5,
+            would_repeat=True,
+            comfort="comfortable",
+            post_affect=AffectSnapshot(valence=0.4, arousal=0.2, agency=0.7),
+            tags=("rain", "settled"),
+        )
+    )
+    branch = create_child_sleep_plan(
+        root,
+        mode="branch",
+        archive=archive,
+        created_at="2026-08-05T22:00:00+00:00",
+    )
+    archive.create(branch)
+    archive.append_event(
+        branch.session_id,
+        kind="echo",
+        label="The rain became a room",
+        position_seconds=123.5,
+        created_at="2026-08-05T22:02:00+00:00",
+    )
+    returned = create_child_sleep_plan(
+        branch,
+        mode="return",
+        archive=archive,
+        created_at="2026-08-05T23:00:00+00:00",
+    )
+    archive.create(returned)
+    return root, branch, returned
+
+
+def test_constellation_exposes_identity_changes_memory_outcome_and_backend(tmp_path: Path):
+    archive = LivingSessionArchive(tmp_path / "living")
+    root, branch, returned = _lineage(archive)
+
+    graph = build_constellation(archive, focus_session_id=branch.session_id)
+    nodes = {node["session_id"]: node for node in graph["nodes"]}
+    edges = {edge["target"]: edge for edge in graph["edges"]}
+
+    assert graph["counts"] == {
+        "sessions": 3,
+        "edges": 2,
+        "lineages": 1,
+        "completed": 1,
+        "echoes": 1,
+        "warnings": 0,
+    }
+    assert len(graph["snapshot_sha256"]) == 64
+    assert graph == build_constellation(archive, focus_session_id=branch.session_id)
+    assert nodes[root.session_id]["backend"]["actual_backends"] == ["python"]
+    assert nodes[root.session_id]["backend"]["latest_output_sha256"] == "f" * 64
+    assert nodes[root.session_id]["outcome"]["affect_delta"]["valence"] == pytest.approx(0.9)
+    assert nodes[branch.session_id]["echo_count"] == 1
+    assert nodes[branch.session_id]["echoes"][0]["label"] == "The rain became a room"
+    assert edges[branch.session_id]["change_count"] == 1
+    assert edges[branch.session_id]["causal_interpretability"] == "high"
+    assert edges[returned.session_id]["recipe_identity_preserved"]
+    assert edges[returned.session_id]["short_label"] == "exact return"
+    assert nodes[branch.session_id]["layout"]["x"] > nodes[root.session_id]["layout"]["x"]
+
+    text = constellation_to_text(graph)
+    assert root.title in text
+    assert branch.mutations[0].key in text
+    assert "descriptive personal records" in text
+
+
+def test_constellation_html_is_self_contained_searchable_and_script_safe(tmp_path: Path):
+    archive = LivingSessionArchive(tmp_path / "living")
+    _, branch, _ = _lineage(archive)
+    archive.append_event(
+        branch.session_id,
+        kind="echo",
+        label="Unsafe </script><script>alert(1)</script> memory",
+        created_at="2026-08-05T22:03:00+00:00",
+    )
+
+    document = render_constellation_html(build_constellation(archive))
+
+    assert '<script src=' not in document
+    assert '<link rel=' not in document
+    assert "constellation-data" in document
+    assert "Search title, motif, echo, hash" in document
+    assert "Filter lineage" in document
+    assert "\\u003c/script\\u003e" in document
+    assert "Unsafe </script>" not in document
+
+
+def test_constellation_lineage_filter_and_focus_are_fail_closed(tmp_path: Path):
+    archive = LivingSessionArchive(tmp_path / "living")
+    root, branch, _ = _lineage(archive)
+    other = create_sleep_plan(
+        SleepRequest(problem="cannot_cross", sound_world="deep_night", duration_minutes=30),
+        created_at="2026-08-06T00:00:00+00:00",
+    )
+    archive.create(other)
+
+    graph = build_constellation(
+        archive,
+        lineage_id=root.lineage_id,
+        focus_session_id=branch.session_id,
+    )
+
+    assert graph["counts"]["sessions"] == 3
+    assert {node["lineage_id"] for node in graph["nodes"]} == {root.lineage_id}
+    with pytest.raises(KeyError, match="lineage not found"):
+        build_constellation(archive, lineage_id="missing-lineage")
+    with pytest.raises(KeyError, match="not present"):
+        build_constellation(archive, lineage_id=root.lineage_id, focus_session_id=other.session_id)
+
+
+def test_constellation_surfaces_parent_absence_instead_of_inventing_an_edge(tmp_path: Path):
+    root = create_sleep_plan(_request(), created_at="2026-08-05T20:00:00+00:00")
+    child = create_child_sleep_plan(
+        root,
+        mode="branch",
+        created_at="2026-08-05T21:00:00+00:00",
+    )
+    orphan_archive = LivingSessionArchive(tmp_path / "orphan")
+    orphan_archive.create(child)
+
+    graph = build_constellation(orphan_archive)
+
+    assert graph["counts"]["edges"] == 0
+    assert graph["counts"]["warnings"] == 1
+    assert graph["warnings"][0]["code"] == "parent-not-in-snapshot"
+    assert graph["nodes"][0]["warnings"][0]["session_id"] == child.session_id
+
+
+def test_constellation_cli_writes_offline_navigator_and_prints_receipts(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    archive_root = tmp_path / "living"
+    archive = LivingSessionArchive(archive_root)
+    root, _, _ = _lineage(archive)
+    destination = tmp_path / "constellation.html"
+
+    assert session_main(
+        [
+            "--root",
+            str(archive_root),
+            "constellation",
+            "--focus",
+            root.session_id,
+            "--html",
+            str(destination),
+        ]
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert destination.is_file()
+    assert "Offline navigator:" in output
+    assert "HTML SHA-256:" in output
+    assert "Snapshot:" in output


### PR DESCRIPTION
## What changed

- adds a deterministic, read-only Living Sessions constellation graph;
- maps session ancestry through directed parent/child edges;
- keeps exact recipe hashes, lineages, generations, backend policy, actual backend receipts, output hashes, echoes, outcomes, and affect deltas visible;
- labels exact returns and disclosed branch/contrast/wander changes;
- adds causal-interpretability labels rather than implying every variation is equally explainable;
- surfaces absent parents, lineage mismatches, generation gaps, and altered return hashes instead of inventing a complete graph;
- adds terminal, JSON, and self-contained offline HTML views;
- adds search plus lineage, status, and mode filters;
- supports fail-closed lineage scope and focused sessions;
- safely embeds arbitrary local labels so `</script>` content cannot break the document;
- prints graph snapshot SHA-256 and HTML SHA-256 receipts;
- exposes `sbgpy-session constellation` and public Python APIs;
- adds Confluence Sessions: explicitly combine selected dimensions from two known lineages while preserving both parent identities, inherited-dimension receipts, conflicts, and causal uncertainty.

## Product boundary

This is a PySbagen session-intelligence and provenance surface. It adds no synthesis engine, curve language, mix effect, editor, plotter, or duplicate SBaGenX DSP.

The Cycloside cross-project idea remains permission-gated and is not touched by this PR.

## Product paths

```bash
sbgpy-session constellation
sbgpy-session constellation --json
sbgpy-session constellation --html
sbgpy-session constellation --lineage LINEAGE_ID --html lineage.html
sbgpy-session constellation --focus SESSION_ID --html focused.html
sbgpy-confluence create --parent-one SESSION_ID --parent-two SESSION_ID --html
```

## Anti-drawer design

The navigator remains useful as history grows because it supports exact return, disclosed comparison, remembered echoes, outcome context, backend/output provenance, and visible incomplete ancestry. It uses no cloud service, points, badges, streak pressure, social ranking, analytics, or remote assets.

## HTE / InvisiSynth use

The train applies the project-owner supplied HTE-Newest reasoning corpus: Memory, Learning, Affect, Dependency Grapher, Parallel Oracle, Synthesis, and InvisiSynth. No HTE runtime code or private configuration is vendored.

## Reconciliation notes

This PR has been reconciled onto current `main` (commit `60de896`). It now includes:
- Original Constellation work from this PR
- Confluence Sessions work (previously PR #15, already merged into this branch)
- Unique Constellation CLI, model, render, and template files preserved from sibling PR #13

The branch now contains 17 files changed, 3100 insertions.

## Qualification

Tests passed: **81 tests** (Python 3.13)
Package build: **successful** (sdist and wheel)

## Review truth

Bugbot is not enabled and performed no review. CodeRabbit automatic review skipped the non-default stacked base. A manual review request was acknowledged, but CodeRabbit reported that it was rate-limited; it produced no submitted review or actionable inline findings.

## Stack

Base: `main` / commit `60de896` (after PR #12 merge)

Head: `agent/living-sessions-constellation-20260805` / commit `e8412de7cfb56c82e089b77864bdaf925bfcfaa4`

## Receipts and docs

- `.beads/pysbagen_living_sessions_constellation_train_2026_08_05.md`
- `.beads/pysbagen_living_sessions_constellation_train_2026_08_05_COMPLETION.md`
- `.beads/pysbagen_living_sessions_confluence_train_2026_08_07.md`
- `docs/product/LIVING_SESSIONS_CONSTELLATION_GUIDE.md`
- `docs/product/LIVING_SESSIONS_CONFLUENCE_GUIDE.md`

## Next product wave

The Cycloside possibility remains parked behind its explicit permission gate.
