### PR TITLE
Build Living Sessions Confluence experiences

### DIFF
--- a/.beads/pysbagen_living_sessions_confluence_train_2026_08_07.md
+++ b/.beads/pysbagen_living_sessions_confluence_train_2026_08_07.md
@@ -1,0 +1,152 @@
+# PySbagen LIV-012 — Living Sessions Confluence Train
+
+Date: 2026-08-07
+Product: PySbagen
+Stack base: `agent/living-sessions-constellation-20260805`
+Train branch: `agent/living-sessions-confluence-20260807`
+
+## Product objective
+
+Make two remembered Living Sessions capable of producing a third experience that is recognizably descended from both, while remaining understandable and reusable.
+
+This train is successful when the listener can say:
+
+> I remember those two sessions. This new one carries something from each of them, adds something of its own, and I can see and hear how it became this experience.
+
+## Beads
+
+### LIV-012.1 — Dual remembered ancestors
+
+Create a Confluence from two distinct stored Living Sessions rather than from detached recipe dictionaries.
+
+Acceptance:
+
+- both ancestors remain named and addressable;
+- both parent recipe identities remain visible in Confluence metadata;
+- same-session self-Confluence is rejected;
+- a Confluence can later be used as an ancestor.
+
+### LIV-012.2 — Experiential inheritance
+
+Represent inherited dimensions as `A`, `B`, `both`, or `new`.
+
+Initial dimensions:
+
+- intent / problem;
+- sound world;
+- intensity;
+- duration;
+- layer blend.
+
+Acceptance:
+
+- explicit inheritance choices are supported;
+- conflicting explicit A/B choices for the same trait fail clearly;
+- differences remain visible as creative tensions.
+
+### LIV-012.3 — Memory-guided suggestion
+
+Use existing local memory to suggest understandable inheritance.
+
+Signals may include:
+
+- outcome rating;
+- would-repeat choice;
+- echoes;
+- shared dimensions;
+- available bridge values.
+
+Acceptance:
+
+- no hidden model;
+- no efficacy claim;
+- the suggestion explains each choice;
+- both ancestors contribute when the source material permits a meaningful distinction.
+
+### LIV-012.4 — Newness created by the meeting
+
+Create dimensions that belong to neither parent exactly when a meaningful bridge exists.
+
+Initial bridges:
+
+- intensity midpoint;
+- duration midpoint;
+- compatible layer union;
+- always-new deterministic generation seed.
+
+Acceptance:
+
+- `new` means a real value not copied from either parent;
+- child recipe identity differs when the experience differs;
+- the result remains reproducible.
+
+### LIV-012.5 — Memorable hybrid identity
+
+Give the Confluence its own title, motif, session ID, lineage ID, generation, and recipe identity.
+
+Acceptance:
+
+- identity carries recognizable material from both parents when possible;
+- identity is not merely `ParentA+ParentB` or a hash dump;
+- the child can be remembered and referred to on its own.
+
+### LIV-012.6 — Normal Living Session life
+
+After creation, a Confluence is a normal Living Session for rendering, echoes, and outcomes.
+
+Acceptance:
+
+- existing `sbgpy-session render` accepts the stored sleep recipe under existing backend policy;
+- existing `mark` and `finish` paths apply;
+- no parallel Confluence-only outcome store is created.
+
+### LIV-012.7 — Dual-parent constellation
+
+Add the second ancestor as a real constellation edge.
+
+Acceptance:
+
+- Parent A keeps the existing primary-parent compatibility path;
+- Parent B receives a second graph edge;
+- intentional cross-lineage ancestry is not mislabeled as a broken lineage;
+- the existing offline HTML renderer can display the enriched graph.
+
+### LIV-012.8 — Product command surface
+
+Expose `sbgpy-confluence` with:
+
+- `suggest`;
+- `create`;
+- `show`;
+- `constellation`.
+
+Acceptance:
+
+- JSON forms remain scriptable;
+- ordinary output emphasizes experience and inheritance rather than internal bookkeeping.
+
+### LIV-012.9 — Product guide
+
+Document the experience, inheritance vocabulary, CLI journey, dual-parent graph, renderer boundary, and anti-audit boundary.
+
+### LIV-012.10 — Qualification
+
+Run the repository's supported Python qualification and packaging checks on the exact final train head.
+
+## Hard boundaries
+
+Do not build:
+
+- audit machinery;
+- audit-of-audit machinery;
+- provenance quality scoring;
+- causality tribunal machinery;
+- duplicate SBaGenX DSP;
+- HTE runtime integration;
+- Cycloside integration.
+
+Existing identity hashes, parent identities, and structural visibility exist because a person needs to understand and return to the experience.
+
+## Product rule
+
+Repeated use must create new value through memory, recognizable variation, lineage, and creativity—not through engagement pressure.

--- a/docs/product/LIVING_SESSIONS_CONFLUENCE_GUIDE.md
+++ b/docs/product/LIVING_SESSIONS_CONFLUENCE_GUIDE.md
@@ -1,0 +1,151 @@
+# Living Sessions Confluence
+
+Confluence Sessions let two remembered Living Sessions become the ancestors of a new experience.
+
+The product idea is deliberately **not** “merge two configuration files.” A Confluence starts from two experiences that already have identities, echoes, outcomes, and history. It then makes a new session by choosing what should remain recognizable from Parent A, what should remain recognizable from Parent B, and where the meeting itself should create something new.
+
+## The experience
+
+A Confluence can:
+
+- inherit a recognizable dimension from Parent A;
+- inherit another dimension from Parent B;
+- preserve a dimension both parents already share;
+- create a deliberate bridge where two parent choices differ;
+- create a fresh deterministic generation seed so the child is its own reproducible experience;
+- retain both ancestors;
+- become an ancestor of later Confluences;
+- use the ordinary Living Sessions render, echo, outcome, and return paths after creation.
+
+Each inheritance item is labeled as one of:
+
+- `A` — inherited from Parent A;
+- `B` — inherited from Parent B;
+- `both` — already shared by both parents;
+- `new` — created by the meeting itself.
+
+That vocabulary is there to make the hybrid understandable, not to create a verification tribunal.
+
+## What can be inherited today
+
+The first Confluence implementation works with Living Sessions backed by PySbagen sleep recipe manifests and considers these experiential dimensions:
+
+- intent / sleep problem;
+- sound world;
+- presence / intensity;
+- duration;
+- layer blend.
+
+The generation seed is always new and is derived deterministically from both parent recipe identities plus the selected blend. It is never silently copied from one parent.
+
+## Suggested inheritance
+
+PySbagen can suggest a blend instead of making the listener manually decide every dimension.
+
+The suggestion is intentionally simple and visible. It can use:
+
+- recorded outcome rating;
+- whether the listener marked the experience worth repeating;
+- remembered echoes;
+- whether a dimension is already shared;
+- whether two different values have a meaningful middle or combined form.
+
+Examples of a genuinely new bridge include:
+
+- `gentle` + `immersive` presence becoming `balanced`;
+- 30 minutes + 90 minutes becoming a 60-minute bridge;
+- two compatible layer blends becoming a union that neither parent used exactly.
+
+A suggestion is not a claim that one parent caused an outcome or that the hybrid will have a particular effect. It is a transparent product choice based on the local memory already present in Living Sessions.
+
+## CLI
+
+Preview a meeting without creating it:
+
+```bash
+sbgpy-confluence suggest SESSION_A SESSION_B
+```
+
+Force selected dimensions to come from specific parents while leaving the rest available for suggestion:
+
+```bash
+sbgpy-confluence suggest SESSION_A SESSION_B \
+  --from-a sound_world \
+  --from-b problem
+```
+
+Multiple dimensions can be comma-separated:
+
+```bash
+sbgpy-confluence create SESSION_A SESSION_B \
+  --from-a sound_world,layers \
+  --from-b problem
+```
+
+Inspect a created Confluence:
+
+```bash
+sbgpy-confluence show CONFLUENCE_SESSION_ID
+```
+
+Then use the normal Living Sessions workflow:
+
+```bash
+sbgpy-session render CONFLUENCE_SESSION_ID -o confluence.wav
+sbgpy-session mark CONFLUENCE_SESSION_ID --kind echo --at 180 --label "The two worlds finally met"
+sbgpy-session finish CONFLUENCE_SESSION_ID --rating 5 --would-repeat yes --comfort comfortable
+```
+
+A completed Confluence can be supplied as either parent in a later `sbgpy-confluence create` command.
+
+## Dual-parent constellation
+
+The ordinary Living Sessions plan keeps Parent A in the existing primary-parent field so existing session storage and rendering remain compatible.
+
+The Confluence event stores the second ancestor and the inheritance story. The Confluence constellation view uses that information to add a real second edge:
+
+```bash
+sbgpy-confluence constellation
+sbgpy-confluence constellation --focus CONFLUENCE_SESSION_ID
+sbgpy-confluence constellation --html confluence-family.html
+```
+
+The resulting graph shows both ancestral routes without pretending that intentional cross-lineage ancestry is a broken single-parent lineage.
+
+## Identity
+
+A Confluence receives:
+
+- a new session ID;
+- a new lineage ID derived from both parent lineages and the new recipe;
+- a new recipe SHA-256;
+- a hybrid title assembled from recognizable pieces of the parent identities when possible;
+- a motif that carries memories from both parents plus a meeting motif;
+- a generation one greater than the older of its two parents.
+
+The goal is that the child feels related to both parents while still being something the listener can remember by itself.
+
+## Renderer boundary
+
+Confluence lives above the renderer.
+
+It does not add DSP, duplicate SBaGenX, or qualify native rendering. If both parents use the same backend policy, the child keeps it. If the parents disagree, the child uses `auto` rather than silently preferring one ancestor's renderer policy.
+
+The existing Living Sessions rendering rules still apply. Native SBaGenX rendering remains gated on the separate typed-render qualification work.
+
+## Product boundary
+
+Confluence exists to make repeated use create more interesting things to return to.
+
+It does **not** add:
+
+- an audit engine;
+- provenance scoring;
+- recursive verification layers;
+- causality adjudication;
+- engagement points, streaks, or leaderboards;
+- cloud accounts or hidden recommendation models.
+
+HTE, InvisiSynth, memory, affect, and synthesis ideas were used as design reasoning. Their runtime machinery is not vendored into PySbagen.
+
+The permission-gated Cycloside idea remains parked and untouched.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ sbgpy-inspect-gui = "inspect_gui:main"
 sbgpy-sleep = "pysbagen.sleep_cli:main"
 sbgpy-sleep-gui = "sleep_gui:main"
 sbgpy-session = "pysbagen.session_cli:main"
+sbgpy-confluence = "pysbagen.confluence_cli:main"
 
 [project.entry-points."pysbagen.generators"]
 # Third parties can register generator plugins in this group.

--- a/pysbagen/confluence.py
+++ b/pysbagen/confluence.py
@@ -1,0 +1,719 @@
+"""Dual-ancestor Living Session synthesis for memorable hybrid experiences."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Literal
+
+from .constellation import build_constellation
+from .living_sessions import AffectSnapshot, LivingSessionArchive, LivingSessionPlan, StoredSession
+from .sleep import SleepLayers, SleepRequest, build_sleep_recipe, recipe_manifest
+
+InheritanceSource = Literal["A", "B", "both", "new"]
+
+TRAIT_KEYS = ("problem", "sound_world", "intensity", "duration_minutes", "layers")
+_TRAIT_LABELS = {
+    "problem": "intent",
+    "sound_world": "sound world",
+    "intensity": "presence",
+    "duration_minutes": "duration",
+    "layers": "layer blend",
+}
+
+
+@dataclass(frozen=True)
+class ConfluenceInheritance:
+    """One experiential dimension carried into a Confluence session."""
+
+    trait: str
+    source: InheritanceSource
+    value: Any
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ConfluenceSuggestion:
+    """Transparent suggestion for how two remembered sessions might meet."""
+
+    parent_a_session_id: str
+    parent_b_session_id: str
+    assignments: tuple[ConfluenceInheritance, ...]
+    tensions: tuple[str, ...]
+    rationale: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "parent_a_session_id": self.parent_a_session_id,
+            "parent_b_session_id": self.parent_b_session_id,
+            "assignments": [item.to_dict() for item in self.assignments],
+            "tensions": list(self.tensions),
+            "rationale": self.rationale,
+        }
+
+
+def suggest_confluence(
+    parent_a: StoredSession,
+    parent_b: StoredSession,
+    *,
+    from_a: Iterable[str] = (),
+    from_b: Iterable[str] = (),
+) -> ConfluenceSuggestion:
+    """Suggest a comprehensible blend using memory, outcome, and audible difference."""
+
+    _validate_parents(parent_a, parent_b)
+    request_a = _request_from_plan(parent_a.plan)
+    request_b = _request_from_plan(parent_b.plan)
+    explicit_a = _normalize_trait_set(from_a)
+    explicit_b = _normalize_trait_set(from_b)
+    overlap = explicit_a & explicit_b
+    if overlap:
+        raise ValueError(
+            "A trait cannot be explicitly inherited from both parents: "
+            + ", ".join(sorted(overlap))
+        )
+
+    values_a = _trait_values(request_a)
+    values_b = _trait_values(request_b)
+    score_a = _memory_score(parent_a)
+    score_b = _memory_score(parent_b)
+    preferred = "A" if score_a >= score_b else "B"
+    assignments: list[ConfluenceInheritance] = []
+    tensions: list[str] = []
+
+    for trait in TRAIT_KEYS:
+        value_a = values_a[trait]
+        value_b = values_b[trait]
+        if value_a == value_b:
+            assignments.append(
+                ConfluenceInheritance(
+                    trait,
+                    "both",
+                    value_a,
+                    f"Both memories already share this {_TRAIT_LABELS[trait]}.",
+                )
+            )
+            continue
+
+        tensions.append(
+            f"{_TRAIT_LABELS[trait]} differs: A={_display(value_a)} · B={_display(value_b)}"
+        )
+
+        if trait in explicit_a:
+            assignments.append(
+                ConfluenceInheritance(
+                    trait,
+                    "A",
+                    value_a,
+                    f"Explicitly keep Parent A's {_TRAIT_LABELS[trait]}.",
+                )
+            )
+            continue
+        if trait in explicit_b:
+            assignments.append(
+                ConfluenceInheritance(
+                    trait,
+                    "B",
+                    value_b,
+                    f"Explicitly keep Parent B's {_TRAIT_LABELS[trait]}.",
+                )
+            )
+            continue
+
+        bridge = _bridge_value(trait, value_a, value_b)
+        if bridge is not None:
+            assignments.append(
+                ConfluenceInheritance(
+                    trait,
+                    "new",
+                    bridge,
+                    f"Create a bridge between the two remembered {_TRAIT_LABELS[trait]} choices.",
+                )
+            )
+            continue
+
+        source = _suggest_source(
+            trait,
+            preferred=preferred,
+            parent_a=parent_a,
+            parent_b=parent_b,
+            existing=assignments,
+        )
+        value = value_a if source == "A" else value_b
+        assignments.append(
+            ConfluenceInheritance(
+                trait,
+                source,
+                value,
+                _inheritance_reason(trait, source, parent_a, parent_b),
+            )
+        )
+
+    assignments = _ensure_both_parents_are_present(
+        assignments,
+        values_a=values_a,
+        values_b=values_b,
+        parent_a=parent_a,
+        parent_b=parent_b,
+        protected_a=explicit_a,
+        protected_b=explicit_b,
+    )
+    inherited_a = [_TRAIT_LABELS[x.trait] for x in assignments if x.source == "A"]
+    inherited_b = [_TRAIT_LABELS[x.trait] for x in assignments if x.source == "B"]
+    newly_bridged = [_TRAIT_LABELS[x.trait] for x in assignments if x.source == "new"]
+    shared = [_TRAIT_LABELS[x.trait] for x in assignments if x.source == "both"]
+    parts = []
+    if inherited_a:
+        parts.append("A carries " + ", ".join(inherited_a))
+    if inherited_b:
+        parts.append("B carries " + ", ".join(inherited_b))
+    if newly_bridged:
+        parts.append("the meeting creates " + ", ".join(newly_bridged))
+    if shared:
+        parts.append("both already share " + ", ".join(shared))
+    parts.append("the generation seed is new so the result is its own reproducible experience")
+    return ConfluenceSuggestion(
+        parent_a_session_id=parent_a.plan.session_id,
+        parent_b_session_id=parent_b.plan.session_id,
+        assignments=tuple(assignments),
+        tensions=tuple(tensions),
+        rationale="; ".join(parts) + ".",
+    )
+
+
+def create_confluence_plan(
+    parent_a: StoredSession,
+    parent_b: StoredSession,
+    *,
+    suggestion: ConfluenceSuggestion | None = None,
+    from_a: Iterable[str] = (),
+    from_b: Iterable[str] = (),
+    pre_affect: AffectSnapshot | None = None,
+    created_at: str | None = None,
+) -> tuple[LivingSessionPlan, ConfluenceSuggestion]:
+    """Create a dual-ancestor plan without writing it to an archive."""
+
+    _validate_parents(parent_a, parent_b)
+    suggestion = suggestion or suggest_confluence(
+        parent_a,
+        parent_b,
+        from_a=from_a,
+        from_b=from_b,
+    )
+    if suggestion.parent_a_session_id != parent_a.plan.session_id:
+        raise ValueError("Confluence suggestion does not belong to Parent A")
+    if suggestion.parent_b_session_id != parent_b.plan.session_id:
+        raise ValueError("Confluence suggestion does not belong to Parent B")
+
+    request_a = _request_from_plan(parent_a.plan)
+    request_b = _request_from_plan(parent_b.plan)
+    values_a = _trait_values(request_a)
+    values_b = _trait_values(request_b)
+    selected: dict[str, Any] = {}
+    for item in suggestion.assignments:
+        if item.trait not in TRAIT_KEYS:
+            raise ValueError(f"Unsupported Confluence trait: {item.trait}")
+        if item.source == "A":
+            selected[item.trait] = values_a[item.trait]
+        elif item.source == "B":
+            selected[item.trait] = values_b[item.trait]
+        elif item.source == "both":
+            if values_a[item.trait] != values_b[item.trait]:
+                raise ValueError(f"Trait {item.trait} is not shared by both parents")
+            selected[item.trait] = values_a[item.trait]
+        elif item.source == "new":
+            selected[item.trait] = item.value
+        else:
+            raise ValueError(f"Unknown Confluence source: {item.source}")
+
+    missing = [trait for trait in TRAIT_KEYS if trait not in selected]
+    if missing:
+        raise ValueError("Confluence suggestion is incomplete: " + ", ".join(missing))
+
+    seed = _new_seed(parent_a.plan, parent_b.plan, selected)
+    request = SleepRequest(
+        problem=str(selected["problem"]),
+        sound_world=str(selected["sound_world"]),
+        intensity=str(selected["intensity"]),
+        duration_minutes=float(selected["duration_minutes"]),
+        user_audio=_selected_user_audio(
+            selected["sound_world"],
+            request_a=request_a,
+            request_b=request_b,
+            assignments=suggestion.assignments,
+        ),
+        layers=_layers_from_value(selected["layers"]),
+        seed=seed,
+    )
+    request.validate()
+    manifest = recipe_manifest(build_sleep_recipe(request))
+    recipe_sha = _hash(manifest)
+    timestamp = created_at or _utc_now()
+    generation = max(parent_a.plan.generation, parent_b.plan.generation) + 1
+    lineage_id = _hash(
+        {
+            "kind": "confluence",
+            "parent_a_lineage": parent_a.plan.lineage_id,
+            "parent_b_lineage": parent_b.plan.lineage_id,
+            "recipe_sha256": recipe_sha,
+        },
+        24,
+    )
+    title, motif = _hybrid_identity(parent_a.plan, parent_b.plan, recipe_sha)
+    session_id = _hash(
+        {
+            "kind": "confluence-session",
+            "lineage_id": lineage_id,
+            "parent_a": parent_a.plan.session_id,
+            "parent_b": parent_b.plan.session_id,
+            "generation": generation,
+            "recipe_sha256": recipe_sha,
+            "created_at": timestamp,
+        },
+        24,
+    )
+    backend_policy = (
+        parent_a.plan.backend_policy
+        if parent_a.plan.backend_policy == parent_b.plan.backend_policy
+        else "auto"
+    )
+    plan = LivingSessionPlan(
+        session_id=session_id,
+        lineage_id=lineage_id,
+        generation=generation,
+        parent_session_id=parent_a.plan.session_id,
+        mode="confluence",
+        title=title,
+        motif=motif,
+        created_at=timestamp,
+        backend_policy=backend_policy,
+        recipe_manifest=manifest,
+        recipe_sha256=recipe_sha,
+        mutations=(),
+        rationale=suggestion.rationale,
+        experimental=True,
+        pre_affect=pre_affect,
+    )
+    return plan, suggestion
+
+
+def create_confluence_session(
+    archive: LivingSessionArchive,
+    parent_a_session_id: str,
+    parent_b_session_id: str,
+    *,
+    from_a: Iterable[str] = (),
+    from_b: Iterable[str] = (),
+    pre_affect: AffectSnapshot | None = None,
+    created_at: str | None = None,
+) -> StoredSession:
+    """Create and persist a new session that remembers both ancestors."""
+
+    parent_a = archive.get(parent_a_session_id)
+    parent_b = archive.get(parent_b_session_id)
+    plan, suggestion = create_confluence_plan(
+        parent_a,
+        parent_b,
+        from_a=from_a,
+        from_b=from_b,
+        pre_affect=pre_affect,
+        created_at=created_at,
+    )
+    archive.create(plan)
+    archive.append_event(
+        plan.session_id,
+        kind="confluence",
+        label=f"{parent_a.plan.title} × {parent_b.plan.title}",
+        payload={
+            "schema": "pysbagen.living-session-confluence.v1",
+            "parent_a": _parent_summary(parent_a),
+            "parent_b": _parent_summary(parent_b),
+            "inheritance": [item.to_dict() for item in suggestion.assignments],
+            "tensions": list(suggestion.tensions),
+            "rationale": suggestion.rationale,
+            "new_seed": plan.recipe_manifest["request"]["seed"],
+            "backend_policy_resolution": (
+                "parents agree"
+                if parent_a.plan.backend_policy == parent_b.plan.backend_policy
+                else "parents differ; Confluence uses auto rather than silently preferring either renderer policy"
+            ),
+        },
+    )
+    return archive.get(plan.session_id)
+
+
+def confluence_metadata(stored: StoredSession) -> dict[str, Any] | None:
+    """Return the persisted Confluence event payload for a session, if present."""
+
+    events = [event for event in stored.events if event.kind == "confluence"]
+    if not events:
+        return None
+    return max(events, key=lambda event: (event.created_at, event.event_id)).payload
+
+
+def build_confluence_constellation(
+    archive: LivingSessionArchive,
+    *,
+    focus_session_id: str | None = None,
+) -> dict[str, Any]:
+    """Enrich the ordinary constellation with second-parent Confluence edges."""
+
+    graph = build_constellation(archive, focus_session_id=focus_session_id)
+    visible_ids = {node["session_id"] for node in graph["nodes"]}
+    edges = list(graph["edges"])
+    existing = {edge["edge_id"] for edge in edges}
+    confluence_count = 0
+    for stored in archive.list_sessions():
+        if stored.plan.session_id not in visible_ids:
+            continue
+        metadata = confluence_metadata(stored)
+        if not metadata:
+            continue
+        parent_b = str((metadata.get("parent_b") or {}).get("session_id") or "")
+        if not parent_b or parent_b not in visible_ids:
+            continue
+        edge_id = f"{parent_b}->{stored.plan.session_id}:confluence-b"
+        if edge_id in existing:
+            continue
+        edges.append(
+            {
+                "edge_id": edge_id,
+                "source": parent_b,
+                "target": stored.plan.session_id,
+                "mode": "confluence-b",
+                "short_label": "confluence · B",
+                "mutations": [],
+                "change_count": 0,
+                "experimental": True,
+                "recipe_identity_preserved": False,
+                "causal_interpretability": "multi-ancestor",
+            }
+        )
+        existing.add(edge_id)
+        confluence_count += 1
+
+    confluence_ids = {
+        stored.plan.session_id
+        for stored in archive.list_sessions()
+        if confluence_metadata(stored) is not None
+    }
+    expected_cross_lineage_codes = {"parent-lineage-mismatch", "generation-gap"}
+    graph["warnings"] = [
+        warning
+        for warning in graph["warnings"]
+        if not (
+            warning["session_id"] in confluence_ids
+            and warning["code"] in expected_cross_lineage_codes
+        )
+    ]
+    for node in graph["nodes"]:
+        if node["session_id"] in confluence_ids:
+            node["warnings"] = [
+                warning
+                for warning in node["warnings"]
+                if warning["code"] not in expected_cross_lineage_codes
+            ]
+
+    graph["edges"] = sorted(edges, key=lambda edge: (edge["source"], edge["target"], edge["edge_id"]))
+    graph["counts"]["edges"] = len(graph["edges"])
+    graph["counts"]["warnings"] = len(graph["warnings"])
+    graph["counts"]["confluence_second_parent_edges"] = confluence_count
+    graph["schema"] = "pysbagen.living-session-constellation.confluence.v1"
+    snapshot_payload = {
+        "nodes": graph["nodes"],
+        "edges": graph["edges"],
+        "warnings": graph["warnings"],
+        "lineages": graph["lineages"],
+    }
+    graph["snapshot_sha256"] = hashlib.sha256(
+        json.dumps(snapshot_payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+    return graph
+
+
+def describe_confluence(stored: StoredSession) -> dict[str, Any]:
+    """Return a user-facing hybrid identity and inheritance summary."""
+
+    metadata = confluence_metadata(stored)
+    if metadata is None:
+        raise ValueError(f"Session {stored.plan.session_id} is not a Confluence session")
+    return {
+        "session_id": stored.plan.session_id,
+        "title": stored.plan.title,
+        "memory_phrase": stored.plan.memory_phrase,
+        "lineage_id": stored.plan.lineage_id,
+        "generation": stored.plan.generation,
+        "recipe_sha256": stored.plan.recipe_sha256,
+        "status": stored.status,
+        "parent_a": metadata["parent_a"],
+        "parent_b": metadata["parent_b"],
+        "inheritance": metadata["inheritance"],
+        "tensions": metadata["tensions"],
+        "rationale": metadata["rationale"],
+        "backend_policy": stored.plan.backend_policy,
+        "outcome": stored.outcome.to_dict() if stored.outcome else None,
+    }
+
+
+def _validate_parents(parent_a: StoredSession, parent_b: StoredSession) -> None:
+    if parent_a.plan.session_id == parent_b.plan.session_id:
+        raise ValueError("Confluence requires two distinct remembered sessions")
+    _request_from_plan(parent_a.plan)
+    _request_from_plan(parent_b.plan)
+
+
+def _request_from_plan(plan: LivingSessionPlan) -> SleepRequest:
+    manifest = plan.recipe_manifest
+    if manifest.get("format") != "pysbagen-sleep-recipe-v1":
+        raise ValueError("Confluence currently supports Living Sessions with sleep recipe manifests")
+    payload = dict(manifest.get("request") or {})
+    layers = payload.get("layers")
+    if layers is not None:
+        payload["layers"] = SleepLayers(**layers)
+    request = SleepRequest(**payload)
+    request.validate()
+    return request
+
+
+def _trait_values(request: SleepRequest) -> dict[str, Any]:
+    layers = request.layers or SleepLayers()
+    return {
+        "problem": request.problem,
+        "sound_world": request.sound_world,
+        "intensity": request.intensity,
+        "duration_minutes": float(request.duration_minutes),
+        "layers": asdict(layers),
+    }
+
+
+def _normalize_trait_set(values: Iterable[str]) -> set[str]:
+    result = {value.strip() for value in values if value and value.strip()}
+    unknown = result - set(TRAIT_KEYS)
+    if unknown:
+        raise ValueError(
+            "Unknown Confluence trait(s): "
+            + ", ".join(sorted(unknown))
+            + ". Choose from: "
+            + ", ".join(TRAIT_KEYS)
+        )
+    return result
+
+
+def _bridge_value(trait: str, value_a: Any, value_b: Any) -> Any | None:
+    if trait == "intensity":
+        order = ["gentle", "balanced", "immersive"]
+        left, right = order.index(str(value_a)), order.index(str(value_b))
+        midpoint = order[(left + right) // 2]
+        if midpoint not in {value_a, value_b}:
+            return midpoint
+    if trait == "duration_minutes":
+        midpoint = round((float(value_a) + float(value_b)) / 2.0 / 5.0) * 5.0
+        if 10.0 <= midpoint <= 180.0 and midpoint not in {float(value_a), float(value_b)}:
+            return midpoint
+    if trait == "layers":
+        a = dict(value_a)
+        b = dict(value_b)
+        union = {key: bool(a.get(key) or b.get(key)) for key in sorted(set(a) | set(b))}
+        if union != a and union != b and any(union.values()):
+            return union
+    return None
+
+
+def _suggest_source(
+    trait: str,
+    *,
+    preferred: str,
+    parent_a: StoredSession,
+    parent_b: StoredSession,
+    existing: list[ConfluenceInheritance],
+) -> Literal["A", "B"]:
+    used = {item.source for item in existing}
+    if trait == "sound_world":
+        echoes_a = sum(event.kind == "echo" for event in parent_a.events)
+        echoes_b = sum(event.kind == "echo" for event in parent_b.events)
+        if echoes_a != echoes_b:
+            return "A" if echoes_a > echoes_b else "B"
+    if "A" not in used:
+        return "A"
+    if "B" not in used:
+        return "B"
+    if trait in {"problem", "intensity"}:
+        return preferred
+    return "B" if preferred == "A" else "A"
+
+
+def _ensure_both_parents_are_present(
+    assignments: list[ConfluenceInheritance],
+    *,
+    values_a: dict[str, Any],
+    values_b: dict[str, Any],
+    parent_a: StoredSession,
+    parent_b: StoredSession,
+    protected_a: set[str],
+    protected_b: set[str],
+) -> list[ConfluenceInheritance]:
+    sources = {item.source for item in assignments}
+    if "A" in sources and "B" in sources:
+        return assignments
+
+    mutable = list(assignments)
+    missing = "A" if "A" not in sources else "B"
+    protected_other = protected_b if missing == "A" else protected_a
+    for index, item in enumerate(mutable):
+        if item.source not in {"A", "B"}:
+            continue
+        if item.trait in protected_other:
+            continue
+        a, b = values_a[item.trait], values_b[item.trait]
+        if a == b:
+            continue
+        value = a if missing == "A" else b
+        mutable[index] = ConfluenceInheritance(
+            item.trait,
+            missing,
+            value,
+            _inheritance_reason(item.trait, missing, parent_a, parent_b)
+            + " This also keeps the Confluence genuinely dual-parent.",
+        )
+        return mutable
+    return mutable
+
+
+def _inheritance_reason(
+    trait: str,
+    source: str,
+    parent_a: StoredSession,
+    parent_b: StoredSession,
+) -> str:
+    parent = parent_a if source == "A" else parent_b
+    echo_count = sum(event.kind == "echo" for event in parent.events)
+    outcome = parent.outcome
+    memory_bits = []
+    if echo_count:
+        memory_bits.append(f"{echo_count} remembered echo{'es' if echo_count != 1 else ''}")
+    if outcome is not None:
+        memory_bits.append(f"{outcome.rating}/5 outcome")
+        if outcome.would_repeat:
+            memory_bits.append("marked worth repeating")
+    memory = ", ".join(memory_bits) if memory_bits else "its recognizable recipe identity"
+    return f"Carry Parent {source}'s {_TRAIT_LABELS[trait]} because this memory contributes {memory}."
+
+
+def _memory_score(stored: StoredSession) -> tuple[int, int, int, str]:
+    outcome = stored.outcome
+    rating = outcome.rating if outcome else 0
+    repeat = int(bool(outcome and outcome.would_repeat))
+    echoes = sum(event.kind == "echo" for event in stored.events)
+    return rating, repeat, echoes, stored.plan.session_id
+
+
+def _selected_user_audio(
+    sound_world: Any,
+    *,
+    request_a: SleepRequest,
+    request_b: SleepRequest,
+    assignments: tuple[ConfluenceInheritance, ...],
+) -> str | None:
+    if sound_world != "user_audio":
+        return None
+    sound_assignment = next(item for item in assignments if item.trait == "sound_world")
+    if sound_assignment.source == "A":
+        return request_a.user_audio
+    if sound_assignment.source == "B":
+        return request_b.user_audio
+    if request_a.user_audio and request_b.user_audio and request_a.user_audio == request_b.user_audio:
+        return request_a.user_audio
+    raise ValueError(
+        "A new/shared user_audio Confluence requires both parents to reference the same available audio file"
+    )
+
+
+def _layers_from_value(value: Any) -> SleepLayers:
+    if isinstance(value, SleepLayers):
+        return value
+    payload = dict(value)
+    layers = SleepLayers(**payload)
+    if not layers.enabled_names():
+        raise ValueError("Confluence cannot disable every audio layer")
+    return layers
+
+
+def _new_seed(parent_a: LivingSessionPlan, parent_b: LivingSessionPlan, selected: dict[str, Any]) -> int:
+    digest = _hash(
+        {
+            "kind": "confluence-seed",
+            "parent_a_recipe": parent_a.recipe_sha256,
+            "parent_b_recipe": parent_b.recipe_sha256,
+            "selected": selected,
+        }
+    )
+    return int(digest[:8], 16) % (2**31 - 2) + 1
+
+
+def _hybrid_identity(
+    parent_a: LivingSessionPlan,
+    parent_b: LivingSessionPlan,
+    recipe_sha256: str,
+) -> tuple[str, tuple[str, ...]]:
+    a_words = parent_a.title.split()
+    b_words = parent_b.title.split()
+    adjective = a_words[0] if a_words else "Meeting"
+    noun = b_words[-1] if b_words else "Current"
+    title = f"{adjective} {noun}"
+    if title in {parent_a.title, parent_b.title}:
+        adjective = b_words[0] if b_words else "Braided"
+        noun = a_words[-1] if a_words else "Tide"
+        title = f"{adjective} {noun}"
+    if title in {parent_a.title, parent_b.title}:
+        title = f"Confluence {recipe_sha256[:6]}"
+
+    motifs: list[str] = []
+    for motif in (*parent_a.motif, *parent_b.motif):
+        if motif not in motifs:
+            motifs.append(motif)
+        if len(motifs) == 2:
+            break
+    bridge_motifs = ("meeting", "braid", "crossing", "confluence", "weave", "delta")
+    bridge = bridge_motifs[int(recipe_sha256[:8], 16) % len(bridge_motifs)]
+    if bridge not in motifs:
+        motifs.append(bridge)
+    while len(motifs) < 3:
+        fallback = bridge_motifs[(int(recipe_sha256[len(motifs):len(motifs)+8], 16) + len(motifs)) % len(bridge_motifs)]
+        if fallback not in motifs:
+            motifs.append(fallback)
+    return title, tuple(motifs[:3])
+
+
+def _parent_summary(stored: StoredSession) -> dict[str, Any]:
+    return {
+        "session_id": stored.plan.session_id,
+        "lineage_id": stored.plan.lineage_id,
+        "title": stored.plan.title,
+        "memory_phrase": stored.plan.memory_phrase,
+        "recipe_sha256": stored.plan.recipe_sha256,
+        "generation": stored.plan.generation,
+        "rating": stored.outcome.rating if stored.outcome else None,
+        "would_repeat": stored.outcome.would_repeat if stored.outcome else None,
+        "echo_count": sum(event.kind == "echo" for event in stored.events),
+    }
+
+
+def _display(value: Any) -> str:
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value, sort_keys=True, ensure_ascii=False)
+    return str(value)
+
+
+def _hash(payload: Any, length: int = 64) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:length]
+
+
+def _utc_now() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat()

--- a/pysbagen/confluence_cli.py
+++ b/pysbagen/confluence_cli.py
@@ -1,0 +1,141 @@
+"""CLI for Living Sessions Confluence experiences."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from .confluence import (
+    TRAIT_KEYS,
+    build_confluence_constellation,
+    create_confluence_session,
+    describe_confluence,
+    suggest_confluence,
+)
+from .constellation import constellation_to_text, render_constellation_html
+from .living_sessions import LivingSessionArchive
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sbgpy-confluence",
+        description="Combine two remembered Living Sessions into a new reproducible experience.",
+    )
+    parser.add_argument("--root", help="Living-session archive root")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    for name, help_text in (
+        ("suggest", "Preview inheritance without writing a session"),
+        ("create", "Create and remember a Confluence session"),
+    ):
+        cmd = commands.add_parser(name, help=help_text)
+        cmd.add_argument("parent_a")
+        cmd.add_argument("parent_b")
+        cmd.add_argument("--from-a", default="", help=f"Comma-separated: {', '.join(TRAIT_KEYS)}")
+        cmd.add_argument("--from-b", default="", help=f"Comma-separated: {', '.join(TRAIT_KEYS)}")
+        cmd.add_argument("--json", action="store_true", dest="as_json")
+
+    show = commands.add_parser("show", help="Show both ancestors and inheritance")
+    show.add_argument("session_id")
+    show.add_argument("--json", action="store_true", dest="as_json")
+
+    graph = commands.add_parser("constellation", help="Show dual-parent ancestry")
+    graph.add_argument("--focus")
+    graph.add_argument("--html", nargs="?", const="living-session-confluence-constellation.html")
+    graph.add_argument("--json", action="store_true", dest="as_json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    archive = LivingSessionArchive(args.root)
+    try:
+        if args.command == "suggest":
+            a, b = archive.get(args.parent_a), archive.get(args.parent_b)
+            suggestion = suggest_confluence(
+                a, b, from_a=_traits(args.from_a), from_b=_traits(args.from_b)
+            )
+            payload = suggestion.to_dict()
+            _emit(payload, args.as_json, header=f"{a.plan.memory_phrase} x {b.plan.memory_phrase}")
+            return 0
+
+        if args.command == "create":
+            stored = create_confluence_session(
+                archive,
+                args.parent_a,
+                args.parent_b,
+                from_a=_traits(args.from_a),
+                from_b=_traits(args.from_b),
+            )
+            payload = describe_confluence(stored)
+            _emit(payload, args.as_json, header=f"Created {payload['memory_phrase']}")
+            if not args.as_json:
+                print("Use sbgpy-session render/mark/finish with this session ID, or reuse it as a later ancestor.")
+            return 0
+
+        if args.command == "show":
+            payload = describe_confluence(archive.get(args.session_id))
+            _emit(payload, args.as_json, header=payload["memory_phrase"])
+            return 0
+
+        graph = build_confluence_constellation(archive, focus_session_id=args.focus)
+        html_export = None
+        if args.html:
+            path = Path(args.html).expanduser()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(render_constellation_html(graph), encoding="utf-8")
+            html_export = {"path": str(path.resolve()), "sha256": _sha256(path)}
+        if args.as_json:
+            payload = {"constellation": graph}
+            if html_export:
+                payload["html_export"] = html_export
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(constellation_to_text(graph))
+            print(
+                "Confluence second-parent connections: "
+                f"{graph['counts'].get('confluence_second_parent_edges', 0)}"
+            )
+            for edge in graph["edges"]:
+                if edge["mode"] == "confluence-b":
+                    print(f"  B {edge['source'][:8]} -> {edge['target'][:8]}")
+            if html_export:
+                print(f"Offline navigator: {html_export['path']}")
+                print(f"HTML SHA-256: {html_export['sha256']}")
+        return 0
+    except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"sbgpy-confluence: {exc}") from exc
+
+
+def _traits(value: str) -> tuple[str, ...]:
+    return tuple(part.strip() for part in value.split(",") if part.strip())
+
+
+def _emit(payload: dict, as_json: bool, *, header: str) -> None:
+    if as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    print(header)
+    if "session_id" in payload:
+        print(f"Session: {payload['session_id']}")
+    for item in payload.get("assignments", payload.get("inheritance", [])):
+        print(f"  {item['trait']} <- {item['source']}: {json.dumps(item['value'], sort_keys=True)}")
+        print(f"    {item['reason']}")
+    for tension in payload.get("tensions", []):
+        print(f"  tension: {tension}")
+    if payload.get("rationale"):
+        print(payload["rationale"])
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pysbagen/tests/test_confluence.py
+++ b/pysbagen/tests/test_confluence.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import pytest
+
+from pysbagen.confluence import (
+    build_confluence_constellation,
+    confluence_metadata,
+    create_confluence_plan,
+    create_confluence_session,
+    describe_confluence,
+    suggest_confluence,
+)
+from pysbagen.living_sessions import LivingSessionArchive, SessionOutcome, create_sleep_plan
+from pysbagen.sleep import SleepLayers, SleepRequest
+
+
+def _parents(tmp_path):
+    archive = LivingSessionArchive(tmp_path / "living")
+    plan_a = create_sleep_plan(
+        SleepRequest(
+            problem="racing_mind",
+            sound_world="rain_room",
+            intensity="gentle",
+            duration_minutes=30,
+            layers=SleepLayers(binaural=True, monaural=False, isochronic=False, harmonic_box=False),
+            seed=11,
+        ),
+        created_at="2026-08-07T10:00:00+00:00",
+    )
+    plan_b = create_sleep_plan(
+        SleepRequest(
+            problem="cannot_cross",
+            sound_world="deep_night",
+            intensity="immersive",
+            duration_minutes=90,
+            layers=SleepLayers(binaural=False, monaural=True, isochronic=True, harmonic_box=False),
+            seed=22,
+        ),
+        created_at="2026-08-07T10:01:00+00:00",
+    )
+    archive.create(plan_a)
+    archive.create(plan_b)
+    archive.append_event(plan_a.session_id, kind="echo", label="Rain became a room", position_seconds=120.0, created_at="2026-08-07T10:02:00+00:00")
+    archive.append_event(plan_b.session_id, kind="echo", label="Deep low opening", position_seconds=60.0, created_at="2026-08-07T10:03:00+00:00")
+    archive.append_event(plan_b.session_id, kind="echo", label="Threshold softened", position_seconds=240.0, created_at="2026-08-07T10:04:00+00:00")
+    archive.finish(SessionOutcome(session_id=plan_a.session_id, completed_at="2026-08-07T11:00:00+00:00", rating=5, would_repeat=True, comfort="comfortable"))
+    archive.finish(SessionOutcome(session_id=plan_b.session_id, completed_at="2026-08-07T11:01:00+00:00", rating=4, would_repeat=True, comfort="comfortable"))
+    return archive, archive.get(plan_a.session_id), archive.get(plan_b.session_id)
+
+
+def test_suggestion_is_dual_parent_and_creates_real_bridge_traits(tmp_path):
+    _, parent_a, parent_b = _parents(tmp_path)
+    suggestion = suggest_confluence(parent_a, parent_b)
+    sources = {item.source for item in suggestion.assignments}
+    assert {"A", "B", "new"} <= sources
+    by_trait = {item.trait: item for item in suggestion.assignments}
+    assert by_trait["intensity"].source == "new"
+    assert by_trait["intensity"].value == "balanced"
+    assert by_trait["duration_minutes"].source == "new"
+    assert by_trait["duration_minutes"].value == 60.0
+    assert "generation seed is new" in suggestion.rationale
+
+
+def test_explicit_inheritance_overrides_suggestion_without_hiding_conflicts(tmp_path):
+    _, parent_a, parent_b = _parents(tmp_path)
+    suggestion = suggest_confluence(parent_a, parent_b, from_a=("sound_world",), from_b=("problem",))
+    by_trait = {item.trait: item for item in suggestion.assignments}
+    assert by_trait["sound_world"].source == "A"
+    assert by_trait["sound_world"].value == "rain_room"
+    assert by_trait["problem"].source == "B"
+    assert by_trait["problem"].value == "cannot_cross"
+    assert any("sound world differs" in item for item in suggestion.tensions)
+    assert any("intent differs" in item for item in suggestion.tensions)
+
+
+def test_same_trait_cannot_be_forced_from_both_parents(tmp_path):
+    _, parent_a, parent_b = _parents(tmp_path)
+    with pytest.raises(ValueError, match="cannot be explicitly inherited from both"):
+        suggest_confluence(parent_a, parent_b, from_a=("sound_world",), from_b=("sound_world",))
+
+
+def test_create_plan_has_new_identity_and_new_seed(tmp_path):
+    _, parent_a, parent_b = _parents(tmp_path)
+    plan, suggestion = create_confluence_plan(parent_a, parent_b, created_at="2026-08-07T12:00:00+00:00")
+    assert plan.mode == "confluence"
+    assert plan.parent_session_id == parent_a.plan.session_id
+    assert plan.lineage_id not in {parent_a.plan.lineage_id, parent_b.plan.lineage_id}
+    assert plan.title not in {parent_a.plan.title, parent_b.plan.title}
+    assert plan.recipe_manifest["request"]["seed"] not in {
+        parent_a.plan.recipe_manifest["request"]["seed"],
+        parent_b.plan.recipe_manifest["request"]["seed"],
+    }
+    assert plan.recipe_sha256 not in {parent_a.plan.recipe_sha256, parent_b.plan.recipe_sha256}
+    assert suggestion.parent_b_session_id == parent_b.plan.session_id
+
+
+def test_persisted_confluence_remembers_both_ancestors_and_inheritance(tmp_path):
+    archive, parent_a, parent_b = _parents(tmp_path)
+    stored = create_confluence_session(archive, parent_a.plan.session_id, parent_b.plan.session_id, created_at="2026-08-07T12:00:00+00:00")
+    metadata = confluence_metadata(stored)
+    assert metadata is not None
+    assert metadata["parent_a"]["session_id"] == parent_a.plan.session_id
+    assert metadata["parent_b"]["session_id"] == parent_b.plan.session_id
+    assert metadata["schema"] == "pysbagen.living-session-confluence.v1"
+    assert {item["source"] for item in metadata["inheritance"]} >= {"A", "B", "new"}
+    description = describe_confluence(stored)
+    assert description["parent_a"]["title"] == parent_a.plan.title
+    assert description["parent_b"]["title"] == parent_b.plan.title
+
+
+def test_confluence_can_become_a_future_ancestor(tmp_path):
+    archive, parent_a, parent_b = _parents(tmp_path)
+    first = create_confluence_session(archive, parent_a.plan.session_id, parent_b.plan.session_id, created_at="2026-08-07T12:00:00+00:00")
+    second = create_confluence_session(archive, first.plan.session_id, parent_a.plan.session_id, created_at="2026-08-07T13:00:00+00:00")
+    metadata = confluence_metadata(second)
+    assert metadata is not None
+    assert metadata["parent_a"]["session_id"] == first.plan.session_id
+    assert second.plan.generation == max(first.plan.generation, parent_a.plan.generation) + 1
+
+
+def test_constellation_contains_second_parent_edge_without_false_lineage_warning(tmp_path):
+    archive, parent_a, parent_b = _parents(tmp_path)
+    confluence = create_confluence_session(archive, parent_a.plan.session_id, parent_b.plan.session_id, created_at="2026-08-07T12:00:00+00:00")
+    graph = build_confluence_constellation(archive, focus_session_id=confluence.plan.session_id)
+    second_edges = [edge for edge in graph["edges"] if edge["mode"] == "confluence-b" and edge["source"] == parent_b.plan.session_id and edge["target"] == confluence.plan.session_id]
+    assert len(second_edges) == 1
+    assert graph["counts"]["confluence_second_parent_edges"] == 1
+    warning_codes = {warning["code"] for warning in graph["warnings"] if warning["session_id"] == confluence.plan.session_id}
+    assert "parent-lineage-mismatch" not in warning_codes
+    assert "generation-gap" not in warning_codes
+
+
+def test_confluence_rejects_using_the_same_session_twice(tmp_path):
+    _, parent_a, _ = _parents(tmp_path)
+    with pytest.raises(ValueError, match="two distinct remembered sessions"):
+        suggest_confluence(parent_a, parent_a)


### PR DESCRIPTION
## What changed

- adds LIV-012 Confluence Sessions above the Living Sessions Constellation train;
- combines two remembered Living Sessions rather than merging detached configuration dictionaries;
- models inherited experiential dimensions as `A`, `B`, `both`, or genuinely `new`;
- uses visible local memory signals such as outcomes, would-repeat choices, and echoes to suggest inheritance;
- supports explicit Parent A / Parent B inheritance overrides;
- exposes creative tensions when the two remembered experiences differ;
- creates real bridge values where a meaningful midpoint or compatible combination exists;
- always derives a fresh deterministic generation seed from both parent identities and the selected blend;
- gives each Confluence a new lineage, recipe identity, title, motif, and generation;
- persists both ancestors and the inheritance story in the ordinary Living Sessions archive;
- allows a Confluence to become a future ancestor;
- adds a real second-parent edge to the offline constellation instead of pretending the product remains single-parent;
- exposes `sbgpy-confluence suggest`, `create`, `show`, and `constellation`;
- keeps ordinary `sbgpy-session render`, `mark`, and `finish` as the lifecycle after creation;
- adds focused regression coverage and a product guide.

## Product experience

The important object is the remembered experience, not its configuration file.

A listener can take two sessions that mattered, inspect what each contributes, deliberately keep recognizable traits from either one, allow PySbagen to suggest understandable inheritance from local memory, and create a third session that feels related to both while still having an identity of its own.

Where the parents differ, the Confluence can create something that neither parent contained exactly. Initial examples include:

- gentle + immersive presence -> balanced;
- 30 min + 90 min -> a 60-minute bridge;
- compatible layer blends -> a new union;
- every Confluence -> a new deterministic generation seed.

## User paths

```bash
sbgpy-confluence suggest SESSION_A SESSION_B
sbgpy-confluence create SESSION_A SESSION_B --from-a sound_world --from-b problem
sbgpy-confluence show CONFLUENCE_SESSION_ID
sbgpy-confluence constellation --focus CONFLUENCE_SESSION_ID --html confluence-family.html

sbgpy-session render CONFLUENCE_SESSION_ID -o confluence.wav
sbgpy-session mark CONFLUENCE_SESSION_ID --kind echo --at 180 --label "The two worlds finally met"
sbgpy-session finish CONFLUENCE_SESSION_ID --rating 5 --would-repeat yes --comfort comfortable
```

## Boundaries

This PR adds no SBaGenX DSP and does not qualify native rendering. Confluence remains above the renderer and follows the existing backend policy.

It also deliberately adds no audit engine, provenance scoring system, recursive verification layer, causality tribunal, engagement scoring, HTE runtime, or Cycloside integration.

HTE/InvisiSynth concepts were used only as reasoning inputs for memory, affect, synthesis, and missing-product-space exploration.

## Stack

Base: `agent/living-sessions-constellation-20260805` / PR #14

Head: `agent/living-sessions-confluence-20260807`

Exact qualified head: `397bb61749838f9b797e8725322890bcac055eec`

## Qualification

GitHub Actions run #74 passed on the exact head above:

- Python 3.10 — passed;
- Python 3.11 — passed;
- Python 3.12 — passed;
- Python 3.13 — passed;
- full pytest suite — 81 passed;
- source distribution — passed;
- wheel — passed.

No submitted review or actionable inline review thread currently exists on this PR.

This PR remains unmerged pending the explicit merge whistle.